### PR TITLE
feat: Add AMD support to KServe example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ response = llm.invoke("Explain MemoryAlloy inference technology in one paragraph
 
 See the [langchain-crusoe README](./langchain-crusoe/README.md) for full setup instructions and usage examples.
 
+[Serving HuggingFace Models on CMK with KServe](./crusoe-kserve-example/)
+
+Deploy open-source LLMs from HuggingFace on Crusoe Managed Kubernetes (CMK) using [KServe](https://kserve.github.io/) and [vLLM](https://docs.vllm.ai/), from a single-GPU endpoint to disaggregated prefill-decode across heterogeneous GPU pools. Supports both NVIDIA and AMD GPU clusters.
+
+Key capabilities:
+
+- **NVIDIA GPU serving** — single-GPU, multi-node tensor parallelism, and disaggregated prefill-decode across A100/H100 node pools
+- **AMD GPU serving** — single-node and multi-node serving on MI300X using ROCm-based vLLM; supports large MoE models like MiniMax-M2
+- **Model deployment** — deploy any HuggingFace model with an OpenAI-compatible `/v1/chat/completions` endpoint; large models (70B+) use persistent storage backed by the Crusoe SSD CSI driver
+- **One-command setup** — `make setup` (NVIDIA) or `make setup-amd` (AMD) provisions the CMK cluster, installs the GPU operator and KServe, and creates the model namespace end-to-end
+
+See the [crusoe-kserve-example README](./crusoe-kserve-example/README.md) for full setup instructions and usage examples.
+
 ### Storage
 
 [Shared Volumes NFS Setup](./shared-volumes-driver-setup/)

--- a/crusoe-kserve-example/.gitignore
+++ b/crusoe-kserve-example/.gitignore
@@ -12,3 +12,7 @@ terraform/terraform.tfvars
 
 # OS
 .DS_Store
+
+env
+prometheus/prometheus.yml
+grafana/provisioning/datasources/prometheus.yml

--- a/crusoe-kserve-example/CLAUDE.md
+++ b/crusoe-kserve-example/CLAUDE.md
@@ -1,17 +1,23 @@
 # CLAUDE.md — KServe LLM Serving on Crusoe
 
-This project deploys open-source LLMs on Crusoe Managed Kubernetes (CMK) using KServe and vLLM.
+This project deploys open-source LLMs on Crusoe Managed Kubernetes (CMK) using KServe and vLLM. It supports both NVIDIA and AMD GPU clusters.
 
 ## What This Does
 
-Provisions a CMK cluster with GPU node pools and installs KServe for LLM inference. Supports three deployment modes:
-- **Basic**: Single-GPU serving (e.g., Qwen2.5-0.5B on 1x A100)
-- **Multi-Node**: Tensor-parallel across multiple nodes (e.g., Qwen2.5-72B on 16 GPUs)
+Provisions a CMK cluster with GPU node pools and installs KServe for LLM inference. Supports five deployment modes:
+- **Basic (NVIDIA)**: Single-GPU serving (e.g., Qwen2.5-0.5B on 1x A100)
+- **Multi-Node (NVIDIA)**: Tensor-parallel across multiple nodes (e.g., Qwen2.5-72B on 16 GPUs)
 - **Disaggregated Prefill-Decode**: H100 for prefill, A100 for decode (cost-optimized)
+- **Basic (AMD)**: Single-GPU or full-node serving on MI300X (e.g., MiniMax-M2 on 8x MI300X)
+- **Multi-Node (AMD)**: Multi-node tensor-parallel on MI300X (e.g., MiniMax-M2 on 2x8 MI300X)
 
 ## Setup Flow
 
-### 1. Configure `terraform/terraform.tfvars`
+There are two independent setup paths: NVIDIA (default) and AMD. They use separate Terraform directories.
+
+### NVIDIA Setup
+
+#### 1. Configure `terraform/terraform.tfvars`
 
 Copy the example and fill in values:
 ```bash
@@ -21,7 +27,7 @@ cd terraform && cp terraform.tfvars.example terraform.tfvars
 Required values the user must provide:
 - `project_id` — Crusoe project ID (get via `crusoe projects list`)
 - `hf_token` — HuggingFace API token
-- `ssh_public_key` — User's SSH public key string
+- `ssh_public_key` — User's SSH public key string; provisioned onto nodes at creation time so the user can SSH in for debugging (e.g. checking driver issues, running `nvidia-smi`)
 - `a100_ib_partition_id` — InfiniBand partition ID for A100 nodes (get via `crusoe networking ib-partitions list`)
 - `h100_ib_partition_id` — InfiniBand partition ID for H100 nodes (only needed if `h100_node_count > 0`)
 
@@ -32,7 +38,7 @@ crusoe networking ib-networks get <ib-network-id> --project-id <project-id> -f j
 ```
 Look for a network with the correct location and `slice_type` (e.g., `a100-80gb-sxm-ib.8x`).
 
-### 2. Provision Infrastructure + Install KServe
+#### 2. Provision Infrastructure + Install KServe
 
 ```bash
 make setup
@@ -45,7 +51,7 @@ This runs `terraform apply` which:
 4. Installs KServe v0.17.0 (standard mode + LLMInferenceService CRDs)
 5. Creates the `kserve-test` namespace with the HuggingFace secret
 
-### 3. Deploy a Model
+#### 3. Deploy a Model
 
 ```bash
 make deploy-basic          # Qwen2.5-0.5B on 1x A100
@@ -54,13 +60,13 @@ make deploy-multi-node     # Qwen2.5-72B on 2x8 A100 (needs a100_node_count=2)
 make deploy-disaggregated  # Qwen2.5-72B with H100 prefill + A100 decode (needs h100_node_count=1)
 ```
 
-### 4. Test
+#### 4. Test
 
 ```bash
 make test   # Port-forward + single curl request
 ```
 
-### 5. Benchmark
+#### 5. Benchmark
 
 Uses vLLM's built-in `vllm bench serve` running inside the serving pod — no port-forward overhead, proper statistical analysis.
 
@@ -76,6 +82,69 @@ make bench BENCH_RATE=inf BENCH_NUM_PROMPTS=300
 ```
 
 Reports TTFT, TPOT (time per output token), ITL (inter-token latency), and throughput with percentiles.
+
+---
+
+### AMD Setup
+
+AMD clusters use a separate Terraform directory (`terraform-amd/`) and require the AMD GPU operator (not the NVIDIA operator). Docker Hub credentials are needed to push the AMD GPU driver image.
+
+#### 1. Configure `terraform-amd/terraform.tfvars`
+
+```bash
+cd terraform-amd && cp terraform.tfvars.example terraform.tfvars
+```
+
+Required values:
+- `project_id` — Crusoe project ID
+- `hf_token` — HuggingFace API token
+- `amd_node_type` — AMD GPU instance type (e.g., `mi300x-192gb-ib.8x`)
+- `amd_ib_partition_id` — InfiniBand partition ID for AMD nodes
+- `ssh_public_key` — User's SSH public key string; provisioned onto nodes at creation time so the user can SSH in for debugging (e.g. checking driver issues, running `rocm-smi`)
+- `docker_username`, `docker_email`, `docker_password` — Docker Hub credentials (for pushing AMD GPU driver image)
+
+#### 2. Provision Infrastructure + Install AMD GPU Operator + KServe
+
+```bash
+make setup-amd
+```
+
+This runs three steps:
+1. `terraform apply` in `terraform-amd/` — creates CMK cluster with **`crusoe_csi` add-on only** (no NVIDIA add-ons), AMD GPU node pool, CPU node pool, fetches kubeconfig
+2. `install-amd-gpu-operator` — installs cert-manager v1.15.1, AMD GPU operator v1.4.2, creates Docker registry secret in `kube-amd-gpu`, applies AMD DeviceConfig
+3. `install-kserve` — installs KServe v0.17.0, patches storage-initializer, creates `kserve-test` namespace with HuggingFace secret
+
+**Key difference from NVIDIA**: AMD clusters use `amd.com/gpu` resource limits instead of `nvidia.com/gpu`, and use the `vllm/vllm-openai-rocm:latest` image (ROCm-based).
+
+#### 3. Deploy a Model on AMD
+
+```bash
+make deploy-amd-basic      # Qwen2.5-0.5B on 1x MI300X
+make deploy-amd-minimax    # MiniMax-M2 on 8x MI300X (TP=8, EP, 1500Gi PVC) — deletes existing PVC first
+make redeploy-amd-minimax  # Update MiniMax-M2 args WITHOUT deleting PVC (preserves downloaded model)
+make deploy-amd-multi-node # MiniMax-M2 on 2x8 MI300X (TP=8, 2 replicas)
+```
+
+**Note**: `deploy-amd-minimax` deletes the PVC before deploying. Use `redeploy-amd-minimax` to update args while preserving already-downloaded model weights.
+
+#### 4. Test AMD
+
+```bash
+make test           # Same port-forward + curl (works for any deployed model)
+make test-amd-minimax  # Test with minimax model name
+```
+
+#### 5. Benchmark AMD
+
+```bash
+make bench-amd                    # Default: 50 req/s, 512 input, 150 output (served-model-name=minimax)
+make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
+```
+
+#### AMD-Specific vLLM Environment Variables
+
+The AMD templates inject these env vars automatically:
+- `VLLM_ROCM_USE_AITER=1` — enables AMD's AITER kernel acceleration (significant throughput improvement on MI300X)
 
 ## Model Storage (PVC)
 
@@ -101,13 +170,26 @@ The Terraform setup also patches the KServe `inferenceservice-config` configmap 
 
 ## Key Files
 
-- `terraform/main.tf` — Cluster, node pools, KServe install, namespace setup (all-in-one)
-- `terraform/variables.tf` — All configurable variables with defaults
-- `terraform/terraform.tfvars.example` — Template for user configuration
-- `helm/crusoe-kserve-example/values.yaml` — Model config, GPU resources, deployment mode toggles
-- `helm/crusoe-kserve-example/templates/` — LLMInferenceService manifests for each mode
+- `terraform/main.tf` — NVIDIA cluster, node pools, KServe install, namespace setup (all-in-one)
+- `terraform/variables.tf` — NVIDIA Terraform variables
+- `terraform/terraform.tfvars.example` — NVIDIA template for user configuration
+- `terraform-amd/main.tf` — AMD cluster + node pools (KServe installed separately by `make setup-amd`)
+- `terraform-amd/variables.tf` — AMD Terraform variables (includes Docker Hub credentials)
+- `terraform-amd/terraform.tfvars.example` — AMD template for user configuration
+- `helm/crusoe-kserve-example/values.yaml` — All deployment mode configs (NVIDIA + AMD)
+- `helm/crusoe-kserve-example/templates/basic-llm.yaml` — NVIDIA single-GPU manifest
+- `helm/crusoe-kserve-example/templates/multi-node-llm.yaml` — NVIDIA multi-node manifest
+- `helm/crusoe-kserve-example/templates/disaggregated-llm.yaml` — NVIDIA disaggregated manifest
+- `helm/crusoe-kserve-example/templates/amd-basic-llm.yaml` — AMD single-GPU manifest
+- `helm/crusoe-kserve-example/templates/amd-multi-node-llm.yaml` — AMD multi-node manifest
+- `monitoring/docker-compose.yml` — Grafana container (port 3000)
+- `monitoring/setup.py` — Configures Grafana datasource + prints dashboard URL
+- `monitoring/env.example` — Template for monitoring credentials (copy to `env` and fill in values)
+- `monitoring/env` — Crusoe credentials for monitoring (not committed)
+- `monitoring/grafana/dashboards/` — Pre-built dashboards (nvidia/, amd/)
+- `scripts/chat.py` — Interactive streaming chat REPL
 - `chat-test.json` — Sample OpenAI-compatible chat request
-- `Makefile` — All commands: `setup`, `deploy-*`, `test`, `bench`, `destroy`
+- `Makefile` — All commands: `setup`, `setup-amd`, `deploy-*`, `test`, `bench`, `monitor-*`, `destroy`
 
 ## Crusoe CLI Notes
 
@@ -119,6 +201,8 @@ The Terraform setup also patches the KServe `inferenceservice-config` configmap 
 
 ## Available GPU SKUs
 
+### NVIDIA
+
 | Node Type                | GPU             | GPUs | VRAM     | BW (TB/s) | Best For                    |
 |--------------------------|-----------------|------|----------|-----------|-----------------------------|
 | a100-80gb-sxm-ib.8x     | A100 SXM 80GB   | 8    | 640 GB   | 2.0       | Decode, general inference   |
@@ -128,6 +212,17 @@ The Terraform setup also patches the KServe `inferenceservice-config` configmap 
 | a100-80gb.1x             | A100 PCIe 80GB  | 1    | 80 GB    | 2.0       | Single-GPU inference        |
 
 nodeSelector labels: `nvidia-a100-80gb-sxm-ib`, `nvidia-h100-80gb-sxm-ib`, `nvidia-h200-141gb-sxm-ib`, `nvidia-l40s`
+
+### AMD
+
+| Node Type              | GPU          | GPUs | VRAM     | Best For                              |
+|------------------------|--------------|------|----------|---------------------------------------|
+| mi300x-192gb-ib.8x     | MI300X       | 8    | 1536 GB  | Large MoE models, high-memory serving |
+
+nodeSelector label: `amd-mi300x-192gb-ib`
+
+Resource key: `amd.com/gpu` (not `nvidia.com/gpu`)
+vLLM image: `vllm/vllm-openai-rocm:latest`
 
 ## Node Count Guidelines
 
@@ -177,6 +272,54 @@ make bench BENCH_RATE=10 BENCH_INPUT_LEN=128        # Low-latency profile
 make bench BENCH_RATE=inf BENCH_NUM_PROMPTS=300      # Max throughput
 ```
 
+## Monitoring (Grafana + Prometheus)
+
+Local monitoring stack runs Grafana + a Crusoe-managed Prometheus datasource via Docker Compose. No in-cluster components needed.
+
+### Prerequisites
+
+Create `monitoring/env` with your Crusoe credentials:
+```
+CRUSOE_PROJECT_ID=<your-project-id>
+CRUSOE_MONITORING_TOKEN=<your-monitoring-token>
+```
+
+Get the monitoring token from the Crusoe console or API.
+
+### Start / Stop
+
+```bash
+make monitor-up-nvidia   # Start with NVIDIA GPU dashboard (default)
+make monitor-up-amd      # Start with AMD GPU dashboard
+make monitor-up          # Alias for monitor-up-nvidia
+
+make monitor-down        # Stop Grafana
+make monitor-clean       # Wipe Grafana state and restart fresh
+```
+
+After starting, `setup.py` automatically:
+1. Waits for Grafana to be ready at `localhost:3000`
+2. Configures the Crusoe Prometheus datasource (pointing at `api.crusoecloud.com/v1alpha5/projects/<id>/metrics/timeseries`)
+3. Prints the dashboard URL
+
+Dashboard URLs (login: admin / admin):
+- NVIDIA: `http://localhost:3000/d/gpu-inference`
+- AMD: `http://localhost:3000/d/amd-gpu-inference`
+
+### Dashboard Files
+
+- `monitoring/grafana/dashboards/nvidia/gpu-inference.json` — NVIDIA GPU inference dashboard
+- `monitoring/grafana/dashboards/amd/amd-gpu-inference.json` — AMD GPU inference dashboard
+- `monitoring/grafana/provisioning/datasources/prometheus.yml` — empty placeholder (datasource is configured at runtime by `setup.py` via Grafana API)
+
+## Scripts
+
+- `scripts/chat.py` — Interactive streaming chat client. Port-forwards to the serving pod and opens a REPL.
+  ```bash
+  make chat              # Auto-detects deployed service
+  make chat MODEL=qwen   # Override model name
+  ```
+
 ## Cleanup
 
 ```bash
@@ -198,3 +341,11 @@ This uninstalls the Helm release and runs `terraform destroy` to tear down all i
 - If vLLM crashes with "unrecognized arguments: /mnt/models", you have `--model` in your args — remove it, KServe injects this automatically
 - Check KServe controller logs: `kubectl logs -n kserve -l control-plane=kserve-controller-manager`
 - Check vLLM logs: `kubectl logs -n kserve-test deploy/<model>-kserve -c main`
+
+### AMD-Specific
+
+- If AMD GPU nodes show no GPU resources (`amd.com/gpu: 0`), the AMD GPU operator DeviceConfig hasn't finished reconciling. Check: `kubectl get deviceconfig -n kube-amd-gpu` and `kubectl get pods -n kube-amd-gpu`
+- If the AMD driver pod is in `ImagePullBackOff`, the Docker registry secret is wrong or the image wasn't pushed. Verify: `kubectl get secret my-docker-secret -n kube-amd-gpu` and re-run `make install-amd-gpu-operator`
+- `VLLM_ROCM_USE_AITER=1` is injected automatically by the AMD Helm templates. Do not set it to `0` unless debugging — it significantly reduces throughput on MI300X
+- AMD clusters use `crusoe_csi` add-on only — no `nvidia_gpu_operator` or `nvidia_network_operator`. If you accidentally create an AMD cluster with NVIDIA add-ons, recreate it
+- For MiniMax-M2 (MoE model), `--enable-expert-parallel` is required alongside `--tensor-parallel-size 8`. Without it, the model may OOM or perform poorly

--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -1,8 +1,18 @@
-.PHONY: help setup deploy-basic deploy-70b deploy-multi-node deploy-disaggregated test bench destroy
+.PHONY: help setup setup-amd install-kserve patch-storage-initializer install-amd-gpu-operator deploy-basic deploy-70b deploy-multi-node deploy-disaggregated deploy-2xa100 deploy-amd-basic deploy-amd-minimax redeploy-amd-minimax deploy-amd-multi-node watch watch-metrics test test-amd-minimax chat bench bench-all bench-all-amd bench-amd monitor-up monitor-up-nvidia monitor-up-amd monitor-down monitor-clean destroy
 
 SHELL := /bin/bash
 NAMESPACE ?= kserve-test
-HF_TOKEN ?= $(shell grep '^hf_token' terraform/terraform.tfvars 2>/dev/null | sed 's/.*= *"//;s/"//')
+HF_TOKEN       ?= $(shell grep '^hf_token'       terraform/terraform.tfvars     2>/dev/null | sed 's/.*= *"//;s/"//')
+KSERVE_VERSION ?= v0.17.0
+
+# AMD config — all values read from terraform-amd/terraform.tfvars
+_AMD_TFVARS    := terraform-amd/terraform.tfvars
+AMD_HF_TOKEN   ?= $(shell grep '^hf_token'        $(_AMD_TFVARS) 2>/dev/null | sed 's/.*= *"//;s/"//')
+DOCKER_USERNAME ?= $(shell grep '^docker_username' $(_AMD_TFVARS) 2>/dev/null | sed 's/.*= *"//;s/"//')
+DOCKER_EMAIL    ?= $(shell grep '^docker_email'    $(_AMD_TFVARS) 2>/dev/null | sed 's/.*= *"//;s/"//')
+DOCKER_PASSWORD  ?= $(shell grep '^docker_password' $(_AMD_TFVARS) 2>/dev/null | sed 's/.*= *"//;s/"//')
+AMD_DRIVER_IMAGE ?= docker.io/$(DOCKER_USERNAME)/amd-gpu-driver
+DRY_RUN          ?= 0
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
@@ -17,6 +27,109 @@ setup: ## Provision cluster, install KServe, create namespace (terraform apply)
 	  terraform init && \
 	  terraform apply
 
+setup-amd: ## Provision AMD cluster, install AMD GPU operator + KServe (configure terraform-amd/terraform.tfvars first) [DRY_RUN=1 to preview]
+ifeq ($(DRY_RUN),1)
+	@echo ""
+	@echo "setup-amd dry run — steps that would be executed:"
+	@echo ""
+	@echo "  [1/3] terraform apply (terraform-amd/)"
+	@echo "        Create CMK cluster (crusoe_csi add-on only)"
+	@echo "        Create AMD GPU node pool and CPU node pool"
+	@echo "        Fetch kubeconfig"
+	@echo ""
+	@echo "  [2/3] install-amd-gpu-operator"
+	@echo "        Install cert-manager v1.15.1"
+	@echo "        Install AMD GPU operator v1.4.2"
+	@echo "        Create Docker registry secret in kube-amd-gpu (user: $(DOCKER_USERNAME))"
+	@echo "        Apply AMD DeviceConfig → $(AMD_DRIVER_IMAGE)"
+	@echo ""
+	@echo "  [3/3] install-kserve"
+	@echo "        Install KServe $(KSERVE_VERSION)"
+	@echo "        Patch storage-initializer for large model downloads"
+	@echo "        Create namespace '$(NAMESPACE)' with HuggingFace secret"
+	@echo ""
+else
+	cd terraform-amd && \
+	  cp -n terraform.tfvars.example terraform.tfvars 2>/dev/null || true && \
+	  terraform init && \
+	  terraform apply
+	$(MAKE) install-amd-gpu-operator
+	$(MAKE) install-kserve HF_TOKEN=$(AMD_HF_TOKEN)
+endif
+
+install-amd-gpu-operator: ## Install cert-manager and AMD GPU operator (requires DOCKER_USERNAME, DOCKER_EMAIL, DOCKER_PASSWORD)
+	@if [ -z "$(DOCKER_USERNAME)" ] || [ -z "$(DOCKER_EMAIL)" ] || [ -z "$(DOCKER_PASSWORD)" ]; then \
+	  echo "ERROR: DOCKER_USERNAME, DOCKER_EMAIL, and DOCKER_PASSWORD are required."; \
+	  echo "  make install-amd-gpu-operator DOCKER_USERNAME=you DOCKER_EMAIL=you@example.com DOCKER_PASSWORD=... AMD_DRIVER_IMAGE=docker.io/you/amd-gpu-driver"; \
+	  exit 1; \
+	fi
+	@set -euo pipefail; \
+	echo "[1/4] Adding Helm repos and installing cert-manager v1.15.1..."; \
+	helm repo add jetstack https://charts.jetstack.io --force-update && helm repo update; \
+	helm install cert-manager jetstack/cert-manager \
+	  --namespace cert-manager \
+	  --create-namespace \
+	  --version v1.15.1 \
+	  --set crds.enabled=true; \
+	echo "[2/4] Installing AMD GPU operator v1.4.2..."; \
+	helm repo add rocm https://rocm.github.io/gpu-operator && helm repo update; \
+	helm install amd-gpu-operator rocm/gpu-operator-charts \
+	  --namespace kube-amd-gpu --create-namespace \
+	  --version v1.4.2; \
+	echo "[3/4] Creating Docker registry secret..."; \
+	kubectl create secret docker-registry my-docker-secret -n kube-amd-gpu \
+	  --docker-username=$(DOCKER_USERNAME) \
+	  --docker-email=$(DOCKER_EMAIL) \
+	  --docker-password=$(DOCKER_PASSWORD) \
+	  --dry-run=client -o yaml | kubectl apply -f -; \
+	echo "[4/4] Applying AMD DeviceConfig..."; \
+	AMD_DRIVER_IMAGE=$(AMD_DRIVER_IMAGE) envsubst < manifests/amd-device-config.yaml | kubectl apply -f -; \
+	echo "=== AMD GPU operator installation complete ==="
+
+install-kserve: ## Install KServe on an existing cluster (skips Terraform infra)
+	@if [ -z "$(HF_TOKEN)" ]; then echo "ERROR: HF_TOKEN is required. Run: make install-kserve HF_TOKEN=hf_..."; exit 1; fi
+	@set -euo pipefail; \
+	BASE_URL="https://github.com/kserve/kserve/releases/download/$(KSERVE_VERSION)"; \
+	echo "=== Installing KServe $(KSERVE_VERSION) ==="; \
+	echo "[1/5] Installing standard mode dependencies..."; \
+	curl -fsSL "$${BASE_URL}/kserve-standard-mode-dependency-install.sh" | bash; \
+	echo "[2/5] Installing LLMInferenceService dependencies..."; \
+	curl -fsSL "$${BASE_URL}/llmisvc-dependency-install.sh" | bash; \
+	echo "[3/5] Installing KServe CRDs..."; \
+	kubectl apply --server-side -f "$${BASE_URL}/kserve-crds.yaml"; \
+	kubectl wait --for=condition=Established crds --all --timeout=60s; \
+	echo "[4/5] Installing KServe controller..."; \
+	kubectl apply --server-side --force-conflicts -f "$${BASE_URL}/kserve.yaml"; \
+	kubectl wait --for=condition=ready pod \
+	  -l control-plane=kserve-controller-manager \
+	  -n kserve --timeout=300s; \
+	echo "Waiting for webhook endpoint..."; \
+	for i in $$(seq 1 30); do \
+	  if kubectl get endpoints kserve-webhook-server-service -n kserve \
+	       -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null | grep -q .; then \
+	    echo "Webhook endpoint ready."; break; \
+	  fi; \
+	  echo "Waiting for webhook... ($$i/30)"; sleep 5; \
+	done; \
+	echo "[5/5] Installing KServe cluster resources..."; \
+	kubectl apply --server-side -f "$${BASE_URL}/kserve-cluster-resources.yaml"; \
+	echo "Patching storage-initializer for large model downloads..."; \
+	kubectl patch configmap inferenceservice-config -n kserve --type merge -p \
+	  '{"data":{"storageInitializer":"{\"image\":\"kserve/storage-initializer:$(KSERVE_VERSION)\",\"memoryRequest\":\"8Gi\",\"memoryLimit\":\"256Gi\",\"cpuRequest\":\"4\",\"cpuLimit\":\"32\",\"envVars\":[{\"name\":\"HF_HUB_DISABLE_XET\",\"value\":\"1\"}],\"caBundleConfigMapName\":\"\",\"caBundleVolumeMountPath\":\"/etc/ssl/custom-certs\",\"enableModelcar\":true,\"cpuModelcar\":\"10m\",\"memoryModelcar\":\"15Mi\",\"uidModelcar\":1010}"}}'; \
+	echo "Creating namespace and HuggingFace secret..."; \
+	kubectl create namespace $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+	kubectl create secret generic hf-secret \
+	  --from-literal=HF_TOKEN=$(HF_TOKEN) \
+	  -n $(NAMESPACE) \
+	  --dry-run=client -o yaml | kubectl apply -f -; \
+	echo "=== KServe $(KSERVE_VERSION) installation complete ==="
+
+patch-storage-initializer: ## Patch storage-initializer configmap for large model downloads (run after KServe is installed)
+	kubectl patch configmap inferenceservice-config -n kserve --type merge -p \
+	  '{"data":{"storageInitializer":"{\"image\":\"kserve/storage-initializer:$(KSERVE_VERSION)\",\"memoryRequest\":\"8Gi\",\"memoryLimit\":\"256Gi\",\"cpuRequest\":\"4\",\"cpuLimit\":\"32\",\"envVars\":[{\"name\":\"HF_HUB_DISABLE_XET\",\"value\":\"1\"}],\"caBundleConfigMapName\":\"\",\"caBundleVolumeMountPath\":\"/etc/ssl/custom-certs\",\"enableModelcar\":true,\"cpuModelcar\":\"10m\",\"memoryModelcar\":\"15Mi\",\"uidModelcar\":1010}"}}'
+	kubectl rollout restart deployment kserve-controller-manager -n kserve
+	@echo "Storage-initializer patched. New limits: 256Gi RAM, 32 CPU. Xet disabled."
+
 # ---------------------------------------------------------------------------
 # Deploy (Helm)
 # ---------------------------------------------------------------------------
@@ -28,7 +141,7 @@ deploy-basic: ## Deploy single-GPU LLM (Qwen2.5-0.5B on 1x A100)
 	  --set multiNode.enabled=false \
 	  --set disaggregated.enabled=false
 
-deploy-70b: ## Deploy Qwen2.5-72B on 8x A100 (single node, TP=8)
+deploy-70b: ## Deploy Qwen2.5-72B on 8x H100 (single node, TP=8)
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
 	  --set hfToken=$(HF_TOKEN) \
 	  --set basic.enabled=true \
@@ -59,6 +172,79 @@ deploy-multi-node: ## Deploy multi-node LLM (Qwen2.5-72B on 2x8 A100)
 	  --set multiNode.enabled=true \
 	  --set disaggregated.enabled=false
 
+deploy-amd-basic: ## Deploy single-GPU LLM on AMD MI300X (Qwen2.5-0.5B)
+	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
+	  --set hfToken=$(HF_TOKEN) \
+	  --set basic.enabled=false \
+	  --set amd.basic.enabled=true \
+	  --set multiNode.enabled=false \
+	  --set amd.multiNode.enabled=false \
+	  --set disaggregated.enabled=false
+
+deploy-amd-minimax: ## Deploy MiniMax-M2 on 8x MI300X (TP8+EP)
+	kubectl delete pvc model-storage -n $(NAMESPACE) --ignore-not-found
+	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
+	  --set hfToken=$(HF_TOKEN) \
+	  --set basic.enabled=false \
+	  --set amd.basic.enabled=true \
+	  --set multiNode.enabled=false \
+	  --set amd.multiNode.enabled=false \
+	  --set disaggregated.enabled=false \
+	  --set modelStorage.enabled=true \
+	  --set modelStorage.size=1500Gi \
+	  --set amd.basic.model.uri=hf://MiniMaxAI/MiniMax-M2 \
+	  --set amd.basic.model.name=minimax \
+	  --set amd.basic.args[0]="--gpu-memory-utilization" \
+	  --set amd.basic.args[1]="0.95" \
+	  --set amd.basic.args[2]="--tensor-parallel-size" \
+	  --set-string amd.basic.args[3]="8" \
+	  --set amd.basic.args[4]="--enable-expert-parallel" \
+	  --set amd.basic.args[5]="--reasoning-parser" \
+	  --set amd.basic.args[6]="minimax_m2_append_think" \
+	  --set amd.basic.args[7]="--trust-remote-code" \
+	  --set amd.basic.resources.limits.gpu="8" \
+	  --set amd.basic.resources.limits.cpu="64" \
+	  --set amd.basic.resources.limits.memory=512Gi \
+	  --set amd.basic.resources.requests.gpu="8" \
+	  --set amd.basic.resources.requests.cpu="32" \
+	  --set amd.basic.resources.requests.memory=256Gi
+
+redeploy-amd-minimax: ## Update MiniMax-M2 args without deleting PVC (preserves downloaded model)
+	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
+	  --set hfToken=$(HF_TOKEN) \
+	  --set basic.enabled=false \
+	  --set amd.basic.enabled=true \
+	  --set multiNode.enabled=false \
+	  --set amd.multiNode.enabled=false \
+	  --set disaggregated.enabled=false \
+	  --set modelStorage.enabled=true \
+	  --set modelStorage.size=1500Gi \
+	  --set amd.basic.model.uri=hf://MiniMaxAI/MiniMax-M2 \
+	  --set amd.basic.model.name=minimax \
+	  --set amd.basic.args[0]="--gpu-memory-utilization" \
+	  --set amd.basic.args[1]="0.95" \
+	  --set amd.basic.args[2]="--tensor-parallel-size" \
+	  --set-string amd.basic.args[3]="8" \
+	  --set amd.basic.args[4]="--enable-expert-parallel" \
+	  --set amd.basic.args[5]="--reasoning-parser" \
+	  --set amd.basic.args[6]="minimax_m2_append_think" \
+	  --set amd.basic.args[7]="--trust-remote-code" \
+	  --set amd.basic.resources.limits.gpu="8" \
+	  --set amd.basic.resources.limits.cpu="64" \
+	  --set amd.basic.resources.limits.memory=512Gi \
+	  --set amd.basic.resources.requests.gpu="8" \
+	  --set amd.basic.resources.requests.cpu="32" \
+	  --set amd.basic.resources.requests.memory=256Gi
+
+deploy-amd-multi-node: ## Deploy multi-node LLM on AMD MI300X (MiniMax-M2 on 2x8)
+	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
+	  --set hfToken=$(HF_TOKEN) \
+	  --set basic.enabled=false \
+	  --set amd.basic.enabled=false \
+	  --set multiNode.enabled=false \
+	  --set amd.multiNode.enabled=true \
+	  --set disaggregated.enabled=false
+
 deploy-disaggregated: ## Deploy disaggregated prefill-decode (H100 + A100)
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
 	  --set hfToken=$(HF_TOKEN) \
@@ -70,7 +256,19 @@ deploy-disaggregated: ## Deploy disaggregated prefill-decode (H100 + A100)
 # Test & Benchmark
 # ---------------------------------------------------------------------------
 
-PORT ?= 8080
+PORT  ?= 8080
+MODEL ?=
+
+chat: ## Interactive streaming chat with the deployed model (MODEL=<name> to override auto-detect)
+	@SVC=$$(kubectl get svc -n $(NAMESPACE) -o name | grep workload | head -1) && \
+	echo "Port-forwarding $$SVC to localhost:$(PORT)..." && \
+	kubectl port-forward -n $(NAMESPACE) $$SVC $(PORT):8000 >/dev/null 2>/dev/null & \
+	PF_PID=$$! && \
+	sleep 2 && \
+	python3 scripts/chat.py \
+	  --url http://localhost:$(PORT) \
+	  $$([ -n "$(MODEL)" ] && echo "--model $(MODEL)" || true) || true; \
+	kill $$PF_PID 2>/dev/null || true
 
 test: ## Port-forward and send a test chat request
 	@echo "Finding workload service..."
@@ -85,14 +283,11 @@ test: ## Port-forward and send a test chat request
 	@kill %1 2>/dev/null || true
 
 BENCH_NUM_PROMPTS ?= 200
-BENCH_RATE ?= 50
-BENCH_INPUT_LEN ?= 512
-BENCH_OUTPUT_LEN ?= 150
+BENCH_RATE        ?= 50
+BENCH_INPUT_LEN   ?= 512
+BENCH_OUTPUT_LEN  ?= 150
 
-bench: ## Run vLLM benchmark from inside the serving pod
-	@DEPLOY=$$(kubectl get deploy -n $(NAMESPACE) -o name | grep -v router | head -1 | sed 's|deployment.apps/||') && \
-	echo "Running vLLM benchmark on $$DEPLOY..." && \
-	kubectl exec -n $(NAMESPACE) deploy/$$DEPLOY -c main -- \
+_bench_run = kubectl exec -n $(NAMESPACE) deploy/$$DEPLOY -c main -- \
 	  vllm bench serve \
 	    --model /mnt/models \
 	    --served-model-name qwen \
@@ -100,10 +295,58 @@ bench: ## Run vLLM benchmark from inside the serving pod
 	    --backend openai-chat \
 	    --endpoint /v1/chat/completions \
 	    --dataset-name random \
+	    --random-output-len $(BENCH_OUTPUT_LEN)
+
+_bench_run_amd = kubectl exec -n $(NAMESPACE) deploy/$$DEPLOY -c main -- \
+	  vllm bench serve \
+	    --model /mnt/models \
+	    --served-model-name minimax \
+	    --base-url http://localhost:8000 \
+	    --backend openai-chat \
+	    --endpoint /v1/chat/completions \
+	    --dataset-name random \
+	    --random-output-len $(BENCH_OUTPUT_LEN)
+
+bench: ## Run a single benchmark profile (configure with BENCH_RATE, BENCH_INPUT_LEN, BENCH_NUM_PROMPTS)
+	@DEPLOY=$$(kubectl get deploy -n $(NAMESPACE) -o name | grep -v router | head -1 | sed 's|deployment.apps/||') && \
+	echo "Running vLLM benchmark on $$DEPLOY..." && \
+	$(call _bench_run) \
 	    --random-input-len $(BENCH_INPUT_LEN) \
-	    --random-output-len $(BENCH_OUTPUT_LEN) \
 	    --num-prompts $(BENCH_NUM_PROMPTS) \
 	    --request-rate $(BENCH_RATE)
+
+bench-amd: ## Run AMD benchmark profile (same params as bench — configure with BENCH_RATE, BENCH_INPUT_LEN, BENCH_NUM_PROMPTS)
+	@DEPLOY=$$(kubectl get deploy -n $(NAMESPACE) -o name | grep -v router | head -1 | sed 's|deployment.apps/||') && \
+	echo "Running vLLM benchmark on $$DEPLOY (AMD)..." && \
+	$(call _bench_run_amd) \
+	    --random-input-len $(BENCH_INPUT_LEN) \
+	    --num-prompts $(BENCH_NUM_PROMPTS) \
+	    --request-rate $(BENCH_RATE)
+
+# ---------------------------------------------------------------------------
+# Local monitoring (Grafana + Prometheus via Docker)
+# ---------------------------------------------------------------------------
+
+monitor-up-nvidia: ## Start Grafana with NVIDIA dashboard (gpu-inference)
+	@test -f monitoring/env || \
+	  (echo "ERROR: create monitoring/env with CRUSOE_PROJECT_ID and CRUSOE_MONITORING_TOKEN"; exit 1)
+	@cd monitoring && DASHBOARDS_DIR=./grafana/dashboards/nvidia docker compose up -d
+	@cd monitoring && CLUSTER=nvidia python3 setup.py
+
+monitor-up-amd: ## Start Grafana with AMD dashboard (amd-gpu-inference)
+	@test -f monitoring/env || \
+	  (echo "ERROR: create monitoring/env with CRUSOE_PROJECT_ID and CRUSOE_MONITORING_TOKEN"; exit 1)
+	@cd monitoring && DASHBOARDS_DIR=./grafana/dashboards/amd docker compose up -d
+	@cd monitoring && CLUSTER=amd python3 setup.py
+
+monitor-up: monitor-up-nvidia ## Alias for monitor-up-nvidia (default)
+
+monitor-down: ## Stop Grafana
+	@cd monitoring && docker compose down
+
+monitor-clean: ## Wipe Grafana state and restart fresh
+	$(MAKE) monitor-down
+	docker volume rm monitoring_grafana-data 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # Cleanup

--- a/crusoe-kserve-example/README.md
+++ b/crusoe-kserve-example/README.md
@@ -1,13 +1,15 @@
 # Serving HuggingFace Models on CMK with KServe
 
-Deploy open-source LLMs from HuggingFace on Crusoe Managed Kubernetes (CMK) using [KServe](https://kserve.github.io/) and [vLLM](https://docs.vllm.ai/), from a single-GPU endpoint to disaggregated prefill-decode across heterogeneous GPU pools.
+Deploy open-source LLMs from HuggingFace on Crusoe Managed Kubernetes (CMK) using [KServe](https://kserve.github.io/) and [vLLM](https://docs.vllm.ai/), from a single-GPU endpoint to disaggregated prefill-decode across heterogeneous GPU pools. Supports both NVIDIA and AMD GPU clusters.
 
 ## Features
 
-- Single-GPU LLM serving (Qwen2.5-0.5B on 1x A100)
-- Multi-node tensor-parallel inference (Qwen2.5-72B across 16 GPUs)
-- Disaggregated prefill-decode with H100 (prefill) and A100 (decode)
-- One `terraform apply` for full infrastructure + KServe setup
+- One command for full infrastructure + KServe setup (NVIDIA or AMD)
+- One command to deploy HuggingFace model
+  - Single-GPU LLM serving (Qwen2.5-0.5B on 1x H100, A100, MI300X, etc.)
+  - Multi-node tensor-parallel inference (Qwen2.5-72B across 16 GPUs)
+  - Disaggregated prefill-decode with H100 (prefill) and A100 (decode)
+- AMD MI300X support with ROCm vLLM (MiniMax-M2)
 - Helm chart for model deployments
 - OpenAI-compatible `/v1/chat/completions` endpoint
 
@@ -18,16 +20,17 @@ Deploy open-source LLMs from HuggingFace on Crusoe Managed Kubernetes (CMK) usin
 - [Helm](https://helm.sh/docs/intro/install/) >= 3.0
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - A [HuggingFace](https://huggingface.co/) account and API token
+- **AMD only**: Docker Hub account (for building AMD GPU driver image)
 
-## Quick Start
+## Quick Start — NVIDIA
 
 ### 1. Configure
 
 ```bash
 cd terraform
 cp terraform.tfvars.example terraform.tfvars
-# Edit terraform.tfvars with your project ID and HuggingFace token
 ```
+Edit `terraform.tfvars` with your project ID, HuggingFace token, IB partition IDs, and node types/count.
 
 ### 2. Provision cluster + install KServe
 
@@ -44,13 +47,13 @@ This single command:
 ### 3. Deploy a model
 
 ```bash
-# Single-GPU (Qwen2.5-0.5B, 1x A100)
+# Single-GPU (Qwen2.5-0.5B, 1x H100)
 make deploy-basic
 
-# Single-node 72B (Qwen2.5-72B, 8x A100 TP=8, with PVC storage)
+# Single-node 72B (Qwen2.5-72B, 8x H100 TP=8, with PVC storage)
 make deploy-70b
 
-# Multi-node (Qwen2.5-72B, 2x8 A100)
+# Multi-node (Qwen2.5-72B, 2x8 H100)
 make deploy-multi-node
 
 # Disaggregated prefill-decode (H100 prefill + A100 decode)
@@ -61,66 +64,123 @@ Large models (70B+) require persistent storage. `deploy-70b` automatically provi
 
 ### 4. Test
 
+Send a single chat completion request.
 ```bash
 make test
 ```
 
-### 5. Benchmark
+### 5. Chat
+Enter an interactive chat interface.
+```bash
+make chat
+```
+
+### 6. Benchmark
 
 Uses vLLM's built-in `vllm bench serve` running inside the serving pod:
 
 ```bash
-# Default: 200 prompts, 50 req/s, 512 input / 150 output tokens
-make bench
-
-# Low-latency profile
-make bench BENCH_RATE=10 BENCH_INPUT_LEN=128
-
-# Max throughput
-make bench BENCH_RATE=inf BENCH_NUM_PROMPTS=300
+make bench                                      # Default: 200 prompts, 50 req/s, 512 input / 150 output tokens
+make bench BENCH_RATE=10 BENCH_INPUT_LEN=128    # Low-latency profile
+make bench BENCH_RATE=inf BENCH_NUM_PROMPTS=300 # Max throughput
 ```
+
+---
+
+## Quick Start — AMD
+
+AMD clusters use a separate Terraform directory and require the AMD GPU operator instead of the NVIDIA operator.
+
+### 1. Configure
+
+```bash
+cd terraform-amd
+cp terraform.tfvars.example terraform.tfvars
+```
+Edit terraform.tfvars with your project ID, HuggingFace token, AMD node type/count, IB partition ID, and Docker Hub credentials.
+
+### 2. Provision cluster + install AMD GPU operator + KServe
+
+```bash
+make setup-amd
+```
+
+This single command:
+- Creates the CMK cluster and node pools (MI300X, CPU)
+- Installs cert-manager + AMD GPU operator v1.4.2
+- Installs KServe v0.17.0
+
+### 3. Deploy a model
+
+```bash
+# Small model (Qwen2.5-0.5B on 1x MI300X)
+make deploy-amd-basic
+
+# MiniMax-M2 on 8x MI300X — TP=8, expert parallel, 1500Gi PVC
+make deploy-amd-minimax
+
+# Multi-node (MiniMax-M2 on 2x8 MI300X)
+make deploy-amd-multi-node
+```
+
+### 4. Chat
+Enter an interactive chat interface.
+```bash
+make chat
+```
+
+### 5. Test and benchmark
+
+```bash
+make bench-amd                                      # 50 req/s, 512 input, 150 output
+make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
+```
+
+---
 
 ## Architecture
 
 ### Deployment Modes
 
-| Mode | Model | GPUs | Nodes | Use Case |
-|------|-------|------|-------|----------|
-| **Basic** | Qwen2.5-0.5B | 1x A100 | 1 | Dev/test, small models |
-| **70B** | Qwen2.5-72B | 8x A100 (TP=8) | 1 | Single-node large model |
-| **Multi-Node** | Qwen2.5-72B | 16x A100 | 2 | Large models that exceed single-node VRAM |
-| **Disaggregated** | Qwen2.5-72B | 8x H100 + 16x A100 | 3 | Production, cost-optimized latency |
+| Mode | GPU | Model | Use Case |
+|------|-----|-------|----------|
+| **Basic (NVIDIA)** | 1x A100 | Qwen2.5-0.5B | Dev/test, small models |
+| **70B (NVIDIA)** | 8x A100 TP=8 | Qwen2.5-72B | Single-node large model |
+| **Multi-Node (NVIDIA)** | 16x A100 (2 nodes) | Qwen2.5-72B | Large models exceeding single-node VRAM |
+| **Disaggregated (NVIDIA)** | 8x H100 + 16x A100 | Qwen2.5-72B | Production, cost-optimized latency |
+| **Basic (AMD)** | 8x MI300X | MiniMax-M2 | Large MoE models, high-memory serving |
+| **Multi-Node (AMD)** | 16x MI300X (2 nodes) | MiniMax-M2 | Multi-node MoE on AMD |
 
-### Why Disaggregated Prefill-Decode?
-
-LLM inference has two phases with different hardware needs:
-
-- **Prefill** processes the full input prompt at once — compute-bound. H100s are ideal (high FP16/FP8 throughput).
-- **Decode** generates one token at a time — memory-bandwidth-bound. A100s deliver sufficient bandwidth at lower cost.
-
-Both A100 SXM and H100 SXM have 80GB HBM, but the H100 provides 3.35 TB/s bandwidth vs the A100's 2 TB/s. Using A100s for decode avoids paying the H100 premium for bandwidth you don't need.
-
-### Cluster Layout
+### NVIDIA Cluster Layout
 
 ```
-CMK Cluster
+CMK Cluster (terraform/)
 ├── 2x CPU (c1a.4x)           — KServe control plane
-├── 2x A100-80GB-SXM-IB.8x    — Decode pool (16 GPUs)
+├── 2x A100-80GB-SXM-IB.8x    — Decode / general inference pool (16 GPUs)
 └── 1x H100-80GB-SXM-IB.8x    — Prefill pool (8 GPUs)
+```
+
+### AMD Cluster Layout
+
+```
+CMK Cluster (terraform-amd/)
+├── 2x CPU (c1a.4x)            — KServe control plane
+└── 1x MI300X-192GB-IB.8x      — AMD GPU pool (8 GPUs, 1536GB VRAM)
 ```
 
 ## Customization
 
-Edit `helm/crusoe-kserve-example/values.yaml` to change models, GPU counts, or resource limits. Then re-run the deploy command.
+Edit `helm/crusoe-kserve-example/values.yaml` to change models, GPU counts, or resource limits, then re-run the deploy command.
 
-For example, to serve a different model on basic mode:
+For example, to serve a different model on AMD basic mode:
 
 ```yaml
-basic:
-  enabled: true
-  model:
-    uri: hf://meta-llama/Llama-3.1-8B-Instruct
-    name: llama
+amd:
+  basic:
+    enabled: true
+    model:
+      uri: hf://meta-llama/Llama-3.1-8B-Instruct
+      name: llama
 ```
 
 ## Networking
@@ -129,6 +189,7 @@ This example uses `kubectl port-forward` for local access. For production, provi
 
 ## Cleanup
 
+This will destroy all resources to stop billing.
 ```bash
 make destroy
 ```
@@ -137,19 +198,33 @@ make destroy
 
 ```
 crusoe-kserve-example/
-├── CLAUDE.md                          # Context for Claude Code to set this up
-├── Makefile                           # make setup / deploy-* / test / bench / destroy
+├── CLAUDE.md                          # Context for Claude Code
+├── Makefile                           # All commands: setup, deploy-*, test, bench, monitor-*, destroy
 ├── chat-test.json                     # Sample request payload for testing
-├── terraform/
+├── scripts/
+│   └── chat.py                        # Interactive streaming chat REPL
+├── terraform/                         # NVIDIA cluster infrastructure
 │   ├── main.tf                        # Cluster, node pools, KServe install, namespace
-│   ├── variables.tf                   # All Terraform variables
-│   └── terraform.tfvars.example       # Example values (copy to terraform.tfvars)
-└── helm/crusoe-kserve-example/
-    ├── Chart.yaml
-    ├── values.yaml                    # Model + resource config
-    └── templates/
-        ├── model-storage.yaml         # StorageClass + PVC for large models
-        ├── basic-llm.yaml             # Single-GPU / single-node deployment
-        ├── multi-node-llm.yaml        # Multi-node tensor parallel
-        └── disaggregated-llm.yaml     # Prefill-decode split
+│   ├── variables.tf
+│   └── terraform.tfvars.example
+├── terraform-amd/                     # AMD cluster infrastructure
+│   ├── main.tf                        # Cluster + node pools (KServe installed by make setup-amd)
+│   ├── variables.tf
+│   └── terraform.tfvars.example
+├── helm/crusoe-kserve-example/
+│   ├── values.yaml                    # Model + resource config (NVIDIA and AMD modes)
+│   └── templates/
+│       ├── model-storage.yaml         # StorageClass + PVC for large models
+│       ├── basic-llm.yaml             # NVIDIA single-GPU deployment
+│       ├── multi-node-llm.yaml        # NVIDIA multi-node tensor parallel
+│       ├── disaggregated-llm.yaml     # NVIDIA prefill-decode split
+│       ├── amd-basic-llm.yaml         # AMD single-node deployment
+│       └── amd-multi-node-llm.yaml    # AMD multi-node tensor parallel
+└── monitoring/
+    ├── docker-compose.yml             # Grafana container (port 3000)
+    ├── env                            # Crusoe credentials (not committed)
+    ├── setup.py                       # Configures Grafana datasource at startup
+    └── grafana/
+        ├── dashboards/nvidia/         # NVIDIA GPU inference dashboard
+        └── dashboards/amd/            # AMD GPU inference dashboard
 ```

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-basic-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-basic-llm.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.amd.basic.enabled }}
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: {{ .Values.amd.basic.model.name }}-llm-amd
+  namespace: {{ .Values.namespace }}
+spec:
+  model:
+    uri: {{ .Values.amd.basic.model.uri }}
+    name: {{ .Values.amd.basic.model.name }}
+  replicas: 1
+  template:
+    {{- if .Values.modelStorage.enabled }}
+    securityContext:
+      fsGroup: 1000
+    {{- end }}
+    containers:
+      - name: main
+        image: {{ .Values.amd.image }}
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-secret
+                key: HF_TOKEN
+          - name: HF_HUB_DISABLE_XET
+            value: "1"
+          - name: VLLM_ROCM_USE_AITER
+            value: "1"
+        {{- if .Values.amd.basic.args }}
+        args:
+          {{- toYaml .Values.amd.basic.args | nindent 10 }}
+        {{- end }}
+        resources:
+          limits:
+            amd.com/gpu: {{ .Values.amd.basic.resources.limits.gpu | quote }}
+            cpu: {{ .Values.amd.basic.resources.limits.cpu | quote }}
+            memory: {{ .Values.amd.basic.resources.limits.memory }}
+          requests:
+            amd.com/gpu: {{ .Values.amd.basic.resources.requests.gpu | quote }}
+            cpu: {{ .Values.amd.basic.resources.requests.cpu | quote }}
+            memory: {{ .Values.amd.basic.resources.requests.memory }}
+    {{- if .Values.modelStorage.enabled }}
+    volumes:
+      - name: kserve-provision-location
+        persistentVolumeClaim:
+          claimName: model-storage
+    {{- end }}
+    nodeSelector:
+      {{- toYaml .Values.amd.basic.nodeSelector | nindent 6 }}
+  router:
+    gateway: {}
+    route: {}
+    scheduler: {}
+{{- end }}

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-multi-node-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-multi-node-llm.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.amd.multiNode.enabled }}
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: {{ .Values.amd.multiNode.model.name }}-llm-multi-node-amd
+  namespace: {{ .Values.namespace }}
+spec:
+  model:
+    uri: {{ .Values.amd.multiNode.model.uri }}
+    name: {{ .Values.amd.multiNode.model.name }}
+  replicas: {{ .Values.amd.multiNode.replicas }}
+  parallelism:
+    tensor: {{ .Values.amd.multiNode.parallelism.tensor }}
+    data: {{ .Values.amd.multiNode.parallelism.data }}
+    dataLocal: {{ .Values.amd.multiNode.parallelism.dataLocal }}
+  template:
+    containers:
+      - name: main
+        image: {{ .Values.amd.image }}
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-secret
+                key: HF_TOKEN
+        args:
+          - "--tensor-parallel-size"
+          - {{ .Values.amd.multiNode.parallelism.tensor | quote }}
+        resources:
+          limits:
+            amd.com/gpu: {{ .Values.amd.multiNode.resources.limits.gpu | quote }}
+            cpu: {{ .Values.amd.multiNode.resources.limits.cpu | quote }}
+            memory: {{ .Values.amd.multiNode.resources.limits.memory }}
+          requests:
+            amd.com/gpu: {{ .Values.amd.multiNode.resources.requests.gpu | quote }}
+            cpu: {{ .Values.amd.multiNode.resources.requests.cpu | quote }}
+            memory: {{ .Values.amd.multiNode.resources.requests.memory }}
+    {{- if .Values.modelStorage.enabled }}
+    volumes:
+      - name: kserve-provision-location
+        persistentVolumeClaim:
+          claimName: model-storage
+    {{- end }}
+    nodeSelector:
+      {{- toYaml .Values.amd.multiNode.nodeSelector | nindent 6 }}
+  worker:
+    containers:
+      - name: main
+        image: {{ .Values.amd.image }}
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-secret
+                key: HF_TOKEN
+        args:
+          - "--tensor-parallel-size"
+          - {{ .Values.amd.multiNode.parallelism.tensor | quote }}
+        resources:
+          limits:
+            amd.com/gpu: {{ .Values.amd.multiNode.resources.limits.gpu | quote }}
+            cpu: {{ .Values.amd.multiNode.resources.limits.cpu | quote }}
+            memory: {{ .Values.amd.multiNode.resources.limits.memory }}
+          requests:
+            amd.com/gpu: {{ .Values.amd.multiNode.resources.requests.gpu | quote }}
+            cpu: {{ .Values.amd.multiNode.resources.requests.cpu | quote }}
+            memory: {{ .Values.amd.multiNode.resources.requests.memory }}
+    {{- if .Values.modelStorage.enabled }}
+    volumes:
+      - name: kserve-provision-location
+        persistentVolumeClaim:
+          claimName: model-storage
+    {{- end }}
+    nodeSelector:
+      {{- toYaml .Values.amd.multiNode.nodeSelector | nindent 6 }}
+  router:
+    gateway: {}
+    route: {}
+    scheduler: {}
+{{- end }}

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
@@ -12,27 +12,6 @@ modelStorage:
   enabled: false
   size: 200Gi
 
