### PR TITLE
grafana-cmk: widen IB dashboard windows to [1h] for slow-cadence fleets

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -278,12 +278,17 @@ All dashboards live in the `Crusoe` folder in Grafana and share a **Cluster** dr
 
 > **IB dashboard caveats (read before relying on absolute Gbps):**
 >
-> On Crusoe-virtualized HCAs the IB port counters surfaced through Crusoe Metrics are not a faithful realtime view of the fabric. Two issues we have observed:
+> On Crusoe-virtualized HCAs the IB port counters surfaced through Crusoe Metrics are not a faithful realtime view of the fabric. Three issues we have observed, all upstream of this repo:
 >
-> 1. **Sparse counter updates.** The agent appears to refresh the IB byte counters roughly every ~270 seconds even though the metric is scraped every 60s. Most `rate(...[1m])` windows therefore see no movement and return `NaN`, leaving panels blank for stretches of an otherwise busy job.
+> 1. **Slow scrape cadence.** The Watch Agent refreshes IB counters far less frequently than DCGM. Measured cadence between fresh samples on the same series:
+>     - H100 fleet (us-southcentral1-a): avg ~270 s, max ~300 s
+>     - B200 fleet (eu-norway1-a): avg ~22 minutes, max ~23 minutes
+>
+>    Because of this, every IB panel in this repo uses **`[1h]` rate windows** and the stat panels wrap bare metric references in **`last_over_time(... [1h])`**. With the typical `$__rate_interval` (~1 min) the panels would render entirely as "No data" — there are simply fewer than 2 samples per minute. The price of the wider window is temporal smoothing: a panel reading represents the average over the trailing hour, not the current second. When the Watch Agent's IB cadence drops to ≤60 s (engineering ticket open), these windows can be tightened — likely down to `$__rate_interval`.
 > 2. **Magnitude is low.** Counter deltas captured during a sustained `perftest` run measured ~10× lower than the actual bandwidth `perftest` reported on the same wire. The `line_rate` label (`gig_bit_per_sec`) also reports `128` on HCAs whose `ibstat` rate is `400`, so the utilization-% panels are calibrated against the wrong denominator.
+> 3. **No in-guest fallback.** `ibv_devinfo`, `perfquery`, and the standard `/sys/class/infiniband/.../counters/` files are not exposed inside Crusoe guest VMs, so there is no in-guest path to scrape accurate per-HCA counters today.
 >
-> Treat the IB dashboards as **diagnostic** (which HCAs are active, where errors are concentrated, when traffic stops) rather than **quantitative** (absolute Gbps / % of line rate). For ground-truth bandwidth measurements, run `perftest` from inside the workload — `ibv_devinfo`, `perfquery`, and the standard `/sys/class/infiniband/.../counters/` files are not exposed inside Crusoe guest VMs, so there is no in-guest path to scrape accurate per-HCA counters today.
+> Treat the IB dashboards as **diagnostic** (which HCAs are active, where errors are concentrated, when traffic stops) rather than **quantitative** (absolute Gbps / % of line rate). For ground-truth bandwidth measurements, run `perftest` from inside the workload.
 
 ---
 

--- a/grafana-cmk/dashboards/cluster-ib-overview.json
+++ b/grafana-cmk/dashboards/cluster-ib-overview.json
@@ -82,7 +82,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "count(count by (vm_name) (crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}))",
+          "expr": "count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])))",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -137,7 +137,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "count(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"})",
+          "expr": "count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h]))",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -192,7 +192,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 8",
+          "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -247,7 +247,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 8",
+          "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -302,7 +302,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -357,7 +357,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "expr": "sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[1h]))",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -399,7 +399,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 8",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8",
           "legendFormat": "{{vm_name}}"
         }
       ]
@@ -440,7 +440,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 8",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8",
           "legendFormat": "{{vm_name}}"
         }
       ]
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 1e9 / sum by (vm_name) (crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}) * 100",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 1e9 / sum by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])) * 100",
           "legendFormat": "{{vm_name}}"
         }
       ]
@@ -522,7 +522,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))",
           "legendFormat": "{{vm_name}}"
         }
       ]
@@ -563,7 +563,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[1h]))",
           "legendFormat": "{{vm_name}}"
         }
       ]

--- a/grafana-cmk/dashboards/node-ib-detail.json
+++ b/grafana-cmk/dashboards/node-ib-detail.json
@@ -98,7 +98,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])) / 8",
+          "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -153,7 +153,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])) / 8",
+          "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -208,7 +208,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]))",
+          "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -263,7 +263,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]))",
+          "expr": "sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -305,7 +305,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])) / 8",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
           "legendFormat": "{{vm_name}}"
         }
       ]
@@ -346,7 +346,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])) / 8",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
           "legendFormat": "{{vm_name}}"
         }
       ]
@@ -387,7 +387,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]) / 8",
+          "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 8",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
       ]
