### PR TITLE
grafana-cmk: audit + expand the IB dashboards

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -7,7 +7,7 @@
 
 ![Cluster GPU Power dashboard at peak load: 1.19 MW total / 1.24 MW peak / 571 kWh consumed](assets/cluster-maxpower.png)
 
-This solution deploys Grafana on a Crusoe Managed Kubernetes (CMK) cluster and configures it to pull GPU, node, and Slurm metrics from the Crusoe Metrics endpoint. You get a persistent Grafana instance you control, with pre-built dashboards for GPU utilization, per-node GPU detail, DCGM/Xid error tracking, GPU power, and InfiniBand fabric activity.
+This solution deploys Grafana on a Crusoe Managed Kubernetes (CMK) cluster and configures it to pull GPU, node, storage, and Slurm metrics from the Crusoe Metrics endpoint. You get a persistent Grafana instance you control, with pre-built dashboards for GPU utilization, per-node GPU detail, DCGM/Xid error tracking, GPU power, InfiniBand fabric activity, Crusoe Shared Storage health, and Slurm cluster state.
 
 What this is: a self-managed Grafana deployment best suited for teams that want dedicated dashboards for CMK or Managed Slurm workloads. Support is best-effort. For fully managed observability, the metrics are also available in Crusoe Command Center without any setup.
 
@@ -256,7 +256,7 @@ Verify the dashboards:
 
 ## Dashboards included
 
-All dashboards live in the `Crusoe` folder in Grafana and share a **Cluster** dropdown (populated from `cluster_id`). The per-node dashboards add a **Node** dropdown for drilling in.
+All dashboards live in the `Crusoe` folder in Grafana. Most have a **Cluster** dropdown populated from `cluster_id` (GPU, IB, and Slurm dashboards each source it from their own primary metric so the dropdown only lists clusters that actually publish that family). Per-node and per-HCA dashboards add a **Node** dropdown; the Shared Storage View uses a single **Crusoe SDisk** dropdown instead because Crusoe block-storage disks are project-scoped, not cluster-scoped.
 
 ### GPU dashboards
 
@@ -272,9 +272,23 @@ All dashboards live in the `Crusoe` folder in Grafana and share a **Cluster** dr
 
 ### InfiniBand dashboards
 
-**InfiniBand Cluster View (`cluster-ib-overview.json`)** — fabric activity across the cluster. Active IB nodes / total HCA ports, aggregate RX / TX bandwidth, per-node aggregate bandwidth time series, per-node RX utilization %, and per-node error / TX-wait rates.
+**InfiniBand Cluster View (`cluster-ib-overview.json`, 20 panels)** — fabric activity and health for the whole cluster.
 
-**InfiniBand Node View (`node-ib-detail.json`)** — per-HCA detail for selected nodes (multi-select). Aggregate RX / TX per node, then a row of per-HCA RX / TX bandwidth, per-HCA RX / TX utilization %, and per-HCA RX errors + TX-wait.
+- **Activity stat row:** Active IB Nodes, Total HCA Ports, Cluster RX BW, Cluster TX BW, Cluster RX pps, Cluster TX pps.
+- **IB Health stat row:** Total RX Errors, Total TX Discards, Link Downed events, Link Recovery events, Remote Physical Errors, Local Link Integrity Errors. All zero on a healthy fabric, red on any non-zero — single-glance "is anything wrong?".
+- **Per-node throughput time series** (RX and TX).
+- **Per-node packet rate time series** (RX and TX pps) — pair with the BW panels to spot small-packet floods.
+- **RX Utilization %** per node + per-node RX errors rate.
+- **TX Wait (back-pressure)** per node + **Top 10 Nodes by combined RX+TX** bar gauge.
+
+**InfiniBand Node View (`node-ib-detail.json`, 14 panels)** — per-HCA detail for selected nodes (multi-select dropdown).
+
+- **Stat row:** Selected Nodes RX, TX, RX errors, link-integrity errors.
+- **Aggregate per node** RX / TX time series.
+- **Per-HCA** RX / TX bandwidth.
+- **Per-HCA** RX / TX utilization %.
+- **Per-HCA** RX / TX packet rate (pps).
+- **Per-HCA** RX errors + TX wait (back-pressure).
 
 > **IB dashboard caveats (read before relying on absolute Gbps):**
 >
@@ -371,7 +385,7 @@ The datasource is reaching Crusoe (no 401), but no metrics come back. Common cau
 - **Watch Agent not installed.** If no Watch Agent is running on the cluster, no metrics reach the Crusoe Metrics backend. Check with your Crusoe account team.
 - **Crusoe Metrics not enabled.** Even with the Watch Agent, the scrape endpoint must be enabled per-project. Contact your account team if the endpoint returns 404 or empty results.
 - **Scrape interval.** The minimum is 60 seconds. If you see "No data" on short time ranges (e.g., last 5 minutes), widen the time range to at least last 1 hour.