-# --------------------------------------------------------------------------
-# Available Crusoe GPU node types (for nodeSelector reference)
-# --------------------------------------------------------------------------
-# | Node Type                  | GPU             | GPUs | VRAM    | BW (TB/s) | Best For              |
-# |----------------------------|-----------------|------|---------|-----------|-----------------------|
-# | a100-80gb-sxm-ib.8x       | A100 SXM 80GB   | 8    | 640 GB  | 2.0       | Decode, general LLM   |
-# | h100-80gb-sxm-ib.8x       | H100 SXM 80GB   | 8    | 640 GB  | 3.35      | Prefill, training     |
-# | h200-141gb-sxm-ib.8x      | H200 SXM 141GB  | 8    | 1128 GB | 4.8       | Large models, highest |
-# | l40s-48gb.1x               | L40S 48GB       | 1    | 48 GB   | 0.86      | Cost-effective small  |
-# | a100-80gb.1x               | A100 PCIe 80GB  | 1    | 80 GB   | 2.0       | Single-GPU inference  |
-#
-# nodeSelector labels:
-#   nvidia-a100-80gb-sxm-ib  (A100 SXM IB)
-#   nvidia-h100-80gb-sxm-ib  (H100 SXM IB)
-#   nvidia-h200-141gb-sxm-ib (H200 SXM IB)
-#   nvidia-l40s              (L40S)
-
-# --------------------------------------------------------------------------
-# Deployment modes — enable the ones you want
-# --------------------------------------------------------------------------
-
 # Basic: single-GPU LLM serving (e.g., Qwen2.5-0.5B-Instruct)
 basic:
   enabled: true
