### PR TITLE
Update KServe example

### DIFF
--- a/crusoe-kserve-example/CLAUDE.md
+++ b/crusoe-kserve-example/CLAUDE.md
@@ -4,11 +4,13 @@ This project deploys open-source LLMs on Crusoe Managed Kubernetes (CMK) using K
 
 ## What This Does
 
-Provisions a CMK cluster with GPU node pools and installs KServe for LLM inference. Supports five deployment modes:
+Provisions a CMK cluster with GPU node pools and installs KServe for LLM inference. Supports six deployment modes:
 - **Basic (NVIDIA)**: Single-GPU serving (e.g., Qwen2.5-0.5B on 1x A100)
+- **Large (NVIDIA)**: Multi-GPU single-node serving (e.g., Qwen2.5-72B on 8x H100, TP=8)
 - **Multi-Node (NVIDIA)**: Tensor-parallel across multiple nodes (e.g., Qwen2.5-72B on 16 GPUs)
 - **Disaggregated Prefill-Decode**: H100 for prefill, A100 for decode (cost-optimized)
-- **Basic (AMD)**: Single-GPU or full-node serving on MI300X (e.g., MiniMax-M2 on 8x MI300X)
+- **Basic (AMD)**: Single-GPU serving on MI300X (e.g., Qwen2.5-0.5B on 1x MI300X)
+- **Large (AMD)**: Multi-GPU single-node serving on MI300X (e.g., MiniMax-M2 on 8x MI300X, TP=8)
 - **Multi-Node (AMD)**: Multi-node tensor-parallel on MI300X (e.g., MiniMax-M2 on 2x8 MI300X)
 
 ## Setup Flow
@@ -28,7 +30,7 @@ Required values the user must provide:
 - `project_id` — Crusoe project ID (get via `crusoe projects list`)
 - `hf_token` — HuggingFace API token
 - `ssh_public_key` — User's SSH public key string; provisioned onto nodes at creation time so the user can SSH in for debugging (e.g. checking driver issues, running `nvidia-smi`)
-- `a100_ib_partition_id` — InfiniBand partition ID for A100 nodes (get via `crusoe networking ib-partitions list`)
+- `a100_ib_partition_id` — InfiniBand partition ID for A100 nodes (only needed if `a100_node_count > 0`)
 - `h100_ib_partition_id` — InfiniBand partition ID for H100 nodes (only needed if `h100_node_count > 0`)
 
 To find the right IB partition, match the partition's IB network location and VM type:
@@ -54,9 +56,9 @@ This runs `terraform apply` which:
 #### 3. Deploy a Model
 
 ```bash
-make deploy-basic          # Qwen2.5-0.5B on 1x A100
-make deploy-70b            # Qwen2.5-72B on 8x A100, TP=8 (with PVC for model storage)
-make deploy-multi-node     # Qwen2.5-72B on 2x8 A100 (needs a100_node_count=2)
+make deploy-basic          # Qwen2.5-0.5B on 1x GPU (GPU type set via basic.nodeSelector in values.yaml)
+make deploy-large          # Qwen2.5-72B on 8x GPU TP=8 (GPU type set via large.nodeSelector in values.yaml)
+make deploy-multi-node     # Qwen2.5-72B on 2x8 GPU (GPU type set via multiNode.nodeSelector in values.yaml)
 make deploy-disaggregated  # Qwen2.5-72B with H100 prefill + A100 decode (needs h100_node_count=1)
 ```
 
@@ -120,18 +122,17 @@ This runs three steps:
 
 ```bash
 make deploy-amd-basic      # Qwen2.5-0.5B on 1x MI300X
-make deploy-amd-minimax    # MiniMax-M2 on 8x MI300X (TP=8, EP, 1500Gi PVC) — deletes existing PVC first
-make redeploy-amd-minimax  # Update MiniMax-M2 args WITHOUT deleting PVC (preserves downloaded model)
+make deploy-amd-large      # MiniMax-M2 on 8x MI300X (TP=8, EP, 1500Gi PVC) — deletes existing PVC first
+make redeploy-amd-large    # Update AMD large model args WITHOUT deleting PVC (preserves downloaded model)
 make deploy-amd-multi-node # MiniMax-M2 on 2x8 MI300X (TP=8, 2 replicas)
 ```
 
-**Note**: `deploy-amd-minimax` deletes the PVC before deploying. Use `redeploy-amd-minimax` to update args while preserving already-downloaded model weights.
+**Note**: `deploy-amd-large` deletes the PVC before deploying. Use `redeploy-amd-large` to update args while preserving already-downloaded model weights.
 
 #### 4. Test AMD
 
 ```bash
-make test           # Same port-forward + curl (works for any deployed model)
-make test-amd-minimax  # Test with minimax model name
+make test  # Port-forward + curl (works for any deployed model)
 ```
 
 #### 5. Benchmark AMD
@@ -148,7 +149,7 @@ The AMD templates inject these env vars automatically:
 
 ## Model Storage (PVC)
 
