### PR TITLE
grafana-cmk: add Storage Cluster View dashboard

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -250,7 +250,7 @@ Verify the dashboards:
 
 1. Click **Dashboards** in the left sidebar.
 2. Open the **Crusoe** folder.
-3. You should see six dashboards: Cluster GPU Overview, Node GPU Detail, DCGM & Xid Errors, Cluster GPU Power, InfiniBand Cluster View, and InfiniBand Node View.
+3. You should see seven dashboards: Cluster GPU Overview, Node GPU Detail, DCGM & Xid Errors, Cluster GPU Power, InfiniBand Cluster View, InfiniBand Node View, and Storage Cluster View.
 
 ---
 
@@ -289,6 +289,24 @@ All dashboards live in the `Crusoe` folder in Grafana and share a **Cluster** dr
 > 3. **No in-guest fallback.** `ibv_devinfo`, `perfquery`, and the standard `/sys/class/infiniband/.../counters/` files are not exposed inside Crusoe guest VMs, so there is no in-guest path to scrape accurate per-HCA counters today.
 >
 > Treat the IB dashboards as **diagnostic** (which HCAs are active, where errors are concentrated, when traffic stops) rather than **quantitative** (absolute Gbps / % of line rate). For ground-truth bandwidth measurements, run `perftest` from inside the workload.
+
+### Storage dashboard
+
+**Storage Cluster View (`storage-cluster-overview.json`)** — cluster-wide disk I/O across all VMs plus Crusoe block-storage health. Surfaces:
+
+- **VM disk I/O** (from `crusoe_vm_disk_*` — guest-VM kernel block-device counters): cluster-wide read/write throughput, read/write IOPS, per-node breakdown, top-10 nodes by combined I/O.
+- **Crusoe block storage / SDisks** (from `crusoe_sdisk_*` — service-side view of Crusoe-provisioned disks): per-disk capacity used (bar gauge), per-disk read/write throughput, and per-disk average read/write latency.
+- **PVCs Bound** stat counting `kube_persistentvolumeclaim_status_phase{phase="Bound"} == 1` to confirm K8s claims are healthy.
+
+A **Disk device filter** template variable defaults to `md.*|vd.*|sd.*` (logical/RAID view — what mount points see), with options to switch to `nvme.*` (per-NVMe physical view) or `nvme.*|md.*|vd.*|sd.*` (all real disks; double-counts when a RAID and its members both report).
+
+> **Storage dashboard caveats:**
+>
+> 1. **`device` label is not pre-filtered.** `crusoe_vm_disk_*` series include non-block-device names like `nvidia0..7` (GPU char devices), `ens3` / `ens7` (network interfaces), and `loop0..7` (squashfs). The dashboard's PromQL filters to `md.*|vd.*|sd.*|nvme.*`-style patterns to drop these from totals. If you want raw, unfiltered numbers, query the metric directly.
+> 2. **RAID double-counting.** On Crusoe H100/B200 nodes the 8 local NVMes are typically RAID0'd into `md127`. Aggregating both `nvme*` and `md*` double-counts the same I/O. Default filter shows the logical (RAID) view.
+> 3. **No in-volume usage.** `kubelet_volume_stats_used_bytes` is not in the Crusoe Metrics catalog, so the dashboard can show "PVC X requested 100 GiB" but not "PVC X is 80% full." For Crusoe-provisioned block storage, `crusoe_sdisk_disk_capacity_used_bytes` is available — but it's project-scoped, not joined to the K8s PV that mounts it.
+> 4. **SDisk panels are project-scoped.** The SDisk metrics aren't keyed by `cluster_id`, so the SDisk panels show every Crusoe-provisioned disk in the project regardless of which cluster is selected in the dropdown.
+> 5. **Latency unit assumed microseconds.** `crusoe_sdisk_disk_read_latency_sum` / `_count` produce an average via `rate(sum)/rate(count)`. Magnitudes (~500) match microseconds for cached SSD reads, but verify against `perftest`-style benchmarks if precision matters.
 
 ---
 
@@ -361,6 +379,7 @@ kubectl create configmap crusoe-dashboards \
   --from-file=cluster-gpu-power.json=dashboards/cluster-gpu-power.json \
   --from-file=cluster-ib-overview.json=dashboards/cluster-ib-overview.json \
   --from-file=node-ib-detail.json=dashboards/node-ib-detail.json \
+  --from-file=storage-cluster-overview.json=dashboards/storage-cluster-overview.json \
   --dry-run=client -o yaml \
   | sed 's/^metadata:$/metadata:\n  labels:\n    grafana_dashboard: "1"/' \
   | kubectl apply -f -