-- **cluster_id label not present on GPU metrics.** The `$cluster` variable in the Cluster GPU Overview dashboard uses `label_values(DCGM_FI_DEV_GPU_UTIL, cluster_id)`. If this label is absent from GPU metrics (it is confirmed on Slurm metrics), the variable will be empty and the `{cluster_id=~"$cluster"}` filter will match nothing. In that case, remove the filter from the affected panel queries.
+- **`cluster_id` label not present on the source metric.** Each dashboard's `$cluster` dropdown sources from a different metric — `DCGM_FI_DEV_GPU_UTIL` for the GPU dashboards, `crusoe_ib_port_throughput_rx` for the IB dashboards, `crusoe_slurm_nodes` for the Slurm dashboard. If the source metric has zero series (or no `cluster_id` label) on your cluster, the dropdown is empty and every `{cluster_id=~"$cluster"}` filter matches nothing. Verify with the discovery curl below and either remove the filter from affected panels or repoint the variable at a metric that does carry `cluster_id`.
 
 ### Dashboard variables are empty or panels show no data
 
@@ -475,5 +489,5 @@ kubectl delete storageclass crusoe-csi-driver-ssd-sc   # optional — only if no
 - **30-day metric retention** on the Crusoe backend. For longer retention, add a Prometheus instance that remote-writes from Crusoe Metrics into your own Thanos or Mimir.
 - **Metrics only.** Logs and distributed traces are not available via Crusoe Metrics. For log aggregation on CMK, see the [CMK logs to GCP](../crusoe-managed-kubernetes-logs-to-gcp) solution in this repository.
 - **Label names.** Dashboards use the `node` label to identify nodes and the `gpu` label for GPU index. These are confirmed correct for Crusoe Metrics on Managed Slurm clusters. If variable dropdowns appear empty on a different cluster type, run the discovery curl in the Troubleshooting section to confirm the actual label names.
-- **Slurm metrics.** `slurm_*` metrics from Managed Slurm clusters (e.g. `slurm_queue_length{cluster_id="..."}`) are available via the same endpoint. Add panels for job queue depth, node state, and wait time as needed.
+- **Per-partition / per-user Slurm breakdown.** The Slurm Cluster View aggregates to the cluster level. `crusoe_slurm_partition_*`, `crusoe_slurm_user_jobs_*`, and `crusoe_slurm_account_jobs_*` series are available with `partition`, `username`, and `account` labels respectively — good follow-up dashboards if you need to slice by partition, user, or accounting group.
 - **Production hardening.** Before exposing this to a team, add TLS via cert-manager + ingress, configure LDAP or SSO in `grafana.ini`, and set `allowUiUpdates: false` on the dashboard provider (already set in `grafana-values.yaml`) to prevent in-browser changes from being overwritten on pod restart.

--- a/grafana-cmk/dashboards/cluster-ib-overview.json
+++ b/grafana-cmk/dashboards/cluster-ib-overview.json
@@ -1,16 +1,17 @@
 {
   "uid": "crusoe-ib-cluster",
   "title": "Crusoe \u2014 InfiniBand Cluster View",
+  "description": "Cluster-wide InfiniBand fabric health and activity. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
   "tags": [
     "crusoe",
     "infiniband",
     "cluster"
   ],
   "schemaVersion": 38,
-  "version": 2,
-  "refresh": "30s",
+  "version": 1,
+  "refresh": "1m",
   "time": {
-    "from": "now-1h",
+    "from": "now-3h",
     "to": "now"
   },
   "templating": {
@@ -24,11 +25,16 @@
           "uid": "crusoe-metrics"
         },
         "query": "label_values(crusoe_ib_port_throughput_rx, cluster_id)",
-        "refresh": 2,
+        "refresh": 1,
         "sort": 1,
         "multi": false,
-        "includeAll": false,
-        "current": {}
+        "includeAll": true,
+        "allValue": ".+",
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        }
       }
     ]
   },
@@ -37,7 +43,7 @@
       "id": 1,
       "type": "stat",
       "title": "Active IB Nodes",
-      "description": "Number of nodes with active IB HCAs",
+      "description": "Number of nodes with at least one active IB HCA series. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -55,7 +61,7 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
@@ -67,10 +73,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -82,7 +84,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])))",
+          "expr": "(count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -92,7 +94,7 @@
       "id": 2,
       "type": "stat",
       "title": "Total HCA Ports",