-Large models (70B+) exceed the node's ephemeral storage (~120GB). The `deploy-70b`, `deploy-multi-node`, and `deploy-disaggregated` targets use a PersistentVolumeClaim backed by the Crusoe SSD CSI driver (`ssd.csi.crusoe.ai`).
+Large models (70B+) exceed the node's ephemeral storage (~120GB). The `deploy-large`, `deploy-amd-large`, `deploy-multi-node`, and `deploy-disaggregated` targets use a PersistentVolumeClaim backed by the Crusoe SSD CSI driver (`ssd.csi.crusoe.ai`).
 
 This is controlled by `modelStorage.enabled` and `modelStorage.size` in values.yaml:
 ```yaml
@@ -176,11 +177,13 @@ The Terraform setup also patches the KServe `inferenceservice-config` configmap 
 - `terraform-amd/main.tf` — AMD cluster + node pools (KServe installed separately by `make setup-amd`)
 - `terraform-amd/variables.tf` — AMD Terraform variables (includes Docker Hub credentials)
 - `terraform-amd/terraform.tfvars.example` — AMD template for user configuration
-- `helm/crusoe-kserve-example/values.yaml` — All deployment mode configs (NVIDIA + AMD)
+- `helm/crusoe-kserve-example/values.yaml` — All deployment mode configs (NVIDIA + AMD); vLLM args are set via Makefile `--set` flags, not here
 - `helm/crusoe-kserve-example/templates/basic-llm.yaml` — NVIDIA single-GPU manifest
+- `helm/crusoe-kserve-example/templates/large-llm.yaml` — NVIDIA multi-GPU single-node manifest
 - `helm/crusoe-kserve-example/templates/multi-node-llm.yaml` — NVIDIA multi-node manifest
 - `helm/crusoe-kserve-example/templates/disaggregated-llm.yaml` — NVIDIA disaggregated manifest
 - `helm/crusoe-kserve-example/templates/amd-basic-llm.yaml` — AMD single-GPU manifest
+- `helm/crusoe-kserve-example/templates/amd-large-llm.yaml` — AMD multi-GPU single-node manifest
 - `helm/crusoe-kserve-example/templates/amd-multi-node-llm.yaml` — AMD multi-node manifest
 - `monitoring/docker-compose.yml` — Grafana container (port 3000)
 - `monitoring/setup.py` — Configures Grafana datasource + prints dashboard URL
@@ -228,13 +231,14 @@ vLLM image: `vllm/vllm-openai-rocm:latest`
 
 | Deployment Mode | a100_node_count | h100_node_count | cpu_node_count |
 |----------------|-----------------|-----------------|----------------|
-| Basic          | 1               | 0               | 2              |
-| Multi-Node     | 2               | 0               | 2              |
+| Basic          | 1 (or 0 if using H100) | 1 (or 0 if using A100) | 2 |
+| Large          | 1 (or 0 if using H100) | 1 (or 0 if using A100) | 2 |
+| Multi-Node     | 2 (or 0 if using H100) | 2 (or 0 if using A100) | 2 |
 | Disaggregated  | 2               | 1               | 2              |
 
 ## Performance Tuning
 
-### vLLM args (set in `values.yaml` under `basic.args`, `disaggregated.decode.args`, etc.)
+### vLLM args (set via `--set <profile>.args[N]=...` in the Makefile deploy targets)
 
 | Flag | What it does | When to use |
 |------|-------------|-------------|

--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-amd install-kserve patch-storage-initializer install-amd-gpu-operator deploy-basic deploy-70b deploy-multi-node deploy-disaggregated deploy-2xa100 deploy-amd-basic deploy-amd-minimax redeploy-amd-minimax deploy-amd-multi-node watch watch-metrics test test-amd-minimax chat bench bench-all bench-all-amd bench-amd monitor-up monitor-up-nvidia monitor-up-amd monitor-down monitor-clean destroy
+.PHONY: help setup setup-amd install-kserve patch-storage-initializer install-amd-gpu-operator deploy-basic deploy-large deploy-multi-node deploy-disaggregated deploy-amd-basic deploy-amd-large redeploy-amd-large deploy-amd-multi-node watch watch-metrics test chat bench bench-all bench-all-amd bench-amd monitor-up monitor-up-nvidia monitor-up-amd monitor-down monitor-clean destroy
 
 SHELL := /bin/bash
 NAMESPACE ?= kserve-test
@@ -12,7 +12,6 @@ DOCKER_USERNAME ?= $(shell grep '^docker_username' $(_AMD_TFVARS) 2>/dev/null | 
 DOCKER_EMAIL    ?= $(shell grep '^docker_email'    $(_AMD_TFVARS) 2>/dev/null | sed 's/.*= *"//;s/"//')
 DOCKER_PASSWORD  ?= $(shell grep '^docker_password' $(_AMD_TFVARS) 2>/dev/null | sed 's/.*= *"//;s/"//')
 AMD_DRIVER_IMAGE ?= docker.io/$(DOCKER_USERNAME)/amd-gpu-driver
-DRY_RUN          ?= 0
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
@@ -27,35 +26,13 @@ setup: ## Provision cluster, install KServe, create namespace (terraform apply)
 	  terraform init && \
 	  terraform apply
 
-setup-amd: ## Provision AMD cluster, install AMD GPU operator + KServe (configure terraform-amd/terraform.tfvars first) [DRY_RUN=1 to preview]
-ifeq ($(DRY_RUN),1)
-	@echo ""
-	@echo "setup-amd dry run — steps that would be executed:"
-	@echo ""
-	@echo "  [1/3] terraform apply (terraform-amd/)"
-	@echo "        Create CMK cluster (crusoe_csi add-on only)"
-	@echo "        Create AMD GPU node pool and CPU node pool"
-	@echo "        Fetch kubeconfig"
-	@echo ""
-	@echo "  [2/3] install-amd-gpu-operator"
-	@echo "        Install cert-manager v1.15.1"
-	@echo "        Install AMD GPU operator v1.4.2"
-	@echo "        Create Docker registry secret in kube-amd-gpu (user: $(DOCKER_USERNAME))"
-	@echo "        Apply AMD DeviceConfig → $(AMD_DRIVER_IMAGE)"
-	@echo ""
-	@echo "  [3/3] install-kserve"
-	@echo "        Install KServe $(KSERVE_VERSION)"
-	@echo "        Patch storage-initializer for large model downloads"
-	@echo "        Create namespace '$(NAMESPACE)' with HuggingFace secret"
-	@echo ""
-else
+setup-amd: ## Provision AMD cluster, install AMD GPU operator + KServe (configure terraform-amd/terraform.tfvars first)
 	cd terraform-amd && \
 	  cp -n terraform.tfvars.example terraform.tfvars 2>/dev/null || true && \
 	  terraform init && \
 	  terraform apply
 	$(MAKE) install-amd-gpu-operator
 	$(MAKE) install-kserve HF_TOKEN=$(AMD_HF_TOKEN)
-endif
 
 install-amd-gpu-operator: ## Install cert-manager and AMD GPU operator (requires DOCKER_USERNAME, DOCKER_EMAIL, DOCKER_PASSWORD)
 	@if [ -z "$(DOCKER_USERNAME)" ] || [ -z "$(DOCKER_EMAIL)" ] || [ -z "$(DOCKER_PASSWORD)" ]; then \
@@ -134,38 +111,36 @@ patch-storage-initializer: ## Patch storage-initializer configmap for large mode
 # Deploy (Helm)
 # ---------------------------------------------------------------------------
 
-deploy-basic: ## Deploy single-GPU LLM (Qwen2.5-0.5B on 1x A100)
-	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
-	  --set hfToken=$(HF_TOKEN) \
-	  --set basic.enabled=true \
-	  --set multiNode.enabled=false \
-	  --set disaggregated.enabled=false
-
-deploy-70b: ## Deploy Qwen2.5-72B on 8x H100 (single node, TP=8)
+deploy-basic: ## Deploy single-GPU LLM (Qwen2.5-0.5B on 1x A100 or H100)
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
 	  --set hfToken=$(HF_TOKEN) \
 	  --set basic.enabled=true \
 	  --set multiNode.enabled=false \
 	  --set disaggregated.enabled=false \
-	  --set modelStorage.enabled=true \
-	  --set modelStorage.size=250Gi \
-	  --set basic.model.uri=hf://Qwen/Qwen2.5-72B-Instruct \
-	  --set basic.model.name=qwen \
 	  --set basic.args[0]="--gpu-memory-utilization" \
 	  --set basic.args[1]="0.95" \
-	  --set basic.args[2]="--tensor-parallel-size" \
-	  --set-string basic.args[3]="8" \
-	  --set basic.args[4]="--enable-chunked-prefill" \
-	  --set basic.args[5]="--max-num-batched-tokens" \
-	  --set-string basic.args[6]="8192" \
-	  --set basic.resources.limits.gpu="8" \
-	  --set basic.resources.limits.cpu="64" \
-	  --set basic.resources.limits.memory=512Gi \
-	  --set basic.resources.requests.gpu="8" \
-	  --set basic.resources.requests.cpu="32" \
-	  --set basic.resources.requests.memory=256Gi
+	  --set basic.args[2]="--enable-chunked-prefill" \
+	  --set basic.args[3]="--max-num-batched-tokens" \
+	  --set-string basic.args[4]="4096"
 
-deploy-multi-node: ## Deploy multi-node LLM (Qwen2.5-72B on 2x8 A100)
+deploy-large: ## Deploy large single-node LLM (Qwen2.5-72B on 8x H100, TP=8) — edit values.yaml large: to change model/resources
+	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
+	  --set hfToken=$(HF_TOKEN) \
+	  --set basic.enabled=false \
+	  --set large.enabled=true \
+	  --set multiNode.enabled=false \
+	  --set disaggregated.enabled=false \
+	  --set modelStorage.enabled=true \
+	  --set modelStorage.size=250Gi \
+	  --set large.args[0]="--gpu-memory-utilization" \
+	  --set large.args[1]="0.95" \
+	  --set large.args[2]="--tensor-parallel-size" \
+	  --set-string large.args[3]="8" \
+	  --set large.args[4]="--enable-chunked-prefill" \
+	  --set large.args[5]="--max-num-batched-tokens" \
+	  --set-string large.args[6]="8192"
+
+deploy-multi-node: ## Deploy multi-node LLM (Qwen2.5-72B on 2x8 A100 or H100)
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
 	  --set hfToken=$(HF_TOKEN) \
 	  --set basic.enabled=false \
@@ -179,62 +154,53 @@ deploy-amd-basic: ## Deploy single-GPU LLM on AMD MI300X (Qwen2.5-0.5B)
 	  --set amd.basic.enabled=true \
 	  --set multiNode.enabled=false \
 	  --set amd.multiNode.enabled=false \
-	  --set disaggregated.enabled=false
+	  --set disaggregated.enabled=false \
+	  --set amd.basic.args[0]="--gpu-memory-utilization" \
+	  --set amd.basic.args[1]="0.95" \
+	  --set amd.basic.args[2]="--enable-chunked-prefill" \
+	  --set amd.basic.args[3]="--max-num-batched-tokens" \
+	  --set-string amd.basic.args[4]="4096"
 
-deploy-amd-minimax: ## Deploy MiniMax-M2 on 8x MI300X (TP8+EP)
+deploy-amd-large: ## Deploy large single-node LLM on AMD MI300X (MiniMax-M2 on 8x MI300X, TP=8) — edit values.yaml amd.large: to change model/resources
 	kubectl delete pvc model-storage -n $(NAMESPACE) --ignore-not-found
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
 	  --set hfToken=$(HF_TOKEN) \
 	  --set basic.enabled=false \
-	  --set amd.basic.enabled=true \
+	  --set amd.basic.enabled=false \
+	  --set amd.large.enabled=true \
 	  --set multiNode.enabled=false \
 	  --set amd.multiNode.enabled=false \
 	  --set disaggregated.enabled=false \
 	  --set modelStorage.enabled=true \
 	  --set modelStorage.size=1500Gi \
-	  --set amd.basic.model.uri=hf://MiniMaxAI/MiniMax-M2 \
-	  --set amd.basic.model.name=minimax \
-	  --set amd.basic.args[0]="--gpu-memory-utilization" \
-	  --set amd.basic.args[1]="0.95" \
-	  --set amd.basic.args[2]="--tensor-parallel-size" \
-	  --set-string amd.basic.args[3]="8" \
-	  --set amd.basic.args[4]="--enable-expert-parallel" \
-	  --set amd.basic.args[5]="--reasoning-parser" \
-	  --set amd.basic.args[6]="minimax_m2_append_think" \
-	  --set amd.basic.args[7]="--trust-remote-code" \
-	  --set amd.basic.resources.limits.gpu="8" \
-	  --set amd.basic.resources.limits.cpu="64" \
-	  --set amd.basic.resources.limits.memory=512Gi \
-	  --set amd.basic.resources.requests.gpu="8" \
-	  --set amd.basic.resources.requests.cpu="32" \
-	  --set amd.basic.resources.requests.memory=256Gi
+	  --set amd.large.args[0]="--gpu-memory-utilization" \
+	  --set amd.large.args[1]="0.95" \
+	  --set amd.large.args[2]="--tensor-parallel-size" \
+	  --set-string amd.large.args[3]="8" \
+	  --set amd.large.args[4]="--enable-expert-parallel" \
+	  --set amd.large.args[5]="--reasoning-parser" \
+	  --set amd.large.args[6]="minimax_m2_append_think" \
+	  --set amd.large.args[7]="--trust-remote-code"
 
-redeploy-amd-minimax: ## Update MiniMax-M2 args without deleting PVC (preserves downloaded model)
+redeploy-amd-large: ## Update AMD large model args without deleting PVC (preserves downloaded model)
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
 	  --set hfToken=$(HF_TOKEN) \
 	  --set basic.enabled=false \
-	  --set amd.basic.enabled=true \
+	  --set amd.basic.enabled=false \
+	  --set amd.large.enabled=true \
 	  --set multiNode.enabled=false \
 	  --set amd.multiNode.enabled=false \
 	  --set disaggregated.enabled=false \
 	  --set modelStorage.enabled=true \
 	  --set modelStorage.size=1500Gi \
-	  --set amd.basic.model.uri=hf://MiniMaxAI/MiniMax-M2 \
-	  --set amd.basic.model.name=minimax \
-	  --set amd.basic.args[0]="--gpu-memory-utilization" \
-	  --set amd.basic.args[1]="0.95" \
-	  --set amd.basic.args[2]="--tensor-parallel-size" \
-	  --set-string amd.basic.args[3]="8" \
-	  --set amd.basic.args[4]="--enable-expert-parallel" \
-	  --set amd.basic.args[5]="--reasoning-parser" \
-	  --set amd.basic.args[6]="minimax_m2_append_think" \
-	  --set amd.basic.args[7]="--trust-remote-code" \
-	  --set amd.basic.resources.limits.gpu="8" \
-	  --set amd.basic.resources.limits.cpu="64" \
-	  --set amd.basic.resources.limits.memory=512Gi \
-	  --set amd.basic.resources.requests.gpu="8" \
-	  --set amd.basic.resources.requests.cpu="32" \
-	  --set amd.basic.resources.requests.memory=256Gi
+	  --set amd.large.args[0]="--gpu-memory-utilization" \
+	  --set amd.large.args[1]="0.95" \
+	  --set amd.large.args[2]="--tensor-parallel-size" \
+	  --set-string amd.large.args[3]="8" \
+	  --set amd.large.args[4]="--enable-expert-parallel" \
+	  --set amd.large.args[5]="--reasoning-parser" \
+	  --set amd.large.args[6]="minimax_m2_append_think" \
+	  --set amd.large.args[7]="--trust-remote-code"
 
 deploy-amd-multi-node: ## Deploy multi-node LLM on AMD MI300X (MiniMax-M2 on 2x8)
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
@@ -250,7 +216,19 @@ deploy-disaggregated: ## Deploy disaggregated prefill-decode (H100 + A100)
 	  --set hfToken=$(HF_TOKEN) \
 	  --set basic.enabled=false \
 	  --set multiNode.enabled=false \
-	  --set disaggregated.enabled=true
+	  --set disaggregated.enabled=true \
+	  --set disaggregated.decode.args[0]="--tensor-parallel-size" \
+	  --set-string disaggregated.decode.args[1]="8" \
+	  --set disaggregated.decode.args[2]="--enforce-eager" \
+	  --set disaggregated.decode.args[3]="--gpu-memory-utilization" \
+	  --set disaggregated.decode.args[4]="0.90" \
+	  --set disaggregated.prefill.args[0]="--tensor-parallel-size" \
+	  --set-string disaggregated.prefill.args[1]="8" \
+	  --set disaggregated.prefill.args[2]="--enable-chunked-prefill" \
+	  --set disaggregated.prefill.args[3]="--max-num-batched-tokens" \
+	  --set-string disaggregated.prefill.args[4]="8192" \
+	  --set disaggregated.prefill.args[5]="--gpu-memory-utilization" \
+	  --set disaggregated.prefill.args[6]="0.90"
 
 # ---------------------------------------------------------------------------
 # Test & Benchmark

--- a/crusoe-kserve-example/README.md
+++ b/crusoe-kserve-example/README.md
@@ -7,6 +7,7 @@ Deploy open-source LLMs from HuggingFace on Crusoe Managed Kubernetes (CMK) usin
 - One command for full infrastructure + KServe setup (NVIDIA or AMD)
 - One command to deploy HuggingFace model
   - Single-GPU LLM serving (Qwen2.5-0.5B on 1x H100, A100, MI300X, etc.)
+  - Single-node multi-GPU inference (Qwen2.5-72B on 8x H100, TP=8)
   - Multi-node tensor-parallel inference (Qwen2.5-72B across 16 GPUs)
   - Disaggregated prefill-decode with H100 (prefill) and A100 (decode)
 - AMD MI300X support with ROCm vLLM (MiniMax-M2)
@@ -29,11 +30,13 @@ Deploy open-source LLMs from HuggingFace on Crusoe Managed Kubernetes (CMK) usin
 ```bash
 cd terraform
 cp terraform.tfvars.example terraform.tfvars