@@ -110,7 +89,7 @@ disaggregated:
         cpu: "32"
         memory: 256Gi
     nodeSelector:
-      crusoe.ai/accelerator: nvidia-h100-80gb-sxm-ib
+      crusoe.ai/accelerator: nvidia-a100-80gb-sxm-ib
   prefill:
     replicas: 1
     args:
@@ -134,3 +113,54 @@ disaggregated:
         memory: 256Gi
     nodeSelector:
       crusoe.ai/accelerator: nvidia-h100-80gb-sxm-ib
+
+# AMD MI300X deployment modes
+amd:
+  image: vllm/vllm-openai-rocm:latest
+
+  # Basic: single-GPU LLM serving on AMD MI300X
+  basic:
+    enabled: false
+    model:
+      uri: hf://Qwen/Qwen2.5-0.5B-Instruct
+      name: qwen
+    args:
+      - "--gpu-memory-utilization"
+      - "0.95"
+      - "--enable-chunked-prefill"
+      - "--max-num-batched-tokens"
+      - "4096"
+    resources:
+      limits:
+        gpu: "1"
+        cpu: "2"
+        memory: 6Gi
+      requests:
+        gpu: "1"
+        cpu: "1"
+        memory: 4Gi
+    nodeSelector:
+      crusoe.ai/accelerator: amd-mi300x-192gb-ib
+
+  # Multi-node: tensor + pipeline parallelism on AMD MI300X
+  multiNode:
+    enabled: false
+    model:
+      uri: hf://MiniMaxAI/MiniMax-M2
+      name: minimax
+    replicas: 2
+    parallelism:
+      tensor: 8
+      data: 16
+      dataLocal: 8
+    resources:
+      limits:
+        gpu: "8"
+        cpu: "64"
+        memory: 512Gi
+      requests:
+        gpu: "8"
+        cpu: "32"
+        memory: 256Gi
+    nodeSelector:
+      crusoe.ai/accelerator: amd-mi300x-192gb-ib