-      "description": "Total IB HCA ports across the cluster",
+      "description": "Total IB HCA ports across the cluster. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -110,7 +112,7 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
@@ -122,10 +124,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -137,7 +135,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h]))",
+          "expr": "(count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -146,8 +144,8 @@
     {
       "id": 3,
       "type": "stat",
-      "title": "Cluster RX Bandwidth",
-      "description": "Total receive bandwidth across all nodes and HCAs",
+      "title": "Cluster RX BW",
+      "description": "Aggregate receive bandwidth across all nodes / HCAs. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -165,7 +163,7 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
@@ -177,10 +175,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -192,7 +186,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8",
+          "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -201,8 +195,8 @@
     {
       "id": 4,
       "type": "stat",
-      "title": "Cluster TX Bandwidth",
-      "description": "Total transmit bandwidth across all nodes and HCAs",
+      "title": "Cluster TX BW",
+      "description": "Aggregate transmit bandwidth across all nodes / HCAs. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -220,7 +214,7 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
@@ -232,10 +226,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -247,7 +237,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8",
+          "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -256,8 +246,8 @@
     {
       "id": 5,
       "type": "stat",
-      "title": "Total RX Errors",
-      "description": "Total receive errors across the cluster",
+      "title": "Cluster RX Packets/s",
+      "description": "Aggregate receive packet rate across all nodes / HCAs. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -275,22 +265,18 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "none",
+          "unit": "pps",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -302,7 +288,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))",
+          "expr": "(sum(rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -311,8 +297,8 @@
     {
       "id": 6,
       "type": "stat",
-      "title": "Total TX Discards",
-      "description": "Total transmit discards across the cluster",
+      "title": "Cluster TX Packets/s",
+      "description": "Aggregate transmit packet rate across all nodes / HCAs. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -330,7 +316,58 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "(sum(rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Total RX Errors",
+      "description": "Cluster-wide RX error increment over the trailing hour. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
@@ -345,7 +382,7 @@
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 1
               }
             ]
           }
@@ -357,24 +394,299 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[1h]))",
+          "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
       ]
     },
     {
-      "id": 7,
+      "id": 8,
+      "type": "stat",
+      "title": "Total TX Discards",
+      "description": "Cluster-wide TX discards over the trailing hour. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "(sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Link Downed Events",
+      "description": "Cluster-wide IB link-down events. Any non-zero value warrants a look \u2014 a flapping or hard-down link affects every job on that node. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "(sum(increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "Link Recovery Events",
+      "description": "Cluster-wide IB link-error-recovery events. Transient recoveries can indicate cable / SerDes issues. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "(sum(increase(crusoe_ib_port_link_error_recovery{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "Remote Physical Errors",
+      "description": "RX errors reported as caused by the partner side of the link. Useful for narrowing fault-isolation to switches or other endpoints. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "(sum(increase(crusoe_ib_port_rcv_remote_physical_errors{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Local Link Integrity Errors",
+      "description": "Local HCA-side link-integrity errors. Often the first signal that a node's IB cable / port is degrading. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 13,
       "type": "timeseries",
       "title": "Per-Node Aggregate RX Bandwidth",
-      "description": "Aggregate RX bandwidth per node (all HCAs summed)",
+      "description": "Per-node aggregate RX bandwidth (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
       "gridPos": {
         "x": 0,
-        "y": 4,
+        "y": 8,
         "w": 12,
         "h": 8
       },
@@ -389,7 +701,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps"
+          "unit": "Bps",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -405,17 +720,17 @@
       ]
     },
     {
-      "id": 8,
+      "id": 14,
       "type": "timeseries",
       "title": "Per-Node Aggregate TX Bandwidth",
-      "description": "Aggregate TX bandwidth per node (all HCAs summed)",
+      "description": "Per-node aggregate TX bandwidth (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
       "gridPos": {
         "x": 12,
-        "y": 4,
+        "y": 8,
         "w": 12,
         "h": 8
       },
@@ -430,7 +745,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps"
+          "unit": "Bps",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -446,17 +764,17 @@
       ]
     },
     {
-      "id": 9,
+      "id": 15,
       "type": "timeseries",
-      "title": "RX Bandwidth Utilization % (per node)",
-      "description": "RX utilization as % of line rate per node",
+      "title": "Per-Node RX Packets/s",
+      "description": "Per-node aggregate RX packet rate (sum across HCAs). Pair with the BW panel above to spot small-packet floods. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
       "gridPos": {
         "x": 0,
-        "y": 12,
+        "y": 16,
         "w": 12,
         "h": 8
       },
@@ -471,7 +789,98 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "percent"
+          "unit": "pps",
+          "custom": {
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[1h]))",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Per-Node TX Packets/s",
+      "description": "Per-node aggregate TX packet rate (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "custom": {
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[1h]))",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "RX Bandwidth Utilization % (per node)",
+      "description": "Per-node aggregate RX utilization as % of total line rate. NOTE: line_rate label reports gig_bit_per_sec=128 on HCAs whose ibstat rate is 400 (NDR), so the denominator is off by ~3\u00d7. Treat as relative not absolute. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -487,17 +896,17 @@
       ]
     },
     {
-      "id": 10,
+      "id": 18,
       "type": "timeseries",
       "title": "RX Errors Rate (per node)",
-      "description": "RX error rate per node",
+      "description": "Per-node RX error rate (events/sec). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
       "gridPos": {
         "x": 12,
-        "y": 12,
+        "y": 24,
         "w": 12,
         "h": 8
       },
@@ -512,7 +921,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "short",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -528,17 +940,17 @@
       ]
     },
     {
-      "id": 11,
+      "id": 19,
       "type": "timeseries",
       "title": "TX Wait (Back-pressure, per node)",
-      "description": "TX wait cycles \u2014 indicates back-pressure or congestion",
+      "description": "Per-node TX-wait increment rate \u2014 indicates congestion or flow control. Rising values mean transmitter is waiting for credits. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
       "gridPos": {
         "x": 0,
-        "y": 20,
+        "y": 32,
         "w": 12,
         "h": 8
       },
@@ -553,7 +965,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "short",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -564,6 +979,48 @@
             "uid": "crusoe-metrics"
           },
           "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[1h]))",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "bargauge",
+      "title": "Top 10 Nodes by Combined RX+TX",
+      "description": "Top 10 nodes by combined RX+TX bandwidth right now. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 32,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(10, sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h]) + rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8)",
+          "instant": true,
           "legendFormat": "{{vm_name}}"
         }
       ]

--- a/grafana-cmk/dashboards/node-ib-detail.json
+++ b/grafana-cmk/dashboards/node-ib-detail.json
@@ -1,16 +1,17 @@
 {
   "uid": "crusoe-ib-node",
   "title": "Crusoe \u2014 InfiniBand Node View",
+  "description": "Per-HCA InfiniBand detail for selected nodes. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
   "tags": [
     "crusoe",
     "infiniband",
     "node"
   ],
   "schemaVersion": 38,
-  "version": 3,
-  "refresh": "30s",
+  "version": 1,
+  "refresh": "1m",
   "time": {
-    "from": "now-1h",
+    "from": "now-3h",
     "to": "now"
   },
   "templating": {
@@ -24,11 +25,16 @@
           "uid": "crusoe-metrics"
         },
         "query": "label_values(crusoe_ib_port_throughput_rx, cluster_id)",
-        "refresh": 2,
+        "refresh": 1,
         "sort": 1,
         "multi": false,
-        "includeAll": false,
-        "current": {}
+        "includeAll": true,
+        "allValue": ".+",
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        }
       },
       {
         "name": "node",
@@ -39,12 +45,16 @@
           "uid": "crusoe-metrics"
         },
         "query": "label_values(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}, vm_name)",
-        "refresh": 2,
+        "refresh": 1,
         "sort": 1,
         "multi": true,
         "includeAll": true,
         "allValue": ".+",
-        "current": {}
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        }
       }
     ]
   },