+terraform init
 ```
 Edit `terraform.tfvars` with your project ID, HuggingFace token, IB partition IDs, and node types/count.
 
 ### 2. Provision cluster + install KServe
 
+Navigate back to `crusoe-kserve-example/` and run:
 ```bash
 make setup
 ```
@@ -50,8 +53,8 @@ This single command:
 # Single-GPU (Qwen2.5-0.5B, 1x H100)
 make deploy-basic
 
-# Single-node 72B (Qwen2.5-72B, 8x H100 TP=8, with PVC storage)
-make deploy-70b
+# Large single-node (Qwen2.5-72B, 8x H100 TP=8, with PVC storage)
+make deploy-large
 
 # Multi-node (Qwen2.5-72B, 2x8 H100)
 make deploy-multi-node
@@ -60,7 +63,23 @@ make deploy-multi-node
 make deploy-disaggregated
 ```
 
-Large models (70B+) require persistent storage. `deploy-70b` automatically provisions a 250Gi SSD PVC via the Crusoe CSI driver to store model weights.
+Large models (70B+) require persistent storage. `deploy-large` automatically provisions a 250Gi SSD PVC via the Crusoe CSI driver to store model weights.
+
+> **Using a different GPU type?** The defaults in `helm/crusoe-kserve-example/values.yaml` target H100 nodes. If your cluster uses another GPU SKU, update the `nodeSelector` for the relevant profile, for example:
+> ```yaml
+> basic:
+>   nodeSelector:
+>     crusoe.ai/accelerator: nvidia-a100-80gb-sxm-ib
+> ```
+> You can print the GPU types in your node pools by running:
+> ```bash
+> kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.crusoe\.ai/accelerator}{"\n"}{end}'
+> ```
+> ```
+> np-520db221-1.us-east1-a.compute.internal       nvidia-a100-80gb-sxm-ib
+> np-59eb87e7-1.us-east1-a.compute.internal
+> np-59eb87e7-2.us-east1-a.compute.internal
+> ```
 
 ### 4. Test
 