@@ -428,7 +428,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]) / 8",
+          "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 8",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
       ]
@@ -469,7 +469,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]) / 1e9 / ignoring(gig_bit_per_sec) crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"} * 100",
+          "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) * 100",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
       ]
@@ -510,7 +510,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]) / 1e9 / ignoring(gig_bit_per_sec) crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"} * 100",
+          "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) * 100",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
       ]
@@ -551,7 +551,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
       ]
@@ -592,7 +592,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
       ]

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -1000,7 +1000,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "count(count by (vm_name) (crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}))",
+              "expr": "count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])))",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1055,7 +1055,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "count(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"})",
+              "expr": "count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h]))",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1110,7 +1110,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 8",
+              "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1165,7 +1165,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 8",
+              "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1220,7 +1220,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1275,7 +1275,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "expr": "sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[1h]))",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1317,7 +1317,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 8",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8",
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -1358,7 +1358,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 8",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8",
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -1399,7 +1399,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[$__rate_interval])) / 1e9 / sum by (vm_name) (crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}) * 100",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 1e9 / sum by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])) * 100",
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -1440,7 +1440,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))",
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -1481,7 +1481,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[1h]))",
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -2332,7 +2332,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])) / 8",
+              "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -2387,7 +2387,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])) / 8",
+              "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -2442,7 +2442,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]))",
+              "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -2497,7 +2497,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]))",
+              "expr": "sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -2539,7 +2539,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])) / 8",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -2580,7 +2580,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])) / 8",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -2621,7 +2621,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]) / 8",
+              "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 8",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
           ]
@@ -2662,7 +2662,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]) / 8",
+              "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 8",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
           ]
@@ -2703,7 +2703,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]) / 1e9 / ignoring(gig_bit_per_sec) crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"} * 100",
+              "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) * 100",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
           ]
@@ -2744,7 +2744,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval]) / 1e9 / ignoring(gig_bit_per_sec) crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"} * 100",
+              "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) * 100",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
           ]
@@ -2785,7 +2785,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
           ]
@@ -2826,7 +2826,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
           ]


### PR DESCRIPTION
## Summary

The Crusoe Watch Agent's IB metric scrape cadence on the B200 fleet (eu-norway1-a) is ~22 minutes between fresh samples per series — measured today, far slower than the ~270 s observed on H100 fleets and far below DCGM. Net effect with the current dashboards: every IB panel renders as "No data" on a fleet where IB metrics are objectively being published (1,512 series confirmed via range queries).

The agent's IB cadence is upstream of this repo and won't drop to ≤60 s near-term on larger clusters. Ship a stopgap that makes the IB dashboards usable on slow-cadence fleets by widening every rate / `last_over_time` window to `[1h]`. Trade-off: panel readings are now trailing-hour averages, not near-realtime — documented in the README.

## Changes

- `dashboards/cluster-ib-overview.json`, `dashboards/node-ib-detail.json`:
  - `rate(crusoe_ib_port_*[$__rate_interval])` → `rate(crusoe_ib_port_*[1h])` on every time-series and stat panel.
  - `increase(crusoe_ib_port_*[$__rate_interval])` → `increase(crusoe_ib_port_*[1h])` on the error / discard stat panels.
  - Bare `crusoe_ib_port_line_rate{...}` selectors used by stat panels and utilization-% denominators wrapped in `last_over_time(...[1h])` so they return a value when the most recent sample is older than the instant-query lookback.
- `manifests/grafana-dashboards-configmap.yaml`: regenerated from the updated dashboard JSONs.
- `README.md` — "IB dashboard caveats" block extended:
  - H100 and B200 measured cadence numbers added (270 s vs 22 min)
  - Explicit note that the repo's IB panels now use `[1h]` windows because of the upstream cadence, and that the windows can be tightened once the Watch Agent drops to ≤60 s
  - Reframed as three numbered caveats (cadence, magnitude, no-in-guest-fallback) — was two
  - Magnitude (~10× undercount on H100) and `line_rate` `gig_bit_per_sec` mislabel kept as they were

## Test plan

Live on come-scale-away (B200 CMK, 206 nodes, eu-norway1-a) after applying the rewritten ConfigMap and a sidecar reload:

- [x] **Active IB Nodes** panel: 189 (was "No data")
- [x] **Total HCA Ports**: 1,512 (was "No data")
- [x] **Cluster RX Bandwidth**: ~1.5 GB/s, averaged over the trailing hour (was "No data")
- [x] **Per-Node Aggregate RX** time series: 189 series, every series has at least one non-zero point in the last hour
- [x] **Per-HCA Utilization %**: 385 series, values range 0.00% – 0.43% (low because most of the fleet is idle right now)
- [x] **Total RX Errors / Total TX Discards** stat panels: 0 (clean fabric)
- [x] All four GPU dashboards still render unchanged
- [x] Auth-proxy sidecar still healthy after ConfigMap reload