@@ -53,7 +63,7 @@
       "id": 1,
       "type": "stat",
       "title": "Selected Nodes RX",
-      "description": "Total RX bandwidth across selected nodes",
+      "description": "Aggregate RX bandwidth across the selected nodes. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -71,7 +81,7 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
@@ -83,10 +93,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -98,7 +104,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
+          "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -108,7 +114,7 @@
       "id": 2,
       "type": "stat",
       "title": "Selected Nodes TX",
-      "description": "Total TX bandwidth across selected nodes",
+      "description": "Aggregate TX bandwidth across the selected nodes. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -126,7 +132,7 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
@@ -138,10 +144,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -153,7 +155,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
+          "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -163,7 +165,7 @@
       "id": 3,
       "type": "stat",
       "title": "RX Errors",
-      "description": "Total RX errors across selected nodes",
+      "description": "RX errors on selected nodes over the trailing hour. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -181,7 +183,7 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
@@ -196,7 +198,7 @@
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 1
               }
             ]
           }
@@ -208,7 +210,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))",
+          "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -218,7 +220,7 @@
       "id": 4,
       "type": "stat",
       "title": "Link Integrity Errors",
-      "description": "Local link integrity errors across selected nodes",
+      "description": "Local link-integrity errors on selected nodes over the trailing hour. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -236,7 +238,7 @@
           ]
         },
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "textMode": "auto"
       },
       "fieldConfig": {
@@ -251,7 +253,7 @@
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 1
               }
             ]
           }
@@ -263,7 +265,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))",
+          "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
@@ -273,7 +275,7 @@
       "id": 5,
       "type": "timeseries",
       "title": "Aggregate RX per Node",
-      "description": "Aggregate RX bandwidth per node (sum across all 8 HCAs)",
+      "description": "Aggregate RX bandwidth per node (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -295,7 +297,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps"
+          "unit": "Bps",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -314,7 +319,7 @@
       "id": 6,
       "type": "timeseries",
       "title": "Aggregate TX per Node",
-      "description": "Aggregate TX bandwidth per node (sum across all 8 HCAs)",
+      "description": "Aggregate TX bandwidth per node (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -336,7 +341,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps"
+          "unit": "Bps",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -355,7 +363,7 @@
       "id": 7,
       "type": "timeseries",
       "title": "Per-HCA RX Bandwidth",
-      "description": "RX bandwidth per HCA port for selected nodes",
+      "description": "Per-HCA RX bandwidth. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -377,7 +385,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps"
+          "unit": "Bps",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -396,7 +407,7 @@
       "id": 8,
       "type": "timeseries",
       "title": "Per-HCA TX Bandwidth",
-      "description": "TX bandwidth per HCA port for selected nodes",
+      "description": "Per-HCA TX bandwidth. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -418,7 +429,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps"
+          "unit": "Bps",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -437,7 +451,7 @@
       "id": 9,
       "type": "timeseries",
       "title": "Per-HCA RX Utilization %",
-      "description": "RX utilization as % of line rate per HCA",
+      "description": "Per-HCA RX utilization as % of line rate. NOTE: line_rate's gig_bit_per_sec label reports 128 on HCAs whose ibstat rate is 400 \u2014 denominator off by ~3\u00d7, treat as relative. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -459,7 +473,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "percent"
+          "unit": "percent",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -478,7 +495,7 @@
       "id": 10,
       "type": "timeseries",
       "title": "Per-HCA TX Utilization %",