@@ -116,8 +135,8 @@ This single command:
 # Small model (Qwen2.5-0.5B on 1x MI300X)
 make deploy-amd-basic
 
-# MiniMax-M2 on 8x MI300X — TP=8, expert parallel, 1500Gi PVC
-make deploy-amd-minimax
+# Large single-node (MiniMax-M2 on 8x MI300X — TP=8, expert parallel, 1500Gi PVC)
+make deploy-amd-large
 
 # Multi-node (MiniMax-M2 on 2x8 MI300X)
 make deploy-amd-multi-node
@@ -138,6 +157,37 @@ make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
 
 ---
 
+## Installing on an Existing Cluster
+
+If you already have a Crusoe CMK cluster with GPU node pools, skip `make setup` / `make setup-amd` and install KServe directly. The cluster must already have the correct add-ons enabled — Terraform sets these automatically, but if you created the cluster manually ensure they are present.
+
+### NVIDIA — Required Add-ons
+
+| Add-on | Purpose |
+|--------|---------|
+| `nvidia_gpu_operator` | GPU driver and device plugin (`nvidia.com/gpu` resource) |
+| `nvidia_network_operator` | RDMA / InfiniBand networking for multi-node TP |
+| `crusoe_csi` | Persistent SSD storage for large model weights |
+
+```bash
+make install-kserve HF_TOKEN=hf_...
+```
+
+### AMD — Required Add-ons
+
+| Add-on | Purpose |
+|--------|---------|
+| `crusoe_csi` | Persistent SSD storage for large model weights |
+
+```bash
+make install-amd-gpu-operator DOCKER_USERNAME=you DOCKER_EMAIL=you@example.com DOCKER_PASSWORD=...
+make install-kserve HF_TOKEN=hf_...
+```
+
+Once KServe is installed, proceed directly to the deploy commands (`make deploy-basic`, `make deploy-large`, etc.).
+
+---
+
 ## Architecture
 
 ### Deployment Modes