--- a/crusoe-kserve-example/monitoring/docker-compose.yml
+++ b/crusoe-kserve-example/monitoring/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ${DASHBOARDS_DIR:-./grafana/dashboards/nvidia}:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    restart: unless-stopped
+
+volumes:
+  grafana-data:

--- a/crusoe-kserve-example/monitoring/env.example
+++ b/crusoe-kserve-example/monitoring/env.example
@@ -1,0 +1,3 @@
+# Rename this file to `env`
+CRUSOE_PROJECT_ID=your-project-id
+CRUSOE_MONITORING_TOKEN=your-monitoring-token

--- a/crusoe-kserve-example/monitoring/grafana/dashboards/amd/amd-gpu-inference.json
+++ b/crusoe-kserve-example/monitoring/grafana/dashboards/amd/amd-gpu-inference.json
@@ -1,0 +1,243 @@
+{
+  "title": "AMD GPU Inference Metrics",
+  "uid": "amd-gpu-inference",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "panels": [
+    {
+      "id": 1,
+      "title": "GPU Utilization",
+      "description": "Percentage of time the GPU graphics engine is actively executing tasks (gpu_gfx_activity). LLM decode is bursty — expect 60-100% during active inference.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "gpu_gfx_activity",
+          "legendFormat": "{{node}} GPU {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 2,
+      "title": "Memory Bandwidth Utilization",
+      "description": "Percentage of peak HBM3 bandwidth in use (gpu_umc_activity). LLM decode is memory-bandwidth bound — MI300x peaks at 5.2 TB/s. Sustained >60% is expected under load.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "gpu_umc_activity",
+          "legendFormat": "{{node}} GPU {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 3,
+      "title": "GPU Memory Used (GiB)",
+      "description": "HBM3 memory allocated (gpu_used_visible_vram) vs total (gpu_total_visible_vram). MI300x has 192 GB per GPU. Model weights are constant; KV cache grows under load. Values are in MiB.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "gpu_used_visible_vram",
+          "legendFormat": "{{node}} GPU {{gpu_id}} used",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "gpu_total_visible_vram",
+          "legendFormat": "{{node}} GPU {{gpu_id}} total",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decmbytes",
+          "min": 0,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 4,
+      "title": "Power Draw (W)",
+      "description": "GPU power consumption (gpu_power_usage). MI300x TDP is 750W. Expect idle ~100W, sustained inference 500-700W under full concurrency.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "gpu_power_usage",
+          "legendFormat": "{{node}} GPU {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "min": 0,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 5,
+      "title": "GPU Temperature (°C)",
+      "description": "Junction temperature (gpu_junction_temperature). MI300x thermal limit ~110°C. Sustained inference should stay below 85°C with adequate cooling.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "gpu_junction_temperature",
+          "legendFormat": "{{node}} GPU {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "min": 0,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 85 }
+            ]
+          }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 6,
+      "title": "XGMI Bandwidth (bytes/s)",
+      "description": "Inter-GPU data transfer over XGMI fabric (equivalent of NVLink). Active during tensor-parallel all-reduce between GPUs. High values indicate healthy TP communication.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "rate(gpu_xgmi_link_rx[1m])",
+          "legendFormat": "{{node}} GPU {{gpu_id}} RX",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "rate(gpu_xgmi_link_tx[1m])",
+          "legendFormat": "{{node}} GPU {{gpu_id}} TX",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "min": 0,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 7,
+      "title": "PCIe Bandwidth (bytes/s)",
+      "description": "Data transfer rate between CPU host memory and GPU over PCIe (pcie_bandwidth). Active during model loading and KV cache migration in disaggregated setups.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "pcie_bandwidth",
+          "legendFormat": "{{node}} GPU {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "min": 0,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 8,
+      "title": "ECC Error Rates (errors/min)",
+      "description": "Correctable (single-bit) and uncorrectable (multi-bit) ECC memory errors per minute. Any uncorrectable errors are a serious hardware signal requiring investigation.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "rate(gpu_ecc_correct_total[1m]) * 60",
+          "legendFormat": "{{node}} GPU {{gpu_id}} correctable",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "rate(gpu_ecc_uncorrect_total[1m]) * 60",
+          "legendFormat": "{{node}} GPU {{gpu_id}} uncorrectable",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.001 }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*uncorrectable.*" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    }
+  ]
+}