-      "description": "TX utilization as % of line rate per HCA",
+      "description": "Per-HCA TX utilization as % of line rate. Same denominator caveat as the RX panel. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -500,7 +517,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "percent"
+          "unit": "percent",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -518,8 +538,8 @@
     {
       "id": 11,
       "type": "timeseries",
-      "title": "RX Errors (per HCA)",
-      "description": "RX error rate per HCA",
+      "title": "Per-HCA RX Packets/s",
+      "description": "Per-HCA RX packet rate. Pair with the BW panel to spot small-packet floods. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -541,7 +561,10 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "pps",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },
@@ -551,7 +574,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+          "expr": "rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
       ]
@@ -559,8 +582,8 @@
     {
       "id": 12,
       "type": "timeseries",
-      "title": "TX Wait / Back-pressure (per HCA)",
-      "description": "TX wait cycles per HCA \u2014 indicates congestion or flow control",
+      "title": "Per-HCA TX Packets/s",
+      "description": "Per-HCA TX packet rate. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -582,7 +605,98 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "pps",
+          "custom": {
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+          "legendFormat": "{{vm_name}} {{hca_number}}"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "RX Errors (per HCA)",
+      "description": "Per-HCA RX error rate (events/sec). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+          "legendFormat": "{{vm_name}} {{hca_number}}"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "TX Wait / Back-pressure (per HCA)",
+      "description": "Per-HCA TX-wait rate \u2014 indicates congestion or flow control. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 36,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "fillOpacity": 10
+          }
         },
         "overrides": []
       },

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -919,16 +919,17 @@ data:
     {
       "uid": "crusoe-ib-cluster",
       "title": "Crusoe \u2014 InfiniBand Cluster View",
+      "description": "Cluster-wide InfiniBand fabric health and activity. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
       "tags": [
         "crusoe",
         "infiniband",
         "cluster"
       ],
       "schemaVersion": 38,
-      "version": 2,
-      "refresh": "30s",
+      "version": 1,
+      "refresh": "1m",
       "time": {
-        "from": "now-1h",
+        "from": "now-3h",
         "to": "now"
       },
       "templating": {
@@ -942,11 +943,16 @@ data:
               "uid": "crusoe-metrics"
             },
             "query": "label_values(crusoe_ib_port_throughput_rx, cluster_id)",
-            "refresh": 2,
+            "refresh": 1,
             "sort": 1,
             "multi": false,
-            "includeAll": false,
-            "current": {}
+            "includeAll": true,
+            "allValue": ".+",
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            }
           }
         ]
       },
@@ -955,7 +961,7 @@ data:
           "id": 1,
           "type": "stat",
           "title": "Active IB Nodes",
-          "description": "Number of nodes with active IB HCAs",
+          "description": "Number of nodes with at least one active IB HCA series. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -973,7 +979,7 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
@@ -985,10 +991,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               }
@@ -1000,7 +1002,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])))",
+              "expr": "(count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1010,7 +1012,7 @@ data:
           "id": 2,
           "type": "stat",
           "title": "Total HCA Ports",
-          "description": "Total IB HCA ports across the cluster",
+          "description": "Total IB HCA ports across the cluster. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -1028,7 +1030,7 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
@@ -1040,10 +1042,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               }
@@ -1055,7 +1053,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h]))",
+              "expr": "(count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1064,8 +1062,8 @@ data:
         {
           "id": 3,
           "type": "stat",
-          "title": "Cluster RX Bandwidth",
-          "description": "Total receive bandwidth across all nodes and HCAs",
+          "title": "Cluster RX BW",
+          "description": "Aggregate receive bandwidth across all nodes / HCAs. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -1083,7 +1081,7 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
@@ -1095,10 +1093,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               }
@@ -1110,7 +1104,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8",
+              "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1119,8 +1113,8 @@ data:
         {
           "id": 4,
           "type": "stat",
-          "title": "Cluster TX Bandwidth",
-          "description": "Total transmit bandwidth across all nodes and HCAs",
+          "title": "Cluster TX BW",
+          "description": "Aggregate transmit bandwidth across all nodes / HCAs. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -1138,7 +1132,7 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
@@ -1150,10 +1144,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               }
@@ -1165,7 +1155,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8",
+              "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1174,8 +1164,8 @@ data:
         {
           "id": 5,
           "type": "stat",
-          "title": "Total RX Errors",
-          "description": "Total receive errors across the cluster",
+          "title": "Cluster RX Packets/s",
+          "description": "Aggregate receive packet rate across all nodes / HCAs. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -1193,22 +1183,18 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "none",
+              "unit": "pps",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               }
@@ -1220,7 +1206,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))",
+              "expr": "(sum(rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -1229,8 +1215,8 @@ data:
         {
           "id": 6,
           "type": "stat",
-          "title": "Total TX Discards",
-          "description": "Total transmit discards across the cluster",
+          "title": "Cluster TX Packets/s",
+          "description": "Aggregate transmit packet rate across all nodes / HCAs. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -1248,7 +1234,58 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "pps",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "(sum(rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "type": "stat",
+          "title": "Total RX Errors",
+          "description": "Cluster-wide RX error increment over the trailing hour. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
@@ -1263,7 +1300,7 @@ data:
                   },
                   {
                     "color": "red",
-                    "value": 80
+                    "value": 1
                   }
                 ]
               }