@@ -145,10 +195,11 @@ make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
 | Mode | GPU | Model | Use Case |
 |------|-----|-------|----------|
 | **Basic (NVIDIA)** | 1x A100 | Qwen2.5-0.5B | Dev/test, small models |
-| **70B (NVIDIA)** | 8x A100 TP=8 | Qwen2.5-72B | Single-node large model |
+| **Large (NVIDIA)** | 8x A100 TP=8 | Qwen2.5-72B | Single-node large model |
 | **Multi-Node (NVIDIA)** | 16x A100 (2 nodes) | Qwen2.5-72B | Large models exceeding single-node VRAM |
 | **Disaggregated (NVIDIA)** | 8x H100 + 16x A100 | Qwen2.5-72B | Production, cost-optimized latency |
-| **Basic (AMD)** | 8x MI300X | MiniMax-M2 | Large MoE models, high-memory serving |
+| **Basic (AMD)** | 1x MI300X | Qwen2.5-0.5B | Dev/test on AMD |
+| **Large (AMD)** | 8x MI300X TP=8 | MiniMax-M2 | Large MoE models, high-memory serving |
 | **Multi-Node (AMD)** | 16x MI300X (2 nodes) | MiniMax-M2 | Multi-node MoE on AMD |
 
 ### NVIDIA Cluster Layout
