### PR TITLE
grafana-cmk: add Shared Storage View and Slurm Cluster View dashboards

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -250,7 +250,7 @@ Verify the dashboards:
 
 1. Click **Dashboards** in the left sidebar.
 2. Open the **Crusoe** folder.
-3. You should see six dashboards: Cluster GPU Overview, Node GPU Detail, DCGM & Xid Errors, Cluster GPU Power, InfiniBand Cluster View, and InfiniBand Node View.
+3. You should see eight dashboards: Cluster GPU Overview, Node GPU Detail, DCGM & Xid Errors, Cluster GPU Power, InfiniBand Cluster View, InfiniBand Node View, Shared Storage View, and Slurm Cluster View.
 
 ---
 
@@ -289,6 +289,46 @@ All dashboards live in the `Crusoe` folder in Grafana and share a **Cluster** dr
 > 3. **No in-guest fallback.** `ibv_devinfo`, `perfquery`, and the standard `/sys/class/infiniband/.../counters/` files are not exposed inside Crusoe guest VMs, so there is no in-guest path to scrape accurate per-HCA counters today.
 >
 > Treat the IB dashboards as **diagnostic** (which HCAs are active, where errors are concentrated, when traffic stops) rather than **quantitative** (absolute Gbps / % of line rate). For ground-truth bandwidth measurements, run `perftest` from inside the workload.