@@ -1275,24 +1312,299 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[1h]))",
+              "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
           ]
         },
         {
-          "id": 7,
+          "id": 8,
+          "type": "stat",
+          "title": "Total TX Discards",
+          "description": "Cluster-wide TX discards over the trailing hour. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 4,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "(sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "type": "stat",
+          "title": "Link Downed Events",
+          "description": "Cluster-wide IB link-down events. Any non-zero value warrants a look \u2014 a flapping or hard-down link affects every job on that node. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 8,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "(sum(increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "type": "stat",
+          "title": "Link Recovery Events",
+          "description": "Cluster-wide IB link-error-recovery events. Transient recoveries can indicate cable / SerDes issues. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "(sum(increase(crusoe_ib_port_link_error_recovery{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 11,
+          "type": "stat",
+          "title": "Remote Physical Errors",
+          "description": "RX errors reported as caused by the partner side of the link. Useful for narrowing fault-isolation to switches or other endpoints. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 16,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "(sum(increase(crusoe_ib_port_rcv_remote_physical_errors{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 12,
+          "type": "stat",
+          "title": "Local Link Integrity Errors",
+          "description": "Local HCA-side link-integrity errors. Often the first signal that a node's IB cable / port is degrading. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 20,
+            "y": 4,
+            "w": 4,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 13,
           "type": "timeseries",
           "title": "Per-Node Aggregate RX Bandwidth",
-          "description": "Aggregate RX bandwidth per node (all HCAs summed)",
+          "description": "Per-node aggregate RX bandwidth (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
           "gridPos": {
             "x": 0,
-            "y": 4,
+            "y": 8,
             "w": 12,
             "h": 8
           },
@@ -1307,7 +1619,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "Bps"
+              "unit": "Bps",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -1323,17 +1638,17 @@ data:
           ]
         },
         {
-          "id": 8,
+          "id": 14,
           "type": "timeseries",
           "title": "Per-Node Aggregate TX Bandwidth",
-          "description": "Aggregate TX bandwidth per node (all HCAs summed)",
+          "description": "Per-node aggregate TX bandwidth (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
           "gridPos": {
             "x": 12,
-            "y": 4,
+            "y": 8,
             "w": 12,
             "h": 8
           },
@@ -1348,7 +1663,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "Bps"
+              "unit": "Bps",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -1364,17 +1682,17 @@ data:
           ]
         },
         {
-          "id": 9,
+          "id": 15,
           "type": "timeseries",
-          "title": "RX Bandwidth Utilization % (per node)",
-          "description": "RX utilization as % of line rate per node",
+          "title": "Per-Node RX Packets/s",
+          "description": "Per-node aggregate RX packet rate (sum across HCAs). Pair with the BW panel above to spot small-packet floods. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
           "gridPos": {
             "x": 0,
-            "y": 12,
+            "y": 16,
             "w": 12,
             "h": 8
           },
@@ -1389,7 +1707,98 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "percent"
+              "unit": "pps",
+              "custom": {
+                "fillOpacity": 10
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[1h]))",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 16,
+          "type": "timeseries",
+          "title": "Per-Node TX Packets/s",
+          "description": "Per-node aggregate TX packet rate (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 16,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "pps",
+              "custom": {
+                "fillOpacity": 10
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[1h]))",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 17,
+          "type": "timeseries",
+          "title": "RX Bandwidth Utilization % (per node)",
+          "description": "Per-node aggregate RX utilization as % of total line rate. NOTE: line_rate label reports gig_bit_per_sec=128 on HCAs whose ibstat rate is 400 (NDR), so the denominator is off by ~3\u00d7. Treat as relative not absolute. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 24,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -1405,17 +1814,17 @@ data:
           ]
         },
         {
-          "id": 10,
+          "id": 18,
           "type": "timeseries",
           "title": "RX Errors Rate (per node)",
-          "description": "RX error rate per node",
+          "description": "Per-node RX error rate (events/sec). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
           "gridPos": {
             "x": 12,
-            "y": 12,
+            "y": 24,
             "w": 12,
             "h": 8
           },
@@ -1430,7 +1839,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "short"
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -1446,17 +1858,17 @@ data:
           ]
         },
         {
-          "id": 11,
+          "id": 19,
           "type": "timeseries",
           "title": "TX Wait (Back-pressure, per node)",
-          "description": "TX wait cycles \u2014 indicates back-pressure or congestion",
+          "description": "Per-node TX-wait increment rate \u2014 indicates congestion or flow control. Rising values mean transmitter is waiting for credits. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
           "gridPos": {
             "x": 0,
-            "y": 20,
+            "y": 32,
             "w": 12,
             "h": 8
           },
@@ -1471,7 +1883,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "short"
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -1482,6 +1897,48 @@ data:
                 "uid": "crusoe-metrics"
               },
               "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[1h]))",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 20,
+          "type": "bargauge",
+          "title": "Top 10 Nodes by Combined RX+TX",
+          "description": "Top 10 nodes by combined RX+TX bandwidth right now. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 32,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "topk(10, sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h]) + rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8)",
+              "instant": true,
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -2235,16 +2692,17 @@ data:
     {
       "uid": "crusoe-ib-node",
       "title": "Crusoe \u2014 InfiniBand Node View",
+      "description": "Per-HCA InfiniBand detail for selected nodes. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
       "tags": [
         "crusoe",
         "infiniband",
         "node"
       ],
       "schemaVersion": 38,
-      "version": 3,
-      "refresh": "30s",
+      "version": 1,
+      "refresh": "1m",
       "time": {
-        "from": "now-1h",
+        "from": "now-3h",
         "to": "now"
       },
       "templating": {
@@ -2258,11 +2716,16 @@ data:
               "uid": "crusoe-metrics"
             },
             "query": "label_values(crusoe_ib_port_throughput_rx, cluster_id)",
-            "refresh": 2,
+            "refresh": 1,
             "sort": 1,
             "multi": false,
-            "includeAll": false,
-            "current": {}
+            "includeAll": true,
+            "allValue": ".+",
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            }
           },
           {
             "name": "node",
@@ -2273,12 +2736,16 @@ data:
               "uid": "crusoe-metrics"
             },
             "query": "label_values(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}, vm_name)",
-            "refresh": 2,
+            "refresh": 1,
             "sort": 1,
             "multi": true,
             "includeAll": true,
             "allValue": ".+",
-            "current": {}
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            }
           }
         ]
       },