@@ -170,18 +221,27 @@ CMK Cluster (terraform-amd/)
 
 ## Customization
 
-Edit `helm/crusoe-kserve-example/values.yaml` to change models, GPU counts, or resource limits, then re-run the deploy command.
+Edit `helm/crusoe-kserve-example/values.yaml` to change models, GPU counts, or resource limits, then re-run the deploy command. vLLM args (e.g. `--tensor-parallel-size`, `--gpu-memory-utilization`) are set via `--set` flags in the Makefile deploy targets, not in `values.yaml`.
 
-For example, to serve a different model on AMD basic mode:
+### Changing the model
+
+To use a different model, update `model.uri` and `model.name` in `values.yaml` for the relevant profile:
 
 ```yaml
-amd:
-  basic:
-    enabled: true
-    model:
-      uri: hf://meta-llama/Llama-3.1-8B-Instruct
-      name: llama
+# For deploy-basic:
+basic:
+  model:
+    uri: hf://meta-llama/Llama-3.1-8B-Instruct
+    name: llama
+
+# For deploy-large:
+large:
+  model:
+    uri: hf://meta-llama/Llama-3.1-70B-Instruct
+    name: llama
 ```
+
+For `deploy-large`, also review the vLLM args in the `deploy-large` target in `Makefile` — `--tensor-parallel-size` must match the number of GPUs, and `modelStorage.size` may need adjustment depending on model weight size.
 
 ## Networking
 
@@ -216,9 +276,11 @@ crusoe-kserve-example/
 │   └── templates/
 │       ├── model-storage.yaml         # StorageClass + PVC for large models
 │       ├── basic-llm.yaml             # NVIDIA single-GPU deployment
+│       ├── large-llm.yaml             # NVIDIA multi-GPU single-node deployment
 │       ├── multi-node-llm.yaml        # NVIDIA multi-node tensor parallel
 │       ├── disaggregated-llm.yaml     # NVIDIA prefill-decode split