--- a/crusoe-kserve-example/monitoring/grafana/dashboards/nvidia/gpu-inference.json
+++ b/crusoe-kserve-example/monitoring/grafana/dashboards/nvidia/gpu-inference.json
@@ -1,0 +1,138 @@
+{
+  "title": "GPU Inference Metrics",
+  "uid": "gpu-inference",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "panels": [
+    {
+      "id": 1,
+      "title": "GPU SM Utilization",
+      "description": "Streaming Multiprocessor (compute) utilization per GPU. LLM decode is bursty — expect 60-100% during active inference.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "DCGM_FI_DEV_GPU_UTIL",
+          "legendFormat": "GPU {{gpu}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 2,
+      "title": "Tensor Core Activity",
+      "description": "Fraction of time tensor cores are active (PIPE_TENSOR_ACTIVE). More meaningful than SM util for transformer inference — shows actual matrix-multiply throughput.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE",
+          "legendFormat": "GPU {{gpu}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 3,
+      "title": "Power Draw (W)",
+      "description": "GPU power consumption. A100 80GB SXM idles at ~100W, peaks at ~400W. Sustained decode at full concurrency typically 250-350W.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "DCGM_FI_DEV_POWER_USAGE",
+          "legendFormat": "GPU {{gpu}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "min": 0,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 4,
+      "title": "HBM Bandwidth Utilization",
+      "description": "Fraction of cycles the HBM memory interface is active (DRAM_ACTIVE). LLM decode is memory-bandwidth bound — weights must be streamed from HBM each token step. Sustained >60% here explains why tensor core activity stays low even at 100% SM utilization.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "DCGM_FI_PROF_DRAM_ACTIVE",
+          "legendFormat": "GPU {{gpu}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 5,
+      "title": "GPU Memory Used (MiB)",
+      "description": "Framebuffer memory in use. Model weights (~28 GB for Qwen2.5-14B on TP=2) are constant; the remainder is KV cache that grows under load.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "DCGM_FI_DEV_FB_USED",
+          "legendFormat": "GPU {{gpu}} used",
+          "refId": "A"
+        },
+        {
+          "datasource": { "uid": "prometheus" },
+          "expr": "DCGM_FI_DEV_FB_FREE",
+          "legendFormat": "GPU {{gpu}} free",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decmbytes",
+          "min": 0,
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+    }
+  ]
+}