@@ -2287,7 +2754,7 @@ data:
           "id": 1,
           "type": "stat",
           "title": "Selected Nodes RX",
-          "description": "Total RX bandwidth across selected nodes",
+          "description": "Aggregate RX bandwidth across the selected nodes. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2305,7 +2772,7 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
@@ -2317,10 +2784,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               }
@@ -2332,7 +2795,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
+              "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -2342,7 +2805,7 @@ data:
           "id": 2,
           "type": "stat",
           "title": "Selected Nodes TX",
-          "description": "Total TX bandwidth across selected nodes",
+          "description": "Aggregate TX bandwidth across the selected nodes. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2360,7 +2823,7 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
@@ -2372,10 +2835,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               }
@@ -2387,7 +2846,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
+              "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -2397,7 +2856,7 @@ data:
           "id": 3,
           "type": "stat",
           "title": "RX Errors",
-          "description": "Total RX errors across selected nodes",
+          "description": "RX errors on selected nodes over the trailing hour. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2415,7 +2874,7 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
@@ -2430,7 +2889,7 @@ data:
                   },
                   {
                     "color": "red",
-                    "value": 80
+                    "value": 1
                   }
                 ]
               }
@@ -2442,7 +2901,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))",
+              "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -2452,7 +2911,7 @@ data:
           "id": 4,
           "type": "stat",
           "title": "Link Integrity Errors",
-          "description": "Local link integrity errors across selected nodes",
+          "description": "Local link-integrity errors on selected nodes over the trailing hour. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2470,7 +2929,7 @@ data:
               ]
             },
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "textMode": "auto"
           },
           "fieldConfig": {
@@ -2485,7 +2944,7 @@ data:
                   },
                   {
                     "color": "red",
-                    "value": 80
+                    "value": 1
                   }
                 ]
               }
@@ -2497,7 +2956,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))",
+              "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
@@ -2507,7 +2966,7 @@ data:
           "id": 5,
           "type": "timeseries",
           "title": "Aggregate RX per Node",
-          "description": "Aggregate RX bandwidth per node (sum across all 8 HCAs)",
+          "description": "Aggregate RX bandwidth per node (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2529,7 +2988,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "Bps"
+              "unit": "Bps",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -2548,7 +3010,7 @@ data:
           "id": 6,
           "type": "timeseries",
           "title": "Aggregate TX per Node",
-          "description": "Aggregate TX bandwidth per node (sum across all 8 HCAs)",
+          "description": "Aggregate TX bandwidth per node (sum across HCAs). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2570,7 +3032,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "Bps"
+              "unit": "Bps",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -2589,7 +3054,7 @@ data:
           "id": 7,
           "type": "timeseries",
           "title": "Per-HCA RX Bandwidth",
-          "description": "RX bandwidth per HCA port for selected nodes",
+          "description": "Per-HCA RX bandwidth. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2611,7 +3076,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "Bps"
+              "unit": "Bps",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -2630,7 +3098,7 @@ data:
           "id": 8,
           "type": "timeseries",
           "title": "Per-HCA TX Bandwidth",
-          "description": "TX bandwidth per HCA port for selected nodes",
+          "description": "Per-HCA TX bandwidth. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2652,7 +3120,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "Bps"
+              "unit": "Bps",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -2671,7 +3142,7 @@ data:
           "id": 9,
           "type": "timeseries",
           "title": "Per-HCA RX Utilization %",
-          "description": "RX utilization as % of line rate per HCA",
+          "description": "Per-HCA RX utilization as % of line rate. NOTE: line_rate's gig_bit_per_sec label reports 128 on HCAs whose ibstat rate is 400 \u2014 denominator off by ~3\u00d7, treat as relative. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2693,7 +3164,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "percent"
+              "unit": "percent",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -2712,7 +3186,7 @@ data:
           "id": 10,
           "type": "timeseries",
           "title": "Per-HCA TX Utilization %",