-│       ├── amd-basic-llm.yaml         # AMD single-node deployment
+│       ├── amd-basic-llm.yaml         # AMD single-GPU deployment
+│       ├── amd-large-llm.yaml         # AMD multi-GPU single-node deployment
 │       └── amd-multi-node-llm.yaml    # AMD multi-node tensor parallel
 └── monitoring/
     ├── docker-compose.yml             # Grafana container (port 3000)

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-large-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-large-llm.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.amd.large.enabled }}
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: {{ .Values.amd.large.model.name }}-llm-amd
+  namespace: {{ .Values.namespace }}
+spec:
+  model:
+    uri: {{ .Values.amd.large.model.uri }}
+    name: {{ .Values.amd.large.model.name }}
+  replicas: 1
+  template:
+    {{- if .Values.modelStorage.enabled }}
+    securityContext:
+      fsGroup: 1000
+    {{- end }}
+    containers:
+      - name: main
+        image: {{ .Values.amd.image }}
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-secret
+                key: HF_TOKEN
+          - name: HF_HUB_DISABLE_XET
+            value: "1"
+          - name: VLLM_ROCM_USE_AITER
+            value: "1"
+        {{- if .Values.amd.large.args }}
+        args:
+          {{- toYaml .Values.amd.large.args | nindent 10 }}
+        {{- end }}
+        resources:
+          limits:
+            amd.com/gpu: {{ .Values.amd.large.resources.limits.gpu | quote }}
+            cpu: {{ .Values.amd.large.resources.limits.cpu | quote }}
+            memory: {{ .Values.amd.large.resources.limits.memory }}
+          requests:
+            amd.com/gpu: {{ .Values.amd.large.resources.requests.gpu | quote }}
+            cpu: {{ .Values.amd.large.resources.requests.cpu | quote }}
+            memory: {{ .Values.amd.large.resources.requests.memory }}
+    {{- if .Values.modelStorage.enabled }}
+    volumes:
+      - name: kserve-provision-location
+        persistentVolumeClaim:
+          claimName: model-storage
+    {{- end }}
+    nodeSelector:
+      {{- toYaml .Values.amd.large.nodeSelector | nindent 6 }}
+  router:
+    gateway: {}
+    route: {}
+    scheduler: {}
+{{- end }}

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/disaggregated-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/disaggregated-llm.yaml
@@ -27,8 +27,10 @@ spec:
               secretKeyRef:
                 name: hf-secret
                 key: HF_TOKEN
+        {{- if .Values.disaggregated.decode.args }}
         args:
           {{- toYaml .Values.disaggregated.decode.args | nindent 10 }}
+        {{- end }}
         resources:
           limits:
             nvidia.com/gpu: {{ .Values.disaggregated.decode.resources.limits.gpu | quote }}
@@ -60,8 +62,10 @@ spec:
                 secretKeyRef:
                   name: hf-secret
                   key: HF_TOKEN
+          {{- if .Values.disaggregated.prefill.args }}
           args:
             {{- toYaml .Values.disaggregated.prefill.args | nindent 12 }}
+          {{- end }}
           resources:
             limits:
               nvidia.com/gpu: {{ .Values.disaggregated.prefill.resources.limits.gpu | quote }}

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/large-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/large-llm.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.large.enabled }}
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: {{ .Values.large.model.name }}-llm
+  namespace: {{ .Values.namespace }}
+spec:
+  model:
+    uri: {{ .Values.large.model.uri }}
+    name: {{ .Values.large.model.name }}
+  replicas: 1
+  template:
+    {{- if .Values.modelStorage.enabled }}
+    securityContext:
+      fsGroup: 1000
+    {{- end }}
+    containers:
+      - name: main
+        image: {{ .Values.image }}
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-secret
+                key: HF_TOKEN
+        {{- if .Values.large.args }}
+        args:
+          {{- toYaml .Values.large.args | nindent 10 }}
+        {{- end }}
+        resources:
+          limits:
+            nvidia.com/gpu: {{ .Values.large.resources.limits.gpu | quote }}
+            cpu: {{ .Values.large.resources.limits.cpu | quote }}
+            memory: {{ .Values.large.resources.limits.memory }}
+          requests:
+            nvidia.com/gpu: {{ .Values.large.resources.requests.gpu | quote }}
+            cpu: {{ .Values.large.resources.requests.cpu | quote }}
+            memory: {{ .Values.large.resources.requests.memory }}
+    {{- if .Values.modelStorage.enabled }}
+    volumes:
+      - name: kserve-provision-location
+        persistentVolumeClaim:
+          claimName: model-storage
+    {{- end }}
+    nodeSelector:
+      {{- toYaml .Values.large.nodeSelector | nindent 6 }}
+  router:
+    gateway: {}
+    route: {}
+    scheduler: {}
+{{- end }}

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
@@ -18,12 +18,6 @@ basic:
   model:
     uri: hf://Qwen/Qwen2.5-0.5B-Instruct
     name: qwen
-  args:
-    - "--gpu-memory-utilization"
-    - "0.95"
-    - "--enable-chunked-prefill"
-    - "--max-num-batched-tokens"
-    - "4096"
   resources:
     limits:
       gpu: "1"
@@ -33,6 +27,24 @@ basic:
       gpu: "1"
       cpu: "1"
       memory: 4Gi
