### PR TITLE
etchosts-pin: a daemon that syncs the results of DNS resolutions into /etc/hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,9 @@ For your applications running on Crusoe Managed Kubernetes cluster, you can coll
 [Crusoe to Splunk HEC Log Forwarder](./crusoe-splunk-hec/README.md)
 
 Crusoe Cloud provides a 90-day history of who did what in your cloud, when, where, and with what result - also called [Crusoe Audit Logs](https://docs.crusoecloud.com/identity-and-security/audit-logs/index.html). This solution provides a sample Python tool to fetch those logs and forward them to a Splunk HTTP Event Collector (HEC). 
+
+### Networking
+
+[/etc/hosts Pin](./etchosts-pin/README.md)
+
+A daemon that resolves a hostname on a fixed interval and keeps the resulting A/AAAA records in `/etc/hosts`. Works around undesirable TTL cache values from intermediate DNS resolvers

--- a/etchosts-pin/.gitignore
+++ b/etchosts-pin/.gitignore
@@ -1,0 +1,1 @@
+etchosts-pin

--- a/etchosts-pin/Dockerfile
+++ b/etchosts-pin/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY *.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o etchosts-pin .
+
+FROM scratch
+COPY --from=builder /app/etchosts-pin /etchosts-pin
+ENTRYPOINT ["/etchosts-pin"]

--- a/etchosts-pin/Makefile
+++ b/etchosts-pin/Makefile
@@ -1,0 +1,23 @@
+IMAGE    ?= etchosts-pin
+TAG      ?= latest
+REGISTRY ?=
+PLATFORM ?= linux/amd64
+
+BIN := etchosts-pin
+
+.PHONY: build test docker-build docker-push clean
+
+build:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o $(BIN) .
+
+test:
+	go test ./...
+
+docker-build:
+	docker buildx build --platform $(PLATFORM) --load -t $(REGISTRY)$(IMAGE):$(TAG) .
+
+docker-push: docker-build
+	docker push $(REGISTRY)$(IMAGE):$(TAG)
+
+clean:
+	rm -f $(BIN)

--- a/etchosts-pin/README.md
+++ b/etchosts-pin/README.md
@@ -6,7 +6,7 @@ A daemon that resolves a hostname on a fixed interval and keeps the resulting A/
 
 On each tick the daemon:
 
-1. Calls `net.LookupHost` against the configured hostname.
+1. Issues a DNS query against the configured hostname.
 2. Reads the current `/etc/hosts`.
 3. Replaces its previously written block (demarcated by `BEGIN`/`END` comments) with the freshly resolved addresses.
 4. Writes the file back in place.
@@ -24,11 +24,12 @@ Records are added, updated, or removed automatically as DNS changes. If a lookup
 
 ## Environment variables
 
-| Variable           | Required | Default       | Description                        |
-|--------------------|----------|---------------|------------------------------------|
-| `RESOLVE_HOSTNAME` | yes      | —             | Hostname to resolve                |
-| `HOSTS_FILE`       | no       | `/etc/hosts`  | Path to the hosts file             |
-| `INTERVAL_SECONDS` | no       | `5`           | Polling interval in seconds        |
+| Variable           | Required | Default       | Description                                                           |
+|--------------------|----------|---------------|-----------------------------------------------------------------------|
+| `RESOLVE_HOSTNAME` | yes      | —             | Comma-delimited hostnames to resolve                                  |
+| `RESOLVERS`        | no       | —             | Comma-delimited hosts to use as resolvers instead of /etc/resolv.conf |
+| `HOSTS_FILE`       | no       | `/etc/hosts`  | Path to the hosts file                                                |
+| `INTERVAL_SECONDS` | no       | `5`           | Polling interval in seconds                                           |
 
 ## Build
 
@@ -75,13 +76,13 @@ Key values in `helm/values.yaml`:
 2. Apply:
 
 ```bash
-kubectl apply -f manifests/daemonset.yaml
+kubectl apply -n <NAMESPACE> -f manifests/daemonset.yaml
 ```
 
 ### Verify
 
 ```bash
-kubectl exec -n kube-system ds/etchosts-pin -- cat /etc/hosts
+kubectl exec -n <NAMESPACE> ds/etchosts-pin -- cat /etc/hosts
 # or on the node itself:
 cat /etc/hosts
 ```

--- a/etchosts-pin/README.md
+++ b/etchosts-pin/README.md
@@ -1,0 +1,94 @@
+# etchosts-pin
+
+A daemon that resolves a hostname on a fixed interval and keeps the resulting A/AAAA records in `/etc/hosts`. Designed to run as a Kubernetes DaemonSet so every node in the cluster gets live, up-to-date entries. Works around undesirable TTL cache values from DNS resolvers
+
+## How it works
+
+On each tick the daemon:
+
+1. Calls `net.LookupHost` against the configured hostname.
+2. Reads the current `/etc/hosts`.
+3. Replaces its previously written block (demarcated by `BEGIN`/`END` comments) with the freshly resolved addresses.
+4. Writes the file back in place.
+
+Records are added, updated, or removed automatically as DNS changes. If a lookup fails, the existing block is left untouched and the error is logged.
+
+### Example `/etc/hosts` entry
+
+```
+# BEGIN etchosts-pin:myservice.internal
+10.0.1.4	myservice.internal
+10.0.1.7	myservice.internal
+# END etchosts-pin:myservice.internal
+```
+
+## Environment variables
+
+| Variable           | Required | Default       | Description                        |
+|--------------------|----------|---------------|------------------------------------|
+| `RESOLVE_HOSTNAME` | yes      | —             | Hostname to resolve                |
+| `HOSTS_FILE`       | no       | `/etc/hosts`  | Path to the hosts file             |
+| `INTERVAL_SECONDS` | no       | `5`           | Polling interval in seconds        |
+
+## Build
+
+```bash
+# Local binary (linux/amd64)
+make build
+
+# Container image
+make docker-build REGISTRY=myregistry.io/ TAG=v1.0.0
+
+# Push
+make docker-push REGISTRY=myregistry.io/ TAG=v1.0.0
+```
+
+The final image is built `FROM scratch` — no OS, no shell, ~3 MB.
+
+## Deploy
+
+### Helm (recommended)
+
+```bash
+helm install etchosts-pin ./helm \
+  --set resolveHostname=myservice.internal \
+  --set image.repository=myregistry.io/etchosts-pin
+```
+
+Key values in `helm/values.yaml`:
+
+| Value | Required | Default | Description |
+|---|---|---|---|
+| `resolveHostname` | yes | — | Hostname to resolve |
+| `image.repository` | yes | — | Image registry and repo |
+| `image.tag` | no | `latest` | Image tag |
+| `resolvers` | no | — | Comma-separated DNS servers; defaults to `/etc/resolv.conf` |
+| `intervalSeconds` | no | `5` | Polling interval in seconds |
+| `hostsFile` | no | `/etc/hosts` | Path to hosts file |
+
+### Raw manifest
+
+1. Edit `manifests/daemonset.yaml`:
+   - Set `RESOLVE_HOSTNAME` to your target hostname.
+   - Replace `REGISTRY/etchosts-pin:latest` with your image reference.
+
+2. Apply:
+
+```bash
+kubectl apply -f manifests/daemonset.yaml
+```
+
+### Verify
+
+```bash
+kubectl exec -n kube-system ds/etchosts-pin -- cat /etc/hosts
+# or on the node itself:
+cat /etc/hosts
+```
+
+## Security notes
+
+- The container runs as `root` (UID 0) — required to write the host's `/etc/hosts`.
+- All Linux capabilities are dropped; `allowPrivilegeEscalation` is false.
+- The root filesystem is read-only; only `/etc/hosts` (hostPath) is writable.
+- No network ports are opened.

--- a/etchosts-pin/go.mod
+++ b/etchosts-pin/go.mod
@@ -1,0 +1,13 @@
+module github.com/crusoecloud/etchosts-pin
+
+go 1.26.0
+
+require github.com/miekg/dns v1.1.72
+
+require (
+	golang.org/x/mod v0.31.0 // indirect
+	golang.org/x/net v0.48.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/tools v0.40.0 // indirect
+)

--- a/etchosts-pin/go.sum
+++ b/etchosts-pin/go.sum
@@ -1,0 +1,14 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=
+github.com/miekg/dns v1.1.72/go.mod h1:+EuEPhdHOsfk6Wk5TT2CzssZdqkmFhf8r+aVyDEToIs=
+golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
+golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
+golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
+golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
+golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/tools v0.40.0 h1:yLkxfA+Qnul4cs9QA3KnlFu0lVmd8JJfoq+E41uSutA=
+golang.org/x/tools v0.40.0/go.mod h1:Ik/tzLRlbscWpqqMRjyWYDisX8bG13FrdXp3o4Sr9lc=

--- a/etchosts-pin/helm/Chart.yaml
+++ b/etchosts-pin/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: etchosts-pin
+description: DaemonSet that resolves a hostname on a fixed interval and pins the results in /etc/hosts on every node
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/etchosts-pin/helm/templates/daemonset.yaml
+++ b/etchosts-pin/helm/templates/daemonset.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: etchosts-pin
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: RESOLVE_HOSTNAME
+              value: {{ required "resolveHostname is required" .Values.resolveHostname | quote }}
+            {{- if .Values.resolvers }}
+            - name: RESOLVERS
+              value: {{ .Values.resolvers | quote }}
+            {{- end }}
+            {{- if .Values.intervalSeconds }}
+            - name: INTERVAL_SECONDS
+              value: {{ .Values.intervalSeconds | quote }}
+            {{- end }}
+            {{- if .Values.hostsFile }}
+            - name: HOSTS_FILE
+              value: {{ .Values.hostsFile | quote }}
+            {{- end }}
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: hosts
+              mountPath: /etc/hosts
+      volumes:
+        - name: hosts
+          hostPath:
+            path: /etc/hosts
+            type: File

--- a/etchosts-pin/helm/values.yaml
+++ b/etchosts-pin/helm/values.yaml
@@ -1,0 +1,31 @@
+image:
+  repository: REGISTRY/etchosts-pin
+  tag: latest
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: pull-secret
+
+# RESOLVE_HOSTNAME is required — set this to the hostname you want pinned.
+resolveHostname: ""
+
+# Optional overrides
+resolvers: ""        # comma-separated list, e.g. "8.8.8.8,8.8.4.4"; defaults to /etc/resolv.conf
+intervalSeconds: ""  # polling interval in seconds; defaults to 5
+hostsFile: ""        # path to hosts file; defaults to /etc/hosts
+
+resources:
+  requests:
+    cpu: 5m
+    memory: 8Mi
+  limits:
+    cpu: 50m
+    memory: 32Mi
+
+priorityClassName: system-node-critical
+
+tolerations:
+  - operator: Exists
+
+nodeSelector: {}
+affinity: {}

--- a/etchosts-pin/helm/values.yaml
+++ b/etchosts-pin/helm/values.yaml
@@ -3,10 +3,9 @@ image:
   tag: latest
   pullPolicy: Always
 
-imagePullSecrets:
-  - name: pull-secret
+imagePullSecrets: []
 
-# RESOLVE_HOSTNAME is required — set this to the hostname you want pinned.
+# RESOLVE_HOSTNAME is required — one or more hostnames to pin, comma-separated.
 resolveHostname: ""
 
 # Optional overrides

--- a/etchosts-pin/main.go
+++ b/etchosts-pin/main.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func main() {
+	hostname := os.Getenv("RESOLVE_HOSTNAME")
+	if hostname == "" {
+		log.Fatal("RESOLVE_HOSTNAME environment variable is required")
+	}
+
+	hostsFile := os.Getenv("HOSTS_FILE")
+	if hostsFile == "" {
+		hostsFile = "/etc/hosts"
+	}
+
+	interval := 5 * time.Second
+	if s := os.Getenv("INTERVAL_SECONDS"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 1 {
+			log.Fatalf("invalid INTERVAL_SECONDS %q: must be a positive integer", s)
+		}
+		interval = time.Duration(n) * time.Second
+	}
+
+	nameservers, err := resolveNameservers()
+	if err != nil {
+		log.Fatalf("failed to determine nameservers: %v", err)
+	}
+
+	log.Printf("starting: hostname=%s file=%s interval=%s", hostname, hostsFile, interval)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Run immediately on start rather than waiting for the first tick.
+	if err := updateHosts(nameservers, hostname, hostsFile); err != nil {
+		log.Printf("error: %v", err)
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := updateHosts(nameservers, hostname, hostsFile); err != nil {
+				log.Printf("error: %v", err)
+			}
+		case sig := <-sigCh:
+			log.Printf("received %s, cleaning up %s", sig, hostsFile)
+			if err := cleanupHosts(hostname, hostsFile); err != nil {
+				log.Printf("cleanup error: %v", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		}
+	}
+}
+
+// resolveNameservers returns nameservers from RESOLVERS env var (comma-delimited)
+// or falls back to /etc/resolv.conf.
+func resolveNameservers() ([]string, error) {
+	if v := os.Getenv("RESOLVERS"); v != "" {
+		var servers []string
+		for _, s := range strings.Split(v, ",") {
+			if s = strings.TrimSpace(s); s != "" {
+				servers = append(servers, s)
+			}
+		}
+		if len(servers) == 0 {
+			return nil, fmt.Errorf("RESOLVERS is set but contains no valid entries")
+		}
+		log.Printf("using nameservers from RESOLVERS: %v", servers)
+		return servers, nil
+	}
+	servers, err := nameserversFromResolvConf("/etc/resolv.conf")
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("using nameservers from /etc/resolv.conf: %v", servers)
+	return servers, nil
+}
+
+func nameserversFromResolvConf(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var servers []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && fields[0] == "nameserver" {
+			servers = append(servers, fields[1])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan %s: %w", path, err)
+	}
+	if len(servers) == 0 {
+		return nil, fmt.Errorf("no nameserver entries found in %s", path)
+	}
+	return servers, nil
+}
+
+// lookupAddresses queries nameservers directly via DNS, completely bypassing
+// /etc/hosts. net.Resolver.LookupHost consults /etc/hosts before DNS regardless
+// of any custom Dial func, which would make us read back our own stale entries.
+func lookupAddresses(nameservers []string, hostname string) ([]string, error) {
+	c := &dns.Client{Net: "udp", Timeout: 5 * time.Second}
+	fqdn := dns.Fqdn(hostname)
+
+	var addrs []string
+	for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA} {
+		results, err := queryDNS(c, nameservers, fqdn, qtype)
+		if err != nil {
+			return nil, fmt.Errorf("query %s: %w", dns.TypeToString[qtype], err)
+		}
+		addrs = append(addrs, results...)
+	}
+
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no A or AAAA records found for %s", hostname)
+	}
+	return addrs, nil
+}
+
+func queryDNS(c *dns.Client, nameservers []string, fqdn string, qtype uint16) ([]string, error) {
+	m := new(dns.Msg)
+	m.SetQuestion(fqdn, qtype)
+	m.RecursionDesired = true
+
+	var lastErr error
+	for _, ns := range nameservers {
+		r, _, err := c.Exchange(m, net.JoinHostPort(ns, "53"))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if r.Rcode != dns.RcodeSuccess && r.Rcode != dns.RcodeNameError {
+			lastErr = fmt.Errorf("DNS error: %s", dns.RcodeToString[r.Rcode])
+			continue
+		}
+		var addrs []string
+		for _, ans := range r.Answer {
+			switch rr := ans.(type) {
+			case *dns.A:
+				addrs = append(addrs, rr.A.String())
+			case *dns.AAAA:
+				addrs = append(addrs, rr.AAAA.String())
+			}
+		}
+		return addrs, nil
+	}
+	return nil, lastErr
+}
+
+// stripBlock removes the managed block for hostname from content and returns
+// the remaining lines with trailing blank lines trimmed.
+func stripBlock(content, hostname string) []string {
+	begin := fmt.Sprintf("# BEGIN etchosts-pin:%s", hostname)
+	end := fmt.Sprintf("# END etchosts-pin:%s", hostname)
+
+	lines := strings.Split(content, "\n")
+	var kept []string
+	inBlock := false
+	for _, line := range lines {
+		switch line {
+		case begin:
+			inBlock = true
+		case end:
+			inBlock = false
+		default:
+			if !inBlock {
+				kept = append(kept, line)
+			}
+		}
+	}
+	for len(kept) > 0 && kept[len(kept)-1] == "" {
+		kept = kept[:len(kept)-1]
+	}
+	return kept
+}
+
+func rewriteFile(f *os.File, content string) error {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek: %w", err)
+	}
+	if err := f.Truncate(0); err != nil {
+		return fmt.Errorf("truncate: %w", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	return nil
+}
+
+func updateHosts(nameservers []string, hostname, hostsFile string) error {
+	addrs, err := lookupAddresses(nameservers, hostname)
+	if err != nil {
+		return fmt.Errorf("resolve %s: %w", hostname, err)
+	}
+
+	f, err := os.OpenFile(hostsFile, os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", hostsFile, err)
+	}
+	defer f.Close()
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", hostsFile, err)
+	}
+
+	kept := stripBlock(string(content), hostname)
+
+	block := []string{"", fmt.Sprintf("# BEGIN etchosts-pin:%s", hostname)}
+	for _, addr := range addrs {
+		block = append(block, fmt.Sprintf("%s\t%s", addr, hostname))
+	}
+	block = append(block, fmt.Sprintf("# END etchosts-pin:%s", hostname))
+
+	if err := rewriteFile(f, strings.Join(append(kept, block...), "\n")+"\n"); err != nil {
+		return fmt.Errorf("%s: %w", hostsFile, err)
+	}
+
+	log.Printf("updated %s → %v", hostname, addrs)
+	return nil
+}
+
+func cleanupHosts(hostname, hostsFile string) error {
+	f, err := os.OpenFile(hostsFile, os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", hostsFile, err)
+	}
+	defer f.Close()
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", hostsFile, err)
+	}
+
+	kept := stripBlock(string(content), hostname)
+
+	if err := rewriteFile(f, strings.Join(kept, "\n")+"\n"); err != nil {
+		return fmt.Errorf("%s: %w", hostsFile, err)
+	}
+
+	log.Printf("removed entries for %s from %s", hostname, hostsFile)
+	return nil
+}