--- a/grafana-cmk/dashboards/storage-cluster-overview.json
+++ b/grafana-cmk/dashboards/storage-cluster-overview.json
@@ -1,0 +1,722 @@
+{
+  "uid": "crusoe-storage-cluster",
+  "title": "Crusoe \u2014 Storage Cluster View",
+  "description": "Cluster-wide disk I/O (VM block devices) and Crusoe block storage (sdisk) health.",
+  "tags": [
+    "crusoe",
+    "storage",
+    "disk"
+  ],
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "1m",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "query": "label_values(DCGM_FI_DEV_GPU_UTIL, cluster_id)",
+        "refresh": 2,
+        "sort": 1,
+        "multi": false,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": {}
+      },
+      {
+        "name": "device",
+        "label": "Disk device filter",
+        "type": "custom",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "query": "md.*|vd.*|sd.* : Logical (RAID + base) , nvme.* : Per-NVMe , .*nvme.*|.*md.*|.*vd.*|.*sd.* : All real disks",
+        "current": {
+          "text": "Logical (RAID + base)",
+          "value": "md.*|vd.*|sd.*"
+        },
+        "options": [
+          {
+            "text": "Logical (RAID + base)",
+            "value": "md.*|vd.*|sd.*",
+            "selected": true
+          },
+          {
+            "text": "Per-NVMe",
+            "value": "nvme.*"
+          },
+          {
+            "text": "All real disks",
+            "value": "md.*|vd.*|sd.*|nvme.*"
+          }
+        ],
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Active Disk Devices",
+      "description": "Number of block-device series currently scraped on the selected cluster + filter.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "count(last_over_time(crusoe_vm_disk_read_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[5m]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Cluster Read Throughput",
+      "description": "Aggregate read bandwidth across all selected disks. Counter rate over the rate interval.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_disk_read_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Cluster Write Throughput",
+      "description": "Aggregate write bandwidth across all selected disks.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_disk_written_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Cluster Read IOPS",
+      "description": "Aggregate read IOPS across all selected disks.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "iops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_disk_reads_completed_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Cluster Write IOPS",
+      "description": "Aggregate write IOPS across all selected disks.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "iops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_disk_writes_completed_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "PVCs Bound",
+      "description": "Persistent Volume Claims in Bound phase on the selected cluster (as reported by kube-state-metrics).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "count(kube_persistentvolumeclaim_status_phase{cluster_id=~\"$cluster\", phase=\"Bound\"} == 1)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Read Throughput by Node",
+      "description": "Per-node read throughput, summed across selected disk devices.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name) (rate(crusoe_vm_disk_read_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Write Throughput by Node",
+      "description": "Per-node write throughput, summed across selected disk devices.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 4,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name) (rate(crusoe_vm_disk_written_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Read IOPS by Node",
+      "description": "Per-node read IOPS, summed across selected disk devices.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 12,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "iops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name) (rate(crusoe_vm_disk_reads_completed_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Write IOPS by Node",
+      "description": "Per-node write IOPS, summed across selected disk devices.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 12,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "iops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name) (rate(crusoe_vm_disk_writes_completed_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "bargauge",
+      "title": "Top 10 Nodes by Total Disk I/O",
+      "description": "Nodes ranked by combined read+write throughput right now.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 20,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(10, sum by (vm_name) (rate(crusoe_vm_disk_read_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]) + rate(crusoe_vm_disk_written_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval])))",
+          "instant": true,
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "bargauge",
+      "title": "Crusoe SDisk Capacity Used",
+      "description": "Per-disk capacity used on Crusoe-provisioned block storage. Project-scoped (not cluster-filtered).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 20,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "crusoe_sdisk_disk_capacity_used_bytes",
+          "instant": true,
+          "legendFormat": "{{disk_name}}"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "SDisk Read/Write Throughput",
+      "description": "Per-disk read/write throughput on Crusoe block storage. Project-scoped (not cluster-filtered).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (disk_name) (rate(crusoe_sdisk_disk_read_bw_bytes_sum[$__rate_interval]))",
+          "legendFormat": "{{disk_name}} read"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (disk_name) (rate(crusoe_sdisk_disk_write_bw_bytes_sum[$__rate_interval]))",
+          "legendFormat": "{{disk_name}} write"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "SDisk Avg Latency",
+      "description": "Average per-operation latency on Crusoe block storage. Histogram avg via rate(sum)/rate(count). Unit assumed microseconds; verify if magnitudes look off.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 28,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (disk_name) (rate(crusoe_sdisk_disk_read_latency_sum[$__rate_interval])) / sum by (disk_name) (rate(crusoe_sdisk_disk_read_latency_count[$__rate_interval]))",
+          "legendFormat": "{{disk_name}} read"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (disk_name) (rate(crusoe_sdisk_disk_write_latency_sum[$__rate_interval])) / sum by (disk_name) (rate(crusoe_sdisk_disk_write_latency_count[$__rate_interval]))",
+          "legendFormat": "{{disk_name}} write"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -2833,6 +2833,729 @@ data:
         }
       ]
     }
+  storage-cluster-overview.json: |-
+    {
+      "uid": "crusoe-storage-cluster",
+      "title": "Crusoe \u2014 Storage Cluster View",
+      "description": "Cluster-wide disk I/O (VM block devices) and Crusoe block storage (sdisk) health.",
+      "tags": [
+        "crusoe",
+        "storage",
+        "disk"
+      ],
+      "schemaVersion": 38,
+      "version": 1,
+      "refresh": "1m",
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "templating": {
+        "list": [
+          {
+            "name": "cluster",
+            "label": "Cluster",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
+            "query": "label_values(DCGM_FI_DEV_GPU_UTIL, cluster_id)",
+            "refresh": 2,
+            "sort": 1,
+            "multi": false,
+            "includeAll": true,
+            "allValue": ".+",
+            "current": {}
+          },
+          {
+            "name": "device",
+            "label": "Disk device filter",
+            "type": "custom",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
+            "query": "md.*|vd.*|sd.* : Logical (RAID + base) , nvme.* : Per-NVMe , .*nvme.*|.*md.*|.*vd.*|.*sd.* : All real disks",
+            "current": {
+              "text": "Logical (RAID + base)",
+              "value": "md.*|vd.*|sd.*"
+            },
+            "options": [
+              {
+                "text": "Logical (RAID + base)",
+                "value": "md.*|vd.*|sd.*",
+                "selected": true
+              },
+              {
+                "text": "Per-NVMe",
+                "value": "nvme.*"
+              },
+              {
+                "text": "All real disks",
+                "value": "md.*|vd.*|sd.*|nvme.*"
+              }
+            ],
+            "includeAll": false,
+            "multi": false
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Active Disk Devices",
+          "description": "Number of block-device series currently scraped on the selected cluster + filter.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "count(last_over_time(crusoe_vm_disk_read_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[5m]))",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Cluster Read Throughput",
+          "description": "Aggregate read bandwidth across all selected disks. Counter rate over the rate interval.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 4,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_disk_read_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Cluster Write Throughput",
+          "description": "Aggregate write bandwidth across all selected disks.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 8,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_disk_written_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Cluster Read IOPS",
+          "description": "Aggregate read IOPS across all selected disks.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "iops",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_disk_reads_completed_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "Cluster Write IOPS",
+          "description": "Aggregate write IOPS across all selected disks.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 16,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "iops",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_disk_writes_completed_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "PVCs Bound",
+          "description": "Persistent Volume Claims in Bound phase on the selected cluster (as reported by kube-state-metrics).",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 20,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "count(kube_persistentvolumeclaim_status_phase{cluster_id=~\"$cluster\", phase=\"Bound\"} == 1)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "Read Throughput by Node",
+          "description": "Per-node read throughput, summed across selected disk devices.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 4,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (vm_name) (rate(crusoe_vm_disk_read_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Write Throughput by Node",
+          "description": "Per-node write throughput, summed across selected disk devices.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 4,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (vm_name) (rate(crusoe_vm_disk_written_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "Read IOPS by Node",
+          "description": "Per-node read IOPS, summed across selected disk devices.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 12,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "iops"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (vm_name) (rate(crusoe_vm_disk_reads_completed_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "Write IOPS by Node",
+          "description": "Per-node write IOPS, summed across selected disk devices.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 12,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "iops"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (vm_name) (rate(crusoe_vm_disk_writes_completed_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]))",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 11,
+          "type": "bargauge",
+          "title": "Top 10 Nodes by Total Disk I/O",
+          "description": "Nodes ranked by combined read+write throughput right now.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 20,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "topk(10, sum by (vm_name) (rate(crusoe_vm_disk_read_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval]) + rate(crusoe_vm_disk_written_bytes_total{cluster_id=~\"$cluster\", device=~\"$device\"}[$__rate_interval])))",
+              "instant": true,
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 12,
+          "type": "bargauge",
+          "title": "Crusoe SDisk Capacity Used",
+          "description": "Per-disk capacity used on Crusoe-provisioned block storage. Project-scoped (not cluster-filtered).",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 20,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "crusoe_sdisk_disk_capacity_used_bytes",
+              "instant": true,
+              "legendFormat": "{{disk_name}}"
+            }
+          ]
+        },
+        {
+          "id": 13,
+          "type": "timeseries",
+          "title": "SDisk Read/Write Throughput",
+          "description": "Per-disk read/write throughput on Crusoe block storage. Project-scoped (not cluster-filtered).",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 28,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (disk_name) (rate(crusoe_sdisk_disk_read_bw_bytes_sum[$__rate_interval]))",
+              "legendFormat": "{{disk_name}} read"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (disk_name) (rate(crusoe_sdisk_disk_write_bw_bytes_sum[$__rate_interval]))",
+              "legendFormat": "{{disk_name}} write"
+            }
+          ]
+        },
+        {
+          "id": 14,
+          "type": "timeseries",
+          "title": "SDisk Avg Latency",
+          "description": "Average per-operation latency on Crusoe block storage. Histogram avg via rate(sum)/rate(count). Unit assumed microseconds; verify if magnitudes look off.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 28,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (disk_name) (rate(crusoe_sdisk_disk_read_latency_sum[$__rate_interval])) / sum by (disk_name) (rate(crusoe_sdisk_disk_read_latency_count[$__rate_interval]))",
+              "legendFormat": "{{disk_name}} read"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (disk_name) (rate(crusoe_sdisk_disk_write_latency_sum[$__rate_interval])) / sum by (disk_name) (rate(crusoe_sdisk_disk_write_latency_count[$__rate_interval]))",
+              "legendFormat": "{{disk_name}} write"
+            }
+          ]
+        }
+      ]
+    }
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
## Summary

Crusoe Metrics exposes three storage-metric families that weren't yet visualized in this repo:

- **`crusoe_vm_disk_*`** — guest-VM kernel block-device counters (read/write bytes, completions), labelled by `vm_name` / `device` / `cluster_id`. 4,441 series on come-scale-away (211 nodes × 32 device names).
- **`crusoe_sdisk_*`** — Crusoe block-storage service view of Crusoe-provisioned disks: capacity used (gauge) plus histogram-shaped throughput, IOPS, and latency. Project-scoped (9 disks in the test project).
- **`kube_persistentvolume_*` / `kube_persistentvolumeclaim_*` / `kube_storageclass_*`** — K8s storage inventory via the kube-state-metrics relay.

Add a single `Storage Cluster View` dashboard surfacing all three.

Cadence is healthy across all three families ([5m]/[15m]/[1h] series counts identical) — no slow-scrape workaround like the one IB needs.

## Changes

- **`dashboards/storage-cluster-overview.json`** (new, 14 panels):
  - Stat row: active disk devices, cluster read/write throughput, cluster read/write IOPS, PVCs Bound.
  - Time-series rows: per-node read & write throughput, per-node read & write IOPS.
  - Bar gauges: top-10 nodes by combined I/O, per-disk Crusoe SDisk capacity used.
  - Per-SDisk read/write throughput and avg latency time series.
  - Variables: `$cluster` (from `label_values(DCGM_FI_DEV_GPU_UTIL, cluster_id)` — matches the GPU pattern), `$device` (custom list defaulting to `md.*|vd.*|sd.*` for the logical/RAID view).
- **`manifests/grafana-dashboards-configmap.yaml`**: regenerated to include the new dashboard.
- **`README.md`**:
  - New "Storage dashboard" subsection under "Dashboards included" describing what's surfaced and the caveats below.
  - Step 5 verify section now expects **seven** dashboards in the Crusoe folder.
  - Troubleshooting "regenerate ConfigMap" snippet updated to include `storage-cluster-overview.json`.

## Documented caveats

- `crusoe_vm_disk_*`'s `device` label includes non-block names (`nvidia0..7`, `ens3`/`ens7`, `loop0..7`) — the dashboard filters them out with `device=~"md.*|vd.*|sd.*"`-style PromQL.
- RAID double-counting: on Crusoe H100/B200, 8 local NVMes are typically RAID0'd into `md127`. Aggregating both `nvme*` and `md*` double-counts; the default device filter is the logical view (`md.*|vd.*|sd.*`).
- `kubelet_volume_stats_used_bytes` is **not** in the Crusoe Metrics catalog, so we can show "PVC X requested 100 GiB" but not "PVC X is 80% full." Engineering ask for the Watch Agent team to expose this.
- SDisk panels are project-scoped (no `cluster_id` label), so they show every Crusoe-provisioned disk in the project regardless of which cluster is selected in the dropdown.
- SDisk latency unit assumed microseconds based on observed magnitudes (~500 for cached SSD reads).

## Test plan

Live on come-scale-away (B200 CMK, 211 nodes, eu-norway1-a) after applying the regenerated ConfigMap and a sidecar reload:

- [x] New dashboard appears in the Crusoe folder (uid `crusoe-storage-cluster`)
- [x] Active disk devices (md+vd+sd filter): **1,051**
- [x] Cluster Read Throughput: ~2.8 MB/s
- [x] Cluster Write Throughput: ~24.7 MB/s
- [x] Cluster Read IOPS: ~353
- [x] Cluster Write IOPS: ~3,861
- [x] PVCs Bound: 2
- [x] SDisk capacity used (sum across 9 disks): ~248 GB
- [x] SDisk avg read latency: ~527 µs
- [x] All existing 6 dashboards still render unchanged
- [x] Auth-proxy sidecar still healthy after the ConfigMap reload