+  nodeSelector:
+    crusoe.ai/accelerator: nvidia-h100-80gb-sxm-ib
+
+# Large: multi-GPU single-node LLM serving (e.g., Qwen2.5-72B-Instruct on 8x H100, TP=8)
+large:
+  enabled: false
+  model:
+    uri: hf://Qwen/Qwen2.5-72B-Instruct
+    name: qwen
+  resources:
+    limits:
+      gpu: "8"
+      cpu: "64"
+      memory: 512Gi
+    requests:
+      gpu: "8"
+      cpu: "32"
+      memory: 256Gi
   nodeSelector:
     crusoe.ai/accelerator: nvidia-h100-80gb-sxm-ib
 
@@ -71,14 +83,6 @@ disaggregated:
       tensor: 8
       data: 16
       dataLocal: 8
-    args:
-      - "--model"
-      - "/mnt/models"
-      - "--tensor-parallel-size"
-      - "8"
-      - "--enforce-eager"
-      - "--gpu-memory-utilization"
-      - "0.90"
     resources:
       limits:
         gpu: "8"
@@ -92,16 +96,6 @@ disaggregated:
       crusoe.ai/accelerator: nvidia-a100-80gb-sxm-ib
   prefill:
     replicas: 1
-    args:
-      - "--model"
-      - "/mnt/models"
-      - "--tensor-parallel-size"
-      - "8"
-      - "--enable-chunked-prefill"
-      - "--max-num-batched-tokens"
-      - "8192"
-      - "--gpu-memory-utilization"
-      - "0.90"
     resources:
       limits:
         gpu: "8"
@@ -124,12 +118,6 @@ amd:
     model:
       uri: hf://Qwen/Qwen2.5-0.5B-Instruct
       name: qwen
-    args:
-      - "--gpu-memory-utilization"
-      - "0.95"
-      - "--enable-chunked-prefill"
-      - "--max-num-batched-tokens"
-      - "4096"
     resources:
       limits:
         gpu: "1"
@@ -139,6 +127,24 @@ amd:
         gpu: "1"
         cpu: "1"
         memory: 4Gi
+    nodeSelector:
+      crusoe.ai/accelerator: amd-mi300x-192gb-ib
+
+  # Large: multi-GPU single-node LLM serving on AMD MI300X (e.g., MiniMax-M2 on 8x MI300X, TP=8)
+  large:
+    enabled: false
+    model:
+      uri: hf://MiniMaxAI/MiniMax-M2
+      name: minimax
+    resources:
+      limits:
+        gpu: "8"
+        cpu: "64"
+        memory: 512Gi
+      requests:
+        gpu: "8"
+        cpu: "32"
+        memory: 256Gi
     nodeSelector:
       crusoe.ai/accelerator: amd-mi300x-192gb-ib
 

--- a/crusoe-kserve-example/terraform/main.tf
+++ b/crusoe-kserve-example/terraform/main.tf
@@ -132,20 +132,9 @@ resource "null_resource" "kserve_install" {
       echo "[4/5] Installing KServe controller..."
       kubectl apply --server-side --force-conflicts -f "$${BASE_URL}/kserve.yaml"
 
-      echo "Waiting for KServe controller to be ready..."
-      kubectl wait --for=condition=ready pod \
-        -l control-plane=kserve-controller-manager \
-        -n kserve --timeout=300s
-
-      echo "Waiting for webhook endpoint to be available..."
-      for i in $(seq 1 30); do
-        if kubectl get endpoints kserve-webhook-server-service -n kserve -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null | grep -q .; then
-          echo "Webhook endpoint ready."
-          break
-        fi
-        echo "Waiting for webhook... ($${i}/30)"
-        sleep 5
-      done
+      echo "Waiting for KServe controllers to be ready..."
+      kubectl rollout status deployment/kserve-controller-manager -n kserve
+      kubectl rollout status deployment/llmisvc-controller-manager -n kserve
 
       echo "[5/5] Installing KServe cluster resources..."
       kubectl apply --server-side -f "$${BASE_URL}/kserve-cluster-resources.yaml"

--- a/crusoe-kserve-example/terraform/terraform.tfvars.example
+++ b/crusoe-kserve-example/terraform/terraform.tfvars.example
@@ -22,3 +22,7 @@ namespace = "kserve-test"
 a100_node_count = 2
 h100_node_count = 1
 cpu_node_count  = 2
+
+# If node count > 0, include the Infiniband partition ID
+a100_ib_partition_id = ""
+h100_ib_partition_id = ""


### PR DESCRIPTION
- Add `large` and `amd.large` Helm profiles (new `large-llm.yaml` and `amd-large-llm.yaml` templates) for single-node multi-GPU serving, replacing the overloaded `basic` profile used by `deploy-70b`
- Rename `deploy-70b` → `deploy-large`, `deploy-amd-minimax` → `deploy-amd-large`, `redeploy-amd-minimax` → `redeploy-amd-large`
- Move all vLLM args out of `values.yaml` into Makefile `--set` flags so `values.yaml` contains only KServe config (model, resources, nodeSelector)
- Remove AMD setup dry-run mode
- Update README with existing-cluster install instructions, model customization guide, GPU nodeSelector discovery command, and corrected architecture table
- Update `CLAUDE.md` to reflect all renames, new profiles, and the vLLM args / values.yaml split
- Add infiniband input to `terraform.tfvars`
- Fix KServe install readiness check: replace custom webhook polling loop with `kubectl rollout status` for both controllers