--- a/crusoe-kserve-example/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/crusoe-kserve-example/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: default
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/crusoe-kserve-example/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/crusoe-kserve-example/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,2 @@
+apiVersion: 1
+datasources: []

--- a/crusoe-kserve-example/monitoring/setup.py
+++ b/crusoe-kserve-example/monitoring/setup.py
@@ -1,0 +1,60 @@
+import base64, json, os, pathlib, sys, time, urllib.request, urllib.error
+
+env = {}
+for line in pathlib.Path("env").read_text().splitlines():
+    line = line.strip()
+    if line and not line.startswith("#") and "=" in line:
+        k, v = line.split("=", 1)
+        env[k.strip()] = v.strip()
+
+token = env.get("CRUSOE_MONITORING_TOKEN", "")
+project_id = env.get("CRUSOE_PROJECT_ID", "")
+if not token or not project_id:
+    sys.exit("ERROR: CRUSOE_MONITORING_TOKEN and CRUSOE_PROJECT_ID must be set in monitoring/env")
+
+auth = base64.b64encode(b"admin:admin").decode()
+headers = {"Content-Type": "application/json", "Authorization": f"Basic {auth}"}
+
+def api(method, path, body=None):
+    req = urllib.request.Request(
+        f"http://localhost:3000{path}",
+        data=json.dumps(body).encode() if body else None,
+        headers=headers,
+        method=method,
+    )
+    try:
+        return json.loads(urllib.request.urlopen(req).read())
+    except urllib.error.HTTPError as e:
+        return json.loads(e.read())
+
+print("Waiting for Grafana...")
+for _ in range(60):
+    try:
+        urllib.request.urlopen("http://localhost:3000/api/health", timeout=2)
+        break
+    except Exception:
+        time.sleep(1)
+else:
+    sys.exit("ERROR: Grafana did not start within 60s")
+
+print("Configuring datasource...")
+ds = {
+    "name": "Crusoe",
+    "type": "prometheus",
+    "uid": "prometheus",
+    "url": f"https://api.crusoecloud.com/v1alpha5/projects/{project_id}/metrics/timeseries",
+    "access": "proxy",
+    "isDefault": True,
+    "jsonData": {"httpMethod": "GET", "httpHeaderName1": "Authorization"},
+    "secureJsonData": {"httpHeaderValue1": f"Bearer {token}"},
+}
+result = api("POST", "/api/datasources", ds)
+if "already exists" in result.get("message", ""):
+    ds_id = api("GET", "/api/datasources/name/Crusoe")["id"]
+    result = api("PUT", f"/api/datasources/{ds_id}", ds)
+print(" ", result.get("message", result))
+
+cluster = os.environ.get("CLUSTER", "nvidia")
+dashboard_uid = "amd-gpu-inference" if cluster == "amd" else "gpu-inference"
+print("\nDone!")
+print(f"Dashboard: http://localhost:3000/d/{dashboard_uid}  (admin / admin)")