-          "description": "TX utilization as % of line rate per HCA",
+          "description": "Per-HCA TX utilization as % of line rate. Same denominator caveat as the RX panel. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2734,7 +3208,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "percent"
+              "unit": "percent",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -2752,8 +3229,8 @@ data:
         {
           "id": 11,
           "type": "timeseries",
-          "title": "RX Errors (per HCA)",
-          "description": "RX error rate per HCA",
+          "title": "Per-HCA RX Packets/s",
+          "description": "Per-HCA RX packet rate. Pair with the BW panel to spot small-packet floods. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2775,7 +3252,10 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "short"
+              "unit": "pps",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
@@ -2785,7 +3265,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+              "expr": "rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
           ]
@@ -2793,8 +3273,8 @@ data:
         {
           "id": 12,
           "type": "timeseries",
-          "title": "TX Wait / Back-pressure (per HCA)",
-          "description": "TX wait cycles per HCA \u2014 indicates congestion or flow control",
+          "title": "Per-HCA TX Packets/s",
+          "description": "Per-HCA TX packet rate. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -2816,7 +3296,98 @@ data:
           },
           "fieldConfig": {
             "defaults": {
-              "unit": "short"
+              "unit": "pps",
+              "custom": {
+                "fillOpacity": 10
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+              "legendFormat": "{{vm_name}} {{hca_number}}"
+            }
+          ]
+        },
+        {
+          "id": 13,
+          "type": "timeseries",
+          "title": "RX Errors (per HCA)",
+          "description": "Per-HCA RX error rate (events/sec). \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 36,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+              "legendFormat": "{{vm_name}} {{hca_number}}"
+            }
+          ]
+        },
+        {
+          "id": 14,
+          "type": "timeseries",
+          "title": "TX Wait / Back-pressure (per HCA)",
+          "description": "Per-HCA TX-wait rate \u2014 indicates congestion or flow control. \u00b7 Window is fixed at [1h] because the Watch Agent's IB scrape cadence is ~19 min on B200 / ~4.5 min on H100; shorter windows would render mostly NaN. The reading is a trailing-hour average.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 36,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },


### PR DESCRIPTION
## Summary

Audit of the existing IB dashboards found that **6 of the 8 IB error / link-event metrics** published by the Watch Agent were never surfaced anywhere, the **packet-rate metrics weren't used**, and the stat panels rendered "No data" instead of `0` on a healthy idle fabric. The audit also caught several places in the README that fell behind as the dashboard set grew.

## Cluster View — 11 → **20 panels**

- **New IB Health stat row** (6 panels): Total RX Errors, Total TX Discards, Link Downed events, Link Recovery events, Remote Physical Errors, Local Link Integrity Errors. All zero on a healthy fabric, red on any non-zero — single-glance "is anything wrong?".
- **New Cluster RX / TX Packets/s** stat panels and per-node RX / TX pps time series. Pair with the BW panels to spot small-packet floods vs throughput-bound traffic.
- **New Top-10 Nodes by Combined RX+TX** bar gauge, matching the pattern used by the Storage dashboard.
- **Layout cleanup**: bottom row no longer has TX-Wait alone with empty space next to it.
- Every stat panel now wraps its expression with `or vector(0)` so empty results render as 0 instead of "No data".
- Every panel description embeds the `[1h]`-window cadence caveat so it surfaces on hover, not only in the README.

## Node View — 12 → **14 panels**

- New per-HCA RX / TX Packets/s time series.
- `or vector(0)` fallbacks on the stat row.
- `[1h]`-window caveat embedded in every panel description.

## README updates

- **Intro sentence** updated to mention Shared Storage and Slurm dashboards alongside GPU / IB.
- **"Dashboards included" section header** rephrased: not every dashboard has a Cluster dropdown (Shared Storage View doesn't), and dashboards that do have one source the variable from different metric families.
- **IB Cluster View / Node View descriptions** expanded to list every panel row including the new IB Health, packets/s, and Top-10 ones.
- **Troubleshooting "cluster_id label not present"** bullet broadened to mention all three `label_values` sources used across dashboards.
- **Limitations bullet** "Slurm metrics" → rephrased as "Per-partition / per-user Slurm breakdown" since the cluster-level Slurm dashboard now exists.

## Test plan

Live verification on come-scale-away (B200, eu-norway1-a) after applying the regenerated ConfigMap:

- [x] Cluster RX Packets/s: **168 M pps**
- [x] Cluster TX Packets/s: **169 M pps**
- [x] Total RX Errors / TX Discards / Link Downed / Link Recovery / Remote Phys Errors / Local Link Integrity: all **0** (clean fabric)
- [x] Top-3 nodes by combined RX+TX: all three at **~4.36 GB/s**
- [x] All previous IB panels still populate (per-node RX/TX, utilization %, RX errors rate, TX-Wait)
- [x] All four other dashboards (GPU, Storage, Slurm) unchanged and still render correctly
- [x] All 8 dashboard JSONs parse with `json.load`; ConfigMap parses with `yaml.safe_load_all`