--- a/etchosts-pin/main.go
+++ b/etchosts-pin/main.go
@@ -17,8 +17,13 @@ import (
 )
 
 func main() {
-	hostname := os.Getenv("RESOLVE_HOSTNAME")
-	if hostname == "" {
+	var hostnames []string
+	for _, h := range strings.Split(os.Getenv("RESOLVE_HOSTNAME"), ",") {
+		if h = strings.TrimSpace(h); h != "" {
+			hostnames = append(hostnames, h)
+		}
+	}
+	if len(hostnames) == 0 {
 		log.Fatal("RESOLVE_HOSTNAME environment variable is required")
 	}
 
@@ -41,7 +46,7 @@ func main() {
 		log.Fatalf("failed to determine nameservers: %v", err)
 	}
 
-	log.Printf("starting: hostname=%s file=%s interval=%s", hostname, hostsFile, interval)
+	log.Printf("starting: hostnames=%v file=%s interval=%s", hostnames, hostsFile, interval)
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
@@ -49,21 +54,31 @@ func main() {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	// Run immediately on start rather than waiting for the first tick.
-	if err := updateHosts(nameservers, hostname, hostsFile); err != nil {
-		log.Printf("error: %v", err)
+	updateAll := func() {
+		for _, h := range hostnames {
+			if err := updateHosts(nameservers, h, hostsFile); err != nil {
+				log.Printf("error: %v", err)
+			}
+		}
 	}
+
+	// Run immediately on start rather than waiting for the first tick.
+	updateAll()
 
 	for {
 		select {
 		case <-ticker.C:
-			if err := updateHosts(nameservers, hostname, hostsFile); err != nil {
-				log.Printf("error: %v", err)
-			}
+			updateAll()
 		case sig := <-sigCh:
 			log.Printf("received %s, cleaning up %s", sig, hostsFile)
-			if err := cleanupHosts(hostname, hostsFile); err != nil {
-				log.Printf("cleanup error: %v", err)
+			var failed bool
+			for _, h := range hostnames {
+				if err := cleanupHosts(h, hostsFile); err != nil {
+					log.Printf("cleanup error: %v", err)
+					failed = true
+				}
+			}
+			if failed {
 				os.Exit(1)
 			}
 			os.Exit(0)
@@ -199,14 +214,11 @@ func stripBlock(content, hostname string) []string {
 }
 
 func rewriteFile(f *os.File, content string) error {
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("seek: %w", err)
-	}
-	if err := f.Truncate(0); err != nil {
-		return fmt.Errorf("truncate: %w", err)
-	}
-	if _, err := f.WriteString(content); err != nil {
+	if _, err := f.WriteAt([]byte(content), 0); err != nil {
 		return fmt.Errorf("write: %w", err)
+	}
+	if err := f.Truncate(int64(len(content))); err != nil {
+		return fmt.Errorf("truncate: %w", err)
 	}
 	return nil
 }

--- a/etchosts-pin/manifests/daemonset.yaml
+++ b/etchosts-pin/manifests/daemonset.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: etchosts-pin
+  labels:
+    app: etchosts-pin
+spec:
+  selector:
+    matchLabels:
+      app: etchosts-pin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: etchosts-pin
+    spec:
+      tolerations:
+        - operator: Exists
+      priorityClassName: system-node-critical
+      imagePullSecrets:
+      - name: pull-secret
+      containers:
+        - name: etchosts-pin
+          image: REGISTRY/etchosts-pin:latest
+          imagePullPolicy: Always
+          env:
+            - name: RESOLVE_HOSTNAME
+              value: "example.org"
+            # Optional overrides:
+            - name: RESOLVERS
+              value: "8.8.8.8,8.8.4.4"  # overrides /etc/resolv.conf
+            # - name: INTERVAL_SECONDS
+            #   value: "5"
+            # - name: HOSTS_FILE
+            #   value: "/etc/hosts"
+          securityContext:
+            runAsUser: 0          # root required to write /etc/hosts
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 5m
+              memory: 8Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          volumeMounts:
+            - name: hosts
+              mountPath: /etc/hosts
+      volumes:
+        - name: hosts
+          hostPath:
+            path: /etc/hosts
+            type: File

--- a/etchosts-pin/manifests/daemonset.yaml
+++ b/etchosts-pin/manifests/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: RESOLVE_HOSTNAME
-              value: "example.org"
+              value: "example.org,other.example.org"
             # Optional overrides:
             - name: RESOLVERS
               value: "8.8.8.8,8.8.4.4"  # overrides /etc/resolv.conf


### PR DESCRIPTION
This is a small daemon that resolves a hostname on a fixed interval and keeps the resulting A/AAAA records in `/etc/hosts`. It is to work around undesirable TTL cache values from intermediate DNS resolvers, ensuring that a host is resolving the correct DNS entries from a particular upstream server.

There is a corresponding helm chart and example daemonset yaml manifest for deployment.