--- a/crusoe-kserve-example/scripts/chat.py
+++ b/crusoe-kserve-example/scripts/chat.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Interactive streaming chat CLI for KServe/vLLM deployments.
+
+Usage:
+    python3 scripts/chat.py [--url URL] [--model MODEL] [--system PROMPT]
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.request
+import urllib.error
+
+RESET       = "\033[0m"
+BOLD        = "\033[1m"
+DIM         = "\033[2m"
+BLUE_BOLD   = "\033[1;34m"
+GREEN_BOLD  = "\033[1;32m"
+CYAN_BOLD   = "\033[1;36m"
+YELLOW_BOLD = "\033[1;33m"
+
+
+def build_params(model_id: str) -> dict:
+    if "minimax" in model_id.lower():
+        return {"temperature": 1.0, "top_p": 0.95, "top_k": 40}
+    return {"temperature": 0.7, "top_p": 1.0}
+
+
+def detect_model(base_url: str) -> str:
+    try:
+        req = urllib.request.Request(
+            f"{base_url}/v1/models",
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+        models = data.get("data", [])
+        if models:
+            return models[0]["id"]
+    except Exception as exc:
+        sys.stderr.write(f"[warn] Could not detect model: {exc}\n")
+    return "default"
+
+
+def stream_chat(url: str, payload: dict):
+    """Yield (field, value) tuples.
+
+    field is 'reasoning_content', 'content', or 'completion_tokens' (final chunk).
+    """
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json", "Accept": "text/event-stream"},
+    )
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8").rstrip("\r\n")
+            if not line.startswith("data: "):
+                continue
+            s = line[6:]
+            if s.strip() == "[DONE]":
+                return
+            try:
+                chunk = json.loads(s)
+            except json.JSONDecodeError:
+                continue
+            usage = chunk.get("usage")
+            if usage and usage.get("completion_tokens"):
+                yield "completion_tokens", usage["completion_tokens"]
+            choices = chunk.get("choices", [])
+            if not choices:
+                continue
+            choice = choices[0]
+            delta = choice.get("delta", {})
+            # reasoning_content may be on delta or on choice directly (vLLM version dependent)
+            reasoning = delta.get("reasoning_content") or choice.get("reasoning_content")
+            content = delta.get("content")
+            if reasoning:
+                yield "reasoning_content", reasoning
+            if content:
+                yield "content", content
+
+
+def print_banner(model: str):
+    lines = [
+        "CMK KServe Chat",
+        model,
+        "",
+        "/clear  reset history    /quit  exit",
+    ]
+    width = max(len(l) for l in lines) + 6
+    bar = "═" * width
+    sys.stdout.write(f"\n{CYAN_BOLD}╔{bar}╗\n")
+    sys.stdout.write(f"║{'':^{width}}║\n")
+    for line in lines:
+        sys.stdout.write(f"║{line:^{width}}║\n")
+    sys.stdout.write(f"║{'':^{width}}║\n")
+    sys.stdout.write(f"╚{bar}╝{RESET}\n\n")
+    sys.stdout.flush()
+
+
+def chat_loop(base_url: str, model: str, display_name: str, system_prompt: str, max_tokens: int):
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+
+    print_banner(display_name)
+
+    while True:
+        try:
+            user_input = input(f"{BLUE_BOLD}You:{RESET} ").strip()
+        except (EOFError, KeyboardInterrupt):
+            sys.stdout.write(f"\n{DIM}Goodbye.{RESET}\n")
+            return
+
+        if not user_input:
+            continue
+        if user_input.lower() in ("/quit", "/exit", "quit", "exit"):
+            sys.stdout.write(f"{DIM}Goodbye.{RESET}\n")
+            return
+        if user_input.lower() == "/clear":
+            messages = []
+            if system_prompt:
+                messages.append({"role": "system", "content": system_prompt})
+            sys.stdout.write(f"{DIM}  History cleared.{RESET}\n\n")
+            continue
+        if user_input.lower() == "/help":
+            sys.stdout.write(
+                f"{DIM}  /clear  — reset conversation history\n"
+                f"  /quit   — exit\n"
+                f"  /help   — show this message{RESET}\n\n"
+            )
+            continue
+
+        messages.append({"role": "user", "content": user_input})
+        sys.stdout.write(f"\n{GREEN_BOLD}Assistant:{RESET} ")
+        sys.stdout.flush()
+
+        payload = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            **build_params(model),
+        }
+
+        start_time        = time.monotonic()
+        first_tok         = None
+        completion_tokens = None
+        full_response     = ""
+        interrupted       = False
+
+        try:
+            for field, value in stream_chat(f"{base_url}/v1/chat/completions", payload):
+                now = time.monotonic()
+                if field == "completion_tokens":
+                    completion_tokens = value
+                    continue
+                if first_tok is None:
+                    first_tok = now
+                    ttft = (now - start_time) * 1000.0
+                    sys.stdout.write(f"{YELLOW_BOLD}[⚡ {ttft:.0f}ms]{RESET} ")
+                    sys.stdout.flush()
+                sys.stdout.write(value)
+                sys.stdout.flush()
+                if field == "content":
+                    full_response += value
+        except KeyboardInterrupt:
+            interrupted = True
+            sys.stdout.write(f"\n{DIM}[interrupted]{RESET}\n\n")
+        except urllib.error.URLError as exc:
+            sys.stdout.write(f"\n{DIM}[connection error: {exc}]{RESET}\n\n")
+            messages.pop()
+            continue
+        except Exception as exc:
+            sys.stdout.write(f"\n{DIM}[error: {exc}]{RESET}\n\n")
+            messages.pop()
+            continue
+
+        if not interrupted:
+            elapsed = time.monotonic() - (first_tok or start_time)
+            tps = completion_tokens / elapsed if completion_tokens and elapsed > 0.001 else 0.0
+            tok_display = str(completion_tokens) if completion_tokens is not None else "?"
+            sys.stdout.write(f"\n{DIM}  ✓ {tps:.1f} tok/s · {tok_display} tokens{RESET}\n\n")
+            sys.stdout.flush()
+
+        if full_response and not interrupted:
+            messages.append({"role": "assistant", "content": full_response})
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url",        default="http://localhost:8080")
+    parser.add_argument("--model",      default=None)
+    parser.add_argument("--system",     default="You are a helpful assistant.")
+    parser.add_argument("--max-tokens", type=int, default=4096)
+    args = parser.parse_args()
+
+    base_url = args.url.rstrip("/")
+
+    sys.stdout.write(f"{DIM}Detecting model...{RESET} ")
+    sys.stdout.flush()
+    model = args.model or detect_model(base_url)
+    display_name = model
+    sys.stdout.write(f"{GREEN_BOLD}{display_name}{RESET}\n")
+    sys.stdout.flush()
+
+    try:
+        chat_loop(base_url, model, display_name, args.system, args.max_tokens)
+    except KeyboardInterrupt:
+        sys.stdout.write(f"\n{DIM}Goodbye.{RESET}\n")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/crusoe-kserve-example/terraform-amd/main.tf
+++ b/crusoe-kserve-example/terraform-amd/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_providers {
+    crusoe = {
+      source = "crusoecloud/crusoe"
+    }
+  }
+}
+
+provider "crusoe" {
+  # Uses CRUSOE_API_KEY / CRUSOE_API_SECRET from environment,
+  # or ~/.crusoe/config if present.
+}
+
+# -----------------------------------------------------------------------------
+# CMK Cluster
+# AMD clusters use crusoe_csi only — no nvidia add-ons needed.
+# The AMD GPU operator is installed separately by make setup-amd.
+# -----------------------------------------------------------------------------
+resource "crusoe_kubernetes_cluster" "kserve_amd" {
+  name       = var.cluster_name
+  version    = var.cluster_version
+  location   = var.location
+  project_id = var.project_id
+  add_ons    = ["crusoe_csi"]
+}
+
+# -----------------------------------------------------------------------------
+# Node Pools
+# -----------------------------------------------------------------------------
+resource "crusoe_kubernetes_node_pool" "amd" {
+  count           = var.amd_node_count > 0 ? 1 : 0
+  name            = var.amd_pool_name
+  cluster_id      = crusoe_kubernetes_cluster.kserve_amd.id
+  instance_count  = var.amd_node_count
+  type            = var.amd_node_type
+  ssh_key         = var.ssh_public_key != "" ? var.ssh_public_key : null
+  ib_partition_id = var.amd_ib_partition_id
+  project_id      = var.project_id
+}
+
+resource "crusoe_kubernetes_node_pool" "cpu" {
+  count          = var.cpu_node_count > 0 ? 1 : 0
+  name           = var.cpu_pool_name
+  cluster_id     = crusoe_kubernetes_cluster.kserve_amd.id
+  instance_count = var.cpu_node_count
+  type           = var.cpu_node_type
+  ssh_key        = var.ssh_public_key != "" ? var.ssh_public_key : null
+  project_id     = var.project_id
+}
+
+# -----------------------------------------------------------------------------
+# Kubeconfig — fetch credentials after cluster + node pools are ready
+# -----------------------------------------------------------------------------
+resource "null_resource" "kubeconfig" {
+  depends_on = [
+    crusoe_kubernetes_cluster.kserve_amd,
+    crusoe_kubernetes_node_pool.amd,
+    crusoe_kubernetes_node_pool.cpu,
+  ]
+
+  provisioner "local-exec" {
+    command = "crusoe kubernetes clusters get-credentials ${crusoe_kubernetes_cluster.kserve_amd.name} --project-id ${var.project_id} -y"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+output "cluster_name" {
+  value = crusoe_kubernetes_cluster.kserve_amd.name
+}
+
+output "next_steps" {
+  value = "Cluster and node pools are ready. make setup-amd will now install the AMD GPU operator and KServe."
+}

--- a/crusoe-kserve-example/terraform-amd/terraform.tfvars.example
+++ b/crusoe-kserve-example/terraform-amd/terraform.tfvars.example
@@ -1,0 +1,31 @@
+# -----------------------------------------------------------------------
+# Crusoe infrastructure
+# -----------------------------------------------------------------------
+project_id      = "your-project-id"
+cluster_name    = "kserve-amd-cluster"
+cluster_version = "1.33.4-cmk.43"
+location        = "us-east1-a"
+
+# AMD GPU node pool
+# Set amd_node_type to your Crusoe AMD GPU SKU
+# Find available SKUs: crusoe compute vms list-types
+amd_node_type       = ""
+amd_node_count      = 1
+amd_ib_partition_id = "your-ib-partition-id"
+
+# CPU nodes for KServe control plane
+cpu_node_count = 2
+
+# SSH public key — provisioned onto nodes at creation time (cannot be added later).
+# Set this to SSH into GPU nodes for debugging (e.g. rocm-smi, driver issues).
+ssh_public_key = "ssh-ed25519 AAAA... user@host"
+
+# -----------------------------------------------------------------------
+# Credentials
+# -----------------------------------------------------------------------
+hf_token = "hf_your_token_here"
+
+docker_username = "your-dockerhub-username"
+docker_email    = "you@example.com"
+# Use Docker PAT, not account password
+docker_password = "your-password"

--- a/crusoe-kserve-example/terraform-amd/variables.tf
+++ b/crusoe-kserve-example/terraform-amd/variables.tf
@@ -1,0 +1,107 @@
+variable "project_id" {
+  description = "Crusoe Cloud project ID"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the CMK cluster"
+  type        = string
+  default     = "kserve-amd-cluster"
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version for the cluster"
+  type        = string
+  default     = "1.33.4-cmk.43"
+}
+
+variable "location" {
+  description = "Crusoe Cloud location (e.g. us-east1-a)"
+  type        = string
+  default     = "us-east1-a"
+}
+
+# --- SSH Key ---
+
+variable "ssh_public_key" {
+  description = "SSH public key for node pool access"
+  type        = string
+  default     = ""
+  # Crusoe provisions this key onto every node at creation time — it cannot be
+  # added later without destroying and recreating the node pool. Set this to
+  # your public key (e.g. contents of ~/.ssh/id_ed25519.pub) so you can SSH
+  # directly into AMD GPU nodes for debugging (e.g. rocm-smi, driver issues).
+}
+
+# --- Credentials (read by make setup-amd, not used by Terraform directly) ---
+
+variable "hf_token" {
+  description = "HuggingFace API token — used by make setup-amd to create the k8s secret"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "docker_username" {
+  description = "Docker Hub username — used by make setup-amd to push the AMD GPU driver image"
+  type        = string
+  default     = ""
+}
+
+variable "docker_email" {
+  description = "Docker Hub email — used by make setup-amd"
+  type        = string
+  default     = ""
+}
+
+variable "docker_password" {
+  description = "Docker Hub password — used by make setup-amd"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# --- AMD GPU Node Pool ---
+
+variable "amd_pool_name" {
+  description = "Name of the AMD GPU node pool"
+  type        = string
+  default     = "amd-pool"
+}
+
+variable "amd_node_count" {
+  description = "Number of AMD GPU nodes"
+  type        = number
+  default     = 1
+}
+
+variable "amd_node_type" {
+  description = "AMD GPU node instance type (e.g. mi300x-192gb-ib.8x)"
+  type        = string
+}
+
+variable "amd_ib_partition_id" {
+  description = "InfiniBand partition ID for the AMD GPU node pool"
+  type        = string
+  default     = ""
+}
+
+# --- CPU Node Pool ---
+
+variable "cpu_pool_name" {
+  description = "Name of the CPU node pool"
+  type        = string
+  default     = "cpu-pool"
+}
+
+variable "cpu_node_count" {
+  description = "Number of CPU nodes"
+  type        = number
+  default     = 2
+}
+
+variable "cpu_node_type" {
+  description = "CPU node instance type"
+  type        = string
+  default     = "c1a.4x"
+}

--- a/crusoe-kserve-example/terraform/main.tf
+++ b/crusoe-kserve-example/terraform/main.tf
@@ -35,6 +35,10 @@ variable "hf_token" {
 variable "ssh_public_key" {
   description = "SSH public key for node pool access"
   type        = string
+  # Crusoe provisions this key onto every node at creation time — it cannot be
+  # added later without destroying and recreating the node pool. Set this to
+  # your public key (e.g. contents of ~/.ssh/id_ed25519.pub) so you can SSH
+  # directly into GPU nodes for debugging (e.g. nvidia-smi, driver issues).
 }
 
 # -----------------------------------------------------------------------------

--- a/crusoe-kserve-example/terraform/terraform.tfvars.example
+++ b/crusoe-kserve-example/terraform/terraform.tfvars.example
@@ -5,6 +5,8 @@ location        = "us-east1-a"
 
 # HuggingFace token — required to pull models
 hf_token       = "hf_your_token_here"
+
+# Set your Crusoe SSH key to SSH into your GPU nodes for debugging
 ssh_public_key = "ssh-ed25519 AAAA... user@host"
 
 # KServe version


### PR DESCRIPTION
Adds AMD GPU support to the KServe LLM serving example alongside the existing NVIDIA setup.

- New `terraform-amd/` infra, AMD Helm templates, and `make setup-amd` / `deploy-amd-*` targets
- MiniMax-M2 as the reference AMD model (single-node TP=8 and multi-node 2x8)
- Local Grafana + Prometheus monitoring stack with NVIDIA and AMD dashboards
- Interactive streaming chat client (`make chat`) with TTFT and tok/s metrics