+
+### Storage dashboard
+
+**Shared Storage View (`storage-cluster-overview.json`)** — per-disk view of Crusoe-provisioned block storage (`crusoe_sdisk_*` metric family). Project-scoped: the dashboard lists every Crusoe SDisk in the project and you drill into one at a time using the **Crusoe SDisk (by Crusoe ID)** dropdown.
+
+Panels:
+
+- **Top stat row** (6 cards): Total SDisks in project, Total Capacity Used across all disks, plus four "Selected Disk" cards — Capacity Used, current Read BW, current Write BW, and average Read Latency.
+- **Per-Disk Capacity Used** bar gauge — **unfiltered**, always shows every disk in the project so you keep the global view. Legend displays `disk_id` (Crusoe Console identifier) followed by `(disk_name)` in parens (the K8s PVC UID), giving you a direct map between what Crusoe Console shows and what `kubectl get pv` shows.
+- **Selected Disk** time-series rows: Read/Write Throughput, Read/Write IOPS, Read Latency, Write Latency.
+
+The dropdown is sourced from `label_values(crusoe_sdisk_disk_capacity_used_bytes, disk_id)` so it lists every disk that's reporting capacity in this project. **No cluster filter** — Crusoe SDisks are scoped to the project, not to a cluster, so cluster filtering would be misleading.
+
+> **Storage dashboard caveats:**
+>
+> 1. **Two identifiers per disk.** Each Crusoe SDisk has both a `disk_id` (Crusoe-side identifier — shown in Crusoe Console and `crusoe storage disks list`) and a `disk_name` (the K8s PVC UID once it's mounted by a CSI driver). They are *different* UUIDs. The dropdown uses `disk_id`; the capacity bar gauge displays both, e.g. `44b160b1-bc88-466a-bdb2-e518941b59f8 (1dd0fac5-44e0-4539-ad89-2924e4f1b822)`.
+> 2. **No in-volume usage.** `kubelet_volume_stats_used_bytes` is not in the Crusoe Metrics catalog, so the dashboard can't show "this disk is 80% full" — only `crusoe_sdisk_disk_capacity_used_bytes`, which is bytes consumed from the Crusoe-storage-service's vantage point.
+> 3. **Latency unit assumed microseconds.** `crusoe_sdisk_disk_read_latency_sum` / `_count` produce an average via `rate(sum)/rate(count)`. Magnitudes (~500 µs for cached SSD reads) match microseconds, but verify with `perftest`-style benchmarks if precision matters. Latency panels fall back to 0 when the disk has no traffic in the window (rather than the more confusing NaN/"No data").
+> 4. **`[2m]` rate windows.** Measured Watch Agent cadence on the SDisk metrics is ~60 s between fresh samples (with occasional 2–12 min outliers). The dashboard uses `[2m]` rate windows so panels update within ~1–2 min of the agent posting fresh data, balanced against the occasional empty point on a scrape gap.
+> 5. **VM-level disk I/O** (the `crusoe_vm_disk_*` family — guest-VM kernel block-device counters) is *not* shown on this dashboard. It's project-wide and node-aggregated rather than per-disk, so it didn't fit the "one disk at a time" focus. If you need it, file a follow-up to ship a separate VM Disk I/O dashboard.
+
+### Slurm dashboard
+
+**Slurm Cluster View (`slurm-cluster-overview.json`)** — control-plane view of a Crusoe Managed Slurm or Slurm-on-CMK cluster. Surfaces:
+
+- **Node states** as stat cards (Total / Allocated / Idle / Mixed / Down-Drained-Fail / Drain-Draining) plus a 12-state stacked time series (`alloc`, `mixed`, `idle`, `drain`, `draining`, `drained`, `down`, `fail`, `maint`, `planned`, `resv`, `unknown`).
+- **Job states** as stat cards (Running, Pending, sdiag Failed, OOM, Cancelled, Timeout, Node-Failed) plus a 9-state stacked time series.
+- **Capacity utilization**: CPU Alloc % and Memory Alloc % gauges (70%/90% thresholds), plus stacked time series of CPU alloc/idle and memory alloc/free.
+- **Scheduler health**: scheduler-cycle mean/last latency (`crusoe_slurm_sched_mean_cycle`, `crusoe_slurm_schedule_cycle_last`) and backfill activity (last cycle duration + avg queue length seen).
+- **Error stats** stat row: Cancelled, Timeout, and Node-Fail jobs.
+
+The `$cluster` variable is sourced from `label_values(crusoe_slurm_nodes, cluster_id)` so the dropdown only lists clusters that actually publish Slurm telemetry.
+
+> **Slurm dashboard caveats:**
+>
+> 1. **Memory unit is MB.** `crusoe_slurm_node_memory_bytes` and `_memory_alloc_bytes` are exported in megabytes despite the `_bytes` suffix (Slurm's RealMemory convention). The dashboard uses Grafana's `mbytes` unit so the panel auto-scales MB → GB → TB. The `Memory Alloc %` gauge ratios the two metrics, so the unit confusion cancels.
+> 2. **Slurm node names don't match Crusoe `vm_name`.** Slurm uses canonical names like `come-scale-away-workers-0`; the Crusoe Metrics relay uses `np-…` for `vm_name`. The two surfaces can't be joined at the node level without an external mapping — so this dashboard doesn't link click-through to the GPU dashboards.
+> 3. **Not all installations expose every state.** Sparse states (`crusoe_slurm_nodes_planned`, `_resv`, `_unknown`, `_maint`) will simply not contribute to the stacked area on a cluster that never enters those states. That's expected — empty isn't broken.
+> 4. **No slurmdbd panel.** The `crusoe_slurm_slurmdbd_queue_size` metric is published but consistently reports 0 on slinky-based Slurm-on-CMK installations (no slurmdbd pod), so showing it was misleading. If your cluster runs Crusoe Managed Slurm with slurmdbd, the metric is meaningful and you can re-add the panel locally.
+> 5. **Single-cluster scope.** The dashboard intentionally surfaces only cluster-wide aggregates. Per-partition (`crusoe_slurm_partition_*`), per-user (`crusoe_slurm_user_jobs_*`), and per-account (`crusoe_slurm_account_jobs_*`) metrics are available and would make good follow-up dashboards if you need that breakdown.
 
 ---
 
@@ -361,6 +401,8 @@ kubectl create configmap crusoe-dashboards \
   --from-file=cluster-gpu-power.json=dashboards/cluster-gpu-power.json \
   --from-file=cluster-ib-overview.json=dashboards/cluster-ib-overview.json \
   --from-file=node-ib-detail.json=dashboards/node-ib-detail.json \
+  --from-file=storage-cluster-overview.json=dashboards/storage-cluster-overview.json \
+  --from-file=slurm-cluster-overview.json=dashboards/slurm-cluster-overview.json \
   --dry-run=client -o yaml \
   | sed 's/^metadata:$/metadata:\n  labels:\n    grafana_dashboard: "1"/' \
   | kubectl apply -f -

--- a/grafana-cmk/dashboards/slurm-cluster-overview.json
+++ b/grafana-cmk/dashboards/slurm-cluster-overview.json
@@ -1,0 +1,1324 @@
+{
+  "uid": "crusoe-slurm-cluster",
+  "title": "Crusoe \u2014 Slurm Cluster View",
+  "description": "Slurm scheduler state: node states, job states, capacity utilization, scheduler/backfill health, error counters.",
+  "tags": [
+    "crusoe",
+    "slurm",
+    "scheduler"
+  ],
+  "schemaVersion": 38,
+  "version": 2,
+  "refresh": "1m",
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "query": "label_values(crusoe_slurm_nodes, cluster_id)",
+        "refresh": 2,
+        "sort": 1,
+        "multi": false,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Total Nodes",
+      "description": "Total nodes Slurm is aware of in the selected cluster.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Allocated",
+      "description": "Nodes currently allocated to jobs.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_alloc{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Idle",
+      "description": "Nodes idle and available to schedule.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_idle{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Mixed",
+      "description": "Nodes partially allocated \u2014 some CPUs in use, some idle.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_mixed{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Down / Drained / Fail",
+      "description": "Nodes currently unusable by the scheduler. Any non-zero value warrants investigation.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_down{cluster_id=~\"$cluster\"}) + sum(crusoe_slurm_nodes_drained{cluster_id=~\"$cluster\"}) + sum(crusoe_slurm_nodes_fail{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Drain / Draining",
+      "description": "Nodes flagged to drain \u2014 they finish current jobs but won't accept new ones.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_drain{cluster_id=~\"$cluster\"}) + sum(crusoe_slurm_nodes_draining{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Running Jobs",
+      "description": "Jobs currently executing on allocated nodes.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_running{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Pending Jobs",
+      "description": "Jobs awaiting resources in the queue.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_pending{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "sdiag Failed",
+      "description": "Jobs that failed since slurmctld start (from sdiag). Any non-zero warrants a look at recent jobs.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_sdiag_jobs_failed{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "OOM Jobs",
+      "description": "Jobs killed due to out-of-memory. Indicates resource requests need tuning.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_outofmemory{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "gauge",
+      "title": "CPU Alloc %",
+      "description": "CPUs allocated vs total across all nodes. Green <70%, yellow 70-90%, red >90%.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_node_cpus_alloc{cluster_id=~\"$cluster\"}) / sum(crusoe_slurm_node_cpus{cluster_id=~\"$cluster\"}) * 100",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "gauge",
+      "title": "Memory Alloc %",
+      "description": "Memory allocated vs total. Note: Slurm exports memory in MB despite the _bytes suffix on the metric name.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_node_memory_alloc_bytes{cluster_id=~\"$cluster\"}) / sum(crusoe_slurm_node_memory_bytes{cluster_id=~\"$cluster\"}) * 100",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Node State Over Time",
+      "description": "Stacked node-count per Slurm state. Watch for drained/down growing or alloc dropping unexpectedly.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 24,
+        "h": 10
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "fillOpacity": 50,
+            "lineInterpolation": "linear",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_alloc{cluster_id=~\"$cluster\"})",
+          "legendFormat": "alloc"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_mixed{cluster_id=~\"$cluster\"})",
+          "legendFormat": "mixed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_idle{cluster_id=~\"$cluster\"})",
+          "legendFormat": "idle"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_drain{cluster_id=~\"$cluster\"})",
+          "legendFormat": "drain"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_draining{cluster_id=~\"$cluster\"})",
+          "legendFormat": "draining"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_drained{cluster_id=~\"$cluster\"})",
+          "legendFormat": "drained"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_down{cluster_id=~\"$cluster\"})",
+          "legendFormat": "down"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_fail{cluster_id=~\"$cluster\"})",
+          "legendFormat": "fail"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_maint{cluster_id=~\"$cluster\"})",
+          "legendFormat": "maint"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_planned{cluster_id=~\"$cluster\"})",
+          "legendFormat": "planned"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_resv{cluster_id=~\"$cluster\"})",
+          "legendFormat": "resv"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_nodes_unknown{cluster_id=~\"$cluster\"})",
+          "legendFormat": "unknown"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Job State Over Time",
+      "description": "Stacked job-count by Slurm state. Spikes in failed/timeout/cancelled vs running can reveal scheduler or workload issues.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 18,
+        "w": 24,
+        "h": 10
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "fillOpacity": 50,
+            "lineInterpolation": "linear",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_running{cluster_id=~\"$cluster\"})",
+          "legendFormat": "running"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_pending{cluster_id=~\"$cluster\"})",
+          "legendFormat": "pending"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_completing{cluster_id=~\"$cluster\"})",
+          "legendFormat": "completing"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_configuring{cluster_id=~\"$cluster\"})",
+          "legendFormat": "configuring"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_suspended{cluster_id=~\"$cluster\"})",
+          "legendFormat": "suspended"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_completed{cluster_id=~\"$cluster\"})",
+          "legendFormat": "completed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_failed{cluster_id=~\"$cluster\"})",
+          "legendFormat": "failed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_cancelled{cluster_id=~\"$cluster\"})",
+          "legendFormat": "cancelled"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_timeout{cluster_id=~\"$cluster\"})",
+          "legendFormat": "timeout"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "CPU Allocation",
+      "description": "CPUs allocated vs idle summed across all nodes in the cluster.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "fillOpacity": 50,
+            "lineInterpolation": "linear",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_node_cpus_alloc{cluster_id=~\"$cluster\"})",
+          "legendFormat": "allocated"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_node_cpus_idle{cluster_id=~\"$cluster\"})",
+          "legendFormat": "idle"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Memory Allocation",
+      "description": "Memory allocated vs free, summed across all nodes. Slurm exports memory in MB despite the _bytes suffix on the metric \u2014 Grafana's mbytes unit auto-scales (MB\u2192GB\u2192TB).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 28,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "mbytes",
+          "custom": {
+            "fillOpacity": 50,
+            "lineInterpolation": "linear",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_node_memory_alloc_bytes{cluster_id=~\"$cluster\"})",
+          "legendFormat": "allocated"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_node_memory_free_bytes{cluster_id=~\"$cluster\"})",
+          "legendFormat": "free"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Scheduler Cycle Latency",
+      "description": "Main scheduler loop duration. Rising values mean the controller is falling behind \u2014 typically indicates queue size growth or contention.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s",
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "linear"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "crusoe_slurm_sched_mean_cycle{cluster_id=~\"$cluster\"}",
+          "legendFormat": "mean"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "crusoe_slurm_schedule_cycle_last{cluster_id=~\"$cluster\"}",
+          "legendFormat": "last"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Backfill Activity",
+      "description": "Backfill scheduler cycle duration and the average queue depth it observed during the cycle. Two series share an axis; the cycle is in \u00b5s, the queue length is unitless.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 36,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "linear"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "crusoe_slurm_bf_cycle_last{cluster_id=~\"$cluster\"}",
+          "legendFormat": "last cycle (\u00b5s)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "crusoe_slurm_bf_queue_len_mean{cluster_id=~\"$cluster\"}",
+          "legendFormat": "avg queue len seen"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "type": "stat",
+      "title": "Cancelled Jobs",
+      "description": "Jobs in cancelled state right now.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 44,
+        "w": 8,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_cancelled{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "stat",
+      "title": "Timeout Jobs",
+      "description": "Jobs killed by Slurm wall-time limit.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 44,
+        "w": 8,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_timeout{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 21,
+      "type": "stat",
+      "title": "Node-Fail Jobs",
+      "description": "Jobs that ended due to node failure. Indicates hardware-level issues.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 44,
+        "w": 8,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_slurm_jobs_node_failed{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana-cmk/dashboards/storage-cluster-overview.json
+++ b/grafana-cmk/dashboards/storage-cluster-overview.json
@@ -1,0 +1,579 @@
+{
+  "uid": "crusoe-storage-cluster",
+  "title": "Crusoe \u2014 Shared Storage View",
+  "description": "Crusoe-provisioned block-storage (SDisk) health: per-disk capacity, throughput, IOPS, and latency. Project-scoped \u2014 all disks in the project are listed; pick one from the Crusoe SDisk (by Crusoe ID) dropdown to drill in. The bar gauge always shows every disk for context.",
+  "tags": [
+    "crusoe",
+    "storage",
+    "sdisk"
+  ],
+  "schemaVersion": 38,
+  "version": 3,
+  "refresh": "1m",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "disk_id",
+        "label": "Crusoe SDisk (by Crusoe ID)",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "query": "label_values(crusoe_sdisk_disk_capacity_used_bytes, disk_id)",
+        "refresh": 1,
+        "sort": 1,
+        "multi": false,
+        "includeAll": false,
+        "current": {},
+        "description": "Crusoe-side disk identifier (matches what `crusoe storage disks list` and the Crusoe Console show). The K8s PVC UID is shown as `disk_name` in the capacity bar gauge legend for translation."
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Total SDisks in Project",
+      "description": "Number of Crusoe block-storage disks the metrics relay sees in this project.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "count(last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Total Capacity Used (all disks)",
+      "description": "Project-wide sum of capacity consumed across every Crusoe SDisk.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Selected Disk: Capacity Used",
+      "description": "Capacity used on the disk picked in the Crusoe SDisk dropdown.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "last_over_time(crusoe_sdisk_disk_capacity_used_bytes{disk_id=\"$disk_id\"}[2m])",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Selected Disk: Read BW",
+      "description": "Average read bandwidth on the selected disk over the last 5 minutes.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_sdisk_disk_read_bw_bytes_sum{disk_id=\"$disk_id\"}[2m]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Selected Disk: Write BW",
+      "description": "Average write bandwidth on the selected disk over the last 5 minutes.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_sdisk_disk_write_bw_bytes_sum{disk_id=\"$disk_id\"}[2m]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Selected Disk: Avg Read Latency",
+      "description": "Average per-operation read latency on the selected disk. 0 when the disk has no read traffic in the last 5 minutes.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_sdisk_disk_read_latency_sum{disk_id=\"$disk_id\"}[2m])) / sum(rate(crusoe_sdisk_disk_read_latency_count{disk_id=\"$disk_id\"}[2m])) or vector(0)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "bargauge",
+      "title": "Per-Disk Capacity Used (all disks)",
+      "description": "Per-disk capacity used. Unfiltered \u2014 every Crusoe SDisk in this project is listed regardless of which disk is selected in the dropdown. Legend shows `disk_id` (Crusoe Console identifier) followed by `disk_name` (K8s PVC UID) so you can map a disk between Crusoe Console and `kubectl get pv`.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 24,
+        "h": 10
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m])",
+          "instant": true,
+          "legendFormat": "{{disk_id}}  ({{disk_name}})"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Selected Disk: Read / Write Throughput",
+      "description": "Per-operation read/write bandwidth on the selected disk. Histogram-sum metric \u2192 use `rate(...)` to convert cumulative to bytes/sec.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_sdisk_disk_read_bw_bytes_sum{disk_id=\"$disk_id\"}[2m]))",
+          "legendFormat": "read"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_sdisk_disk_write_bw_bytes_sum{disk_id=\"$disk_id\"}[2m]))",
+          "legendFormat": "write"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Selected Disk: Read / Write IOPS",
+      "description": "Read/write operations per second on the selected disk.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 14,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "iops",
+          "custom": {
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_sdisk_disk_read_iops_count{disk_id=\"$disk_id\"}[2m]))",
+          "legendFormat": "read"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_sdisk_disk_write_iops_count{disk_id=\"$disk_id\"}[2m]))",
+          "legendFormat": "write"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Selected Disk: Read Latency",
+      "description": "Average per-operation read latency on the selected disk. Computed as `rate(latency_sum) / rate(latency_count)`. Falls back to 0 when the disk has no read traffic in the window \u2014 that's not a dashboard bug, just an idle disk.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s",
+          "custom": {
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_sdisk_disk_read_latency_sum{disk_id=\"$disk_id\"}[2m])) / sum(rate(crusoe_sdisk_disk_read_latency_count{disk_id=\"$disk_id\"}[2m])) or vector(0)",
+          "legendFormat": "avg read latency"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Selected Disk: Write Latency",
+      "description": "Average per-operation write latency on the selected disk. Computed as `rate(latency_sum) / rate(latency_count)`. Falls back to 0 when the disk has no write traffic in the window.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 22,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s",
+          "custom": {
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_sdisk_disk_write_latency_sum{disk_id=\"$disk_id\"}[2m])) / sum(rate(crusoe_sdisk_disk_write_latency_count{disk_id=\"$disk_id\"}[2m])) or vector(0)",
+          "legendFormat": "avg write latency"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -2833,6 +2833,1911 @@ data:
         }
       ]
     }
+  slurm-cluster-overview.json: |-
+    {
+      "uid": "crusoe-slurm-cluster",
+      "title": "Crusoe \u2014 Slurm Cluster View",
+      "description": "Slurm scheduler state: node states, job states, capacity utilization, scheduler/backfill health, error counters.",
+      "tags": [
+        "crusoe",
+        "slurm",
+        "scheduler"
+      ],
+      "schemaVersion": 38,
+      "version": 2,
+      "refresh": "1m",
+      "time": {
+        "from": "now-3h",
+        "to": "now"
+      },
+      "templating": {
+        "list": [
+          {
+            "name": "cluster",
+            "label": "Cluster",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
+            "query": "label_values(crusoe_slurm_nodes, cluster_id)",
+            "refresh": 2,
+            "sort": 1,
+            "multi": false,
+            "includeAll": true,
+            "allValue": ".+",
+            "current": {}
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Total Nodes",
+          "description": "Total nodes Slurm is aware of in the selected cluster.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Allocated",
+          "description": "Nodes currently allocated to jobs.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 4,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_alloc{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Idle",
+          "description": "Nodes idle and available to schedule.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 8,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_idle{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Mixed",
+          "description": "Nodes partially allocated \u2014 some CPUs in use, some idle.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_mixed{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "Down / Drained / Fail",
+          "description": "Nodes currently unusable by the scheduler. Any non-zero value warrants investigation.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 16,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_down{cluster_id=~\"$cluster\"}) + sum(crusoe_slurm_nodes_drained{cluster_id=~\"$cluster\"}) + sum(crusoe_slurm_nodes_fail{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "Drain / Draining",
+          "description": "Nodes flagged to drain \u2014 they finish current jobs but won't accept new ones.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 20,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_drain{cluster_id=~\"$cluster\"}) + sum(crusoe_slurm_nodes_draining{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "type": "stat",
+          "title": "Running Jobs",
+          "description": "Jobs currently executing on allocated nodes.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_running{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "type": "stat",
+          "title": "Pending Jobs",
+          "description": "Jobs awaiting resources in the queue.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 4,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_pending{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "type": "stat",
+          "title": "sdiag Failed",
+          "description": "Jobs that failed since slurmctld start (from sdiag). Any non-zero warrants a look at recent jobs.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 8,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_sdiag_jobs_failed{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "type": "stat",
+          "title": "OOM Jobs",
+          "description": "Jobs killed due to out-of-memory. Indicates resource requests need tuning.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_outofmemory{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 11,
+          "type": "gauge",
+          "title": "CPU Alloc %",
+          "description": "CPUs allocated vs total across all nodes. Green <70%, yellow 70-90%, red >90%.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 16,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_node_cpus_alloc{cluster_id=~\"$cluster\"}) / sum(crusoe_slurm_node_cpus{cluster_id=~\"$cluster\"}) * 100",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 12,
+          "type": "gauge",
+          "title": "Memory Alloc %",
+          "description": "Memory allocated vs total. Note: Slurm exports memory in MB despite the _bytes suffix on the metric name.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 20,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_node_memory_alloc_bytes{cluster_id=~\"$cluster\"}) / sum(crusoe_slurm_node_memory_bytes{cluster_id=~\"$cluster\"}) * 100",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 13,
+          "type": "timeseries",
+          "title": "Node State Over Time",
+          "description": "Stacked node-count per Slurm state. Watch for drained/down growing or alloc dropping unexpectedly.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 8,
+            "w": 24,
+            "h": 10
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "fillOpacity": 50,
+                "lineInterpolation": "linear",
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_alloc{cluster_id=~\"$cluster\"})",
+              "legendFormat": "alloc"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_mixed{cluster_id=~\"$cluster\"})",
+              "legendFormat": "mixed"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_idle{cluster_id=~\"$cluster\"})",
+              "legendFormat": "idle"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_drain{cluster_id=~\"$cluster\"})",
+              "legendFormat": "drain"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_draining{cluster_id=~\"$cluster\"})",
+              "legendFormat": "draining"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_drained{cluster_id=~\"$cluster\"})",
+              "legendFormat": "drained"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_down{cluster_id=~\"$cluster\"})",
+              "legendFormat": "down"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_fail{cluster_id=~\"$cluster\"})",
+              "legendFormat": "fail"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_maint{cluster_id=~\"$cluster\"})",
+              "legendFormat": "maint"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_planned{cluster_id=~\"$cluster\"})",
+              "legendFormat": "planned"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_resv{cluster_id=~\"$cluster\"})",
+              "legendFormat": "resv"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_nodes_unknown{cluster_id=~\"$cluster\"})",
+              "legendFormat": "unknown"
+            }
+          ]
+        },
+        {
+          "id": 14,
+          "type": "timeseries",
+          "title": "Job State Over Time",
+          "description": "Stacked job-count by Slurm state. Spikes in failed/timeout/cancelled vs running can reveal scheduler or workload issues.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 18,
+            "w": 24,
+            "h": 10
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "fillOpacity": 50,
+                "lineInterpolation": "linear",
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_running{cluster_id=~\"$cluster\"})",
+              "legendFormat": "running"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_pending{cluster_id=~\"$cluster\"})",
+              "legendFormat": "pending"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_completing{cluster_id=~\"$cluster\"})",
+              "legendFormat": "completing"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_configuring{cluster_id=~\"$cluster\"})",
+              "legendFormat": "configuring"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_suspended{cluster_id=~\"$cluster\"})",
+              "legendFormat": "suspended"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_completed{cluster_id=~\"$cluster\"})",
+              "legendFormat": "completed"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_failed{cluster_id=~\"$cluster\"})",
+              "legendFormat": "failed"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_cancelled{cluster_id=~\"$cluster\"})",
+              "legendFormat": "cancelled"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_timeout{cluster_id=~\"$cluster\"})",
+              "legendFormat": "timeout"
+            }
+          ]
+        },
+        {
+          "id": 15,
+          "type": "timeseries",
+          "title": "CPU Allocation",
+          "description": "CPUs allocated vs idle summed across all nodes in the cluster.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 28,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "fillOpacity": 50,
+                "lineInterpolation": "linear",
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_node_cpus_alloc{cluster_id=~\"$cluster\"})",
+              "legendFormat": "allocated"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_node_cpus_idle{cluster_id=~\"$cluster\"})",
+              "legendFormat": "idle"
+            }
+          ]
+        },
+        {
+          "id": 16,
+          "type": "timeseries",
+          "title": "Memory Allocation",
+          "description": "Memory allocated vs free, summed across all nodes. Slurm exports memory in MB despite the _bytes suffix on the metric \u2014 Grafana's mbytes unit auto-scales (MB\u2192GB\u2192TB).",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 28,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "mbytes",
+              "custom": {
+                "fillOpacity": 50,
+                "lineInterpolation": "linear",
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_node_memory_alloc_bytes{cluster_id=~\"$cluster\"})",
+              "legendFormat": "allocated"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_node_memory_free_bytes{cluster_id=~\"$cluster\"})",
+              "legendFormat": "free"
+            }
+          ]
+        },
+        {
+          "id": 17,
+          "type": "timeseries",
+          "title": "Scheduler Cycle Latency",
+          "description": "Main scheduler loop duration. Rising values mean the controller is falling behind \u2014 typically indicates queue size growth or contention.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 36,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "\u00b5s",
+              "custom": {
+                "fillOpacity": 10,
+                "lineInterpolation": "linear"
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "crusoe_slurm_sched_mean_cycle{cluster_id=~\"$cluster\"}",
+              "legendFormat": "mean"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "crusoe_slurm_schedule_cycle_last{cluster_id=~\"$cluster\"}",
+              "legendFormat": "last"
+            }
+          ]
+        },
+        {
+          "id": 18,
+          "type": "timeseries",
+          "title": "Backfill Activity",
+          "description": "Backfill scheduler cycle duration and the average queue depth it observed during the cycle. Two series share an axis; the cycle is in \u00b5s, the queue length is unitless.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 36,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10,
+                "lineInterpolation": "linear"
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "crusoe_slurm_bf_cycle_last{cluster_id=~\"$cluster\"}",
+              "legendFormat": "last cycle (\u00b5s)"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "crusoe_slurm_bf_queue_len_mean{cluster_id=~\"$cluster\"}",
+              "legendFormat": "avg queue len seen"
+            }
+          ]
+        },
+        {
+          "id": 19,
+          "type": "stat",
+          "title": "Cancelled Jobs",
+          "description": "Jobs in cancelled state right now.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 44,
+            "w": 8,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_cancelled{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 20,
+          "type": "stat",
+          "title": "Timeout Jobs",
+          "description": "Jobs killed by Slurm wall-time limit.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 8,
+            "y": 44,
+            "w": 8,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_timeout{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 21,
+          "type": "stat",
+          "title": "Node-Fail Jobs",
+          "description": "Jobs that ended due to node failure. Indicates hardware-level issues.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 16,
+            "y": 44,
+            "w": 8,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_slurm_jobs_node_failed{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        }
+      ]
+    }
+  storage-cluster-overview.json: |-
+    {
+      "uid": "crusoe-storage-cluster",
+      "title": "Crusoe \u2014 Shared Storage View",
+      "description": "Crusoe-provisioned block-storage (SDisk) health: per-disk capacity, throughput, IOPS, and latency. Project-scoped \u2014 all disks in the project are listed; pick one from the Crusoe SDisk (by Crusoe ID) dropdown to drill in. The bar gauge always shows every disk for context.",
+      "tags": [
+        "crusoe",
+        "storage",
+        "sdisk"
+      ],
+      "schemaVersion": 38,
+      "version": 3,
+      "refresh": "1m",
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "templating": {
+        "list": [
+          {
+            "name": "disk_id",
+            "label": "Crusoe SDisk (by Crusoe ID)",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
+            "query": "label_values(crusoe_sdisk_disk_capacity_used_bytes, disk_id)",
+            "refresh": 1,
+            "sort": 1,
+            "multi": false,
+            "includeAll": false,
+            "current": {},
+            "description": "Crusoe-side disk identifier (matches what `crusoe storage disks list` and the Crusoe Console show). The K8s PVC UID is shown as `disk_name` in the capacity bar gauge legend for translation."
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Total SDisks in Project",
+          "description": "Number of Crusoe block-storage disks the metrics relay sees in this project.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "count(last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m]))",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Total Capacity Used (all disks)",
+          "description": "Project-wide sum of capacity consumed across every Crusoe SDisk.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 4,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m]))",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Selected Disk: Capacity Used",
+          "description": "Capacity used on the disk picked in the Crusoe SDisk dropdown.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 8,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "last_over_time(crusoe_sdisk_disk_capacity_used_bytes{disk_id=\"$disk_id\"}[2m])",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Selected Disk: Read BW",
+          "description": "Average read bandwidth on the selected disk over the last 5 minutes.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_sdisk_disk_read_bw_bytes_sum{disk_id=\"$disk_id\"}[2m]))",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "Selected Disk: Write BW",
+          "description": "Average write bandwidth on the selected disk over the last 5 minutes.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 16,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_sdisk_disk_write_bw_bytes_sum{disk_id=\"$disk_id\"}[2m]))",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "Selected Disk: Avg Read Latency",
+          "description": "Average per-operation read latency on the selected disk. 0 when the disk has no read traffic in the last 5 minutes.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 20,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "\u00b5s",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_sdisk_disk_read_latency_sum{disk_id=\"$disk_id\"}[2m])) / sum(rate(crusoe_sdisk_disk_read_latency_count{disk_id=\"$disk_id\"}[2m])) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "type": "bargauge",
+          "title": "Per-Disk Capacity Used (all disks)",
+          "description": "Per-disk capacity used. Unfiltered \u2014 every Crusoe SDisk in this project is listed regardless of which disk is selected in the dropdown. Legend shows `disk_id` (Crusoe Console identifier) followed by `disk_name` (K8s PVC UID) so you can map a disk between Crusoe Console and `kubectl get pv`.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 4,
+            "w": 24,
+            "h": 10
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m])",
+              "instant": true,
+              "legendFormat": "{{disk_id}}  ({{disk_name}})"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Selected Disk: Read / Write Throughput",
+          "description": "Per-operation read/write bandwidth on the selected disk. Histogram-sum metric \u2192 use `rate(...)` to convert cumulative to bytes/sec.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 14,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "custom": {
+                "fillOpacity": 10
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_sdisk_disk_read_bw_bytes_sum{disk_id=\"$disk_id\"}[2m]))",
+              "legendFormat": "read"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_sdisk_disk_write_bw_bytes_sum{disk_id=\"$disk_id\"}[2m]))",
+              "legendFormat": "write"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "Selected Disk: Read / Write IOPS",
+          "description": "Read/write operations per second on the selected disk.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 14,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "iops",
+              "custom": {
+                "fillOpacity": 10
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_sdisk_disk_read_iops_count{disk_id=\"$disk_id\"}[2m]))",
+              "legendFormat": "read"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_sdisk_disk_write_iops_count{disk_id=\"$disk_id\"}[2m]))",
+              "legendFormat": "write"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "Selected Disk: Read Latency",
+          "description": "Average per-operation read latency on the selected disk. Computed as `rate(latency_sum) / rate(latency_count)`. Falls back to 0 when the disk has no read traffic in the window \u2014 that's not a dashboard bug, just an idle disk.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 22,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "\u00b5s",
+              "custom": {
+                "fillOpacity": 10
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_sdisk_disk_read_latency_sum{disk_id=\"$disk_id\"}[2m])) / sum(rate(crusoe_sdisk_disk_read_latency_count{disk_id=\"$disk_id\"}[2m])) or vector(0)",
+              "legendFormat": "avg read latency"
+            }
+          ]
+        },
+        {
+          "id": 11,
+          "type": "timeseries",
+          "title": "Selected Disk: Write Latency",
+          "description": "Average per-operation write latency on the selected disk. Computed as `rate(latency_sum) / rate(latency_count)`. Falls back to 0 when the disk has no write traffic in the window.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 22,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "\u00b5s",
+              "custom": {
+                "fillOpacity": 10
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_sdisk_disk_write_latency_sum{disk_id=\"$disk_id\"}[2m])) / sum(rate(crusoe_sdisk_disk_write_latency_count{disk_id=\"$disk_id\"}[2m])) or vector(0)",
+              "legendFormat": "avg write latency"
+            }
+          ]
+        }
+      ]
+    }
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
## Summary

Two new dashboards, both verified end-to-end on the `come-scale-away` cluster (Slurm-on-CMK via slinky, 192 worker nodes, 9 Crusoe SDisks).

### Shared Storage View (`storage-cluster-overview.json`, uid `crusoe-storage-cluster`)

Per-disk health for Crusoe-provisioned block storage from the `crusoe_sdisk_*` metric family.

- Single template variable: **`$disk_id`** (sourced from `label_values(crusoe_sdisk_disk_capacity_used_bytes, disk_id)`). **No cluster filter** — SDisks are project-scoped.
- **Per-Disk Capacity Used** bar gauge stays unfiltered (every disk visible) with dual-legend `{{disk_id}} ({{disk_name}})` so users can map a disk between **Crusoe Console** (`disk_id`) and **`kubectl get pv`** (`disk_name`).
- All per-disk time series — Read/Write Throughput, Read/Write IOPS, Read/Write Latency — and four "Selected Disk" stat cards filter to the chosen disk.
- Latency uses `rate(latency_sum)/rate(latency_count) or vector(0)` so idle disks render `0` instead of "No data".
- Rate windows pinned to **`[2m]`** — measured Watch Agent cadence on the SDisk metrics is ~60 s between fresh samples (1h observation on the live cluster). Validated against `[5m]` by sampling read BW once per minute for 5 minutes during a burst → idle transition: `[2m]` tracked the 14 MB/s → 0.2 MB/s drop within 1–2 min; `[5m]` was still showing 1.3 MB/s when the disk had been idle for 4 min.

### Slurm Cluster View (`slurm-cluster-overview.json`, uid `crusoe-slurm-cluster`)

21-panel control-plane view of a Crusoe Managed Slurm or Slurm-on-CMK cluster. Single template variable `$cluster` populated from `label_values(crusoe_slurm_nodes, cluster_id)` so the dropdown only lists clusters that publish Slurm telemetry.

- **Node-state stats**: Total / Allocated / Idle / Mixed / Down+Drained+Fail / Drain+Draining
- **Node State Over Time**: 12-state stacked area (`alloc`, `mixed`, `idle`, `drain`, `draining`, `drained`, `down`, `fail`, `maint`, `planned`, `resv`, `unknown`)
- **Job-state stats**: Running, Pending, sdiag Failed, OOM, Cancelled, Timeout, Node-Fail
- **Job State Over Time**: 9-state stacked area
- **Capacity** gauges + stacked time series: CPU Alloc %, Memory Alloc %, CPU alloc/idle, memory alloc/free (`mbytes` unit — Slurm reports RealMemory in MB despite the `_bytes` suffix)
- **Scheduler health**: `crusoe_slurm_sched_mean_cycle`, `crusoe_slurm_schedule_cycle_last`, `crusoe_slurm_bf_cycle_last`, `crusoe_slurm_bf_queue_len_mean`

`crusoe_slurm_slurmdbd_queue_size` was **deliberately not included**: it reports 0 over 24 h on slinky-based Slurm-on-CMK because slurmdbd isn't deployed on that stack. The README caveat tells users on Crusoe Managed Slurm (which does run slurmdbd) how to re-add the panel locally if they want it.

## Other changes

- `manifests/grafana-dashboards-configmap.yaml`: regenerated to include both new dashboards.
- `README.md`:
  - Step 5 verify bumped to **eight dashboards** (was six).
  - New `### Storage dashboard` and `### Slurm dashboard` subsections under `## Dashboards included`, each with a `> Caveats` block (disk_id vs disk_name dual identity, no `kubelet_volume_stats_used_bytes`, latency unit µs, `[2m]` window choice, slurmdbd-not-deployed-on-slinky note, etc.)
  - Troubleshooting regenerate-ConfigMap snippet updated to include both new `--from-file=` lines.

## Live values from come-scale-away during validation

- **Slurm**: 192 total nodes (128 alloc / 62 idle / 3 unhealthy), 17 jobs (2 running / 14 pending / 1 cancelled), 66.7% CPU & memory allocation, scheduler mean cycle 2.4 ms, backfill last cycle 296 ms.
- **Storage**: 9 SDisks summing to 248 GB used; selected disk `44b160b1-bc88-466a-bdb2-e518941b59f8` showed 147 B/s read BW idle, 411 µs avg read latency, and matched the disk_name `1dd0fac5-...` (the slurm controller statesave PV).

## Test plan

- [x] `kubectl apply -f manifests/grafana-dashboards-configmap.yaml` succeeds and the k8s-sidecar provisions both new dashboards into the Crusoe folder within 60 s.
- [x] Grafana `/api/search` confirms uids `crusoe-storage-cluster` and `crusoe-slurm-cluster` are visible.
- [x] All Storage panel queries return real data for the selected disk; latency panel renders `0` (not "No data") when the disk is idle.
- [x] All Slurm panel queries return live values matching the underlying cluster state via direct `/api/v1/query` against Crusoe Metrics.
- [x] Auth-proxy sidecar still healthy; previous 6 dashboards unchanged.