### PR TITLE
grafana-cmk: add GPU thermal section + fix $cluster variable default

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -260,7 +260,10 @@ All dashboards live in the `Crusoe` folder in Grafana. Most have a **Cluster** d
 
 ### GPU dashboards
 
-**Cluster GPU Overview (`cluster-gpu-overview.json`)** — cluster-wide GPU health and utilization. Total GPUs / nodes, average utilization gauge with 70%/90% thresholds, per-node utilization time series, memory used vs total, power draw by node, top-10 nodes by utilization.
+**Cluster GPU Overview (`cluster-gpu-overview.json`, 14 panels)** — cluster-wide GPU health, utilization, and thermals.
+
+- **Utilization + capacity**: Total GPUs / nodes, average utilization gauge (70%/90% thresholds), per-node utilization time series, memory used vs total, power draw by node, top-10 nodes by utilization.
+- **Thermal section**: stat row (Hottest GPU, Cluster Avg, GPUs ≥80°C, GPUs ≥85°C slowdown threshold) sourced from `DCGM_FI_DEV_GPU_TEMP`, a full-width **Top 10 Hottest Nodes** bar gauge, and a full-width **Per-Node Max GPU Temp Over Time** line graph below. Thresholds use green <70°C / yellow 70–80°C / red ≥80°C throughout. HBM memory temperature (`DCGM_FI_DEV_MEMORY_TEMP`) is available as a separate metric if you want to mirror this section for HBM later — currently surfaced only on the Node GPU Detail dashboard.
 
 **Node GPU Detail (`node-gpu-detail.json`)** — per-GPU breakdown for one node. Utilization per device, memory used, temperature with 75 °C / 85 °C thresholds, power draw, and SM/memory clocks (useful for spotting thermal throttling).
 

--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -260,7 +260,7 @@ All dashboards live in the `Crusoe` folder in Grafana. Most have a **Cluster** d
 
 ### GPU dashboards
 
-**Cluster GPU Overview (`cluster-gpu-overview.json`, 14 panels)** — cluster-wide GPU health, utilization, and thermals.
+**Cluster GPU Overview (`cluster-gpu-overview.json`, 13 panels)** — cluster-wide GPU health, utilization, and thermals.
 
 - **Utilization + capacity**: Total GPUs / nodes, average utilization gauge (70%/90% thresholds), per-node utilization time series, memory used vs total, power draw by node, top-10 nodes by utilization.
 - **Thermal section**: stat row (Hottest GPU, Cluster Avg, GPUs ≥80°C, GPUs ≥85°C slowdown threshold) sourced from `DCGM_FI_DEV_GPU_TEMP`, a full-width **Top 10 Hottest Nodes** bar gauge, and a full-width **Per-Node Max GPU Temp Over Time** line graph below. Thresholds use green <70°C / yellow 70–80°C / red ≥80°C throughout. HBM memory temperature (`DCGM_FI_DEV_MEMORY_TEMP`) is available as a separate metric if you want to mirror this section for HBM later — currently surfaced only on the Node GPU Detail dashboard.

--- a/grafana-cmk/dashboards/cluster-gpu-overview.json
+++ b/grafana-cmk/dashboards/cluster-gpu-overview.json
@@ -11,18 +11,51 @@
   ],
   "__elements": {},
   "__requires": [
-    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "11.0.0"},
-    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"},
-    {"type": "panel", "id": "stat", "name": "Stat", "version": ""},
-    {"type": "panel", "id": "gauge", "name": "Gauge", "version": ""},
-    {"type": "panel", "id": "timeseries", "name": "Time series", "version": ""},
-    {"type": "panel", "id": "bargauge", "name": "Bar gauge", "version": ""}
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    }
   ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -39,31 +72,59 @@
   "links": [],
   "panels": [
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Total number of GPU time series currently reporting. One time series per GPU device.",
       "fieldConfig": {
         "defaults": {
-          "color": {"fixedColor": "blue", "mode": "fixed"},
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
           "mappings": [],
-          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "count(DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
           "instant": true,
           "legendFormat": "",
@@ -74,31 +135,59 @@
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Number of distinct nodes reporting GPU metrics.\n\nThe 'node' label is the standard Prometheus scrape target label; it represents the node hostname as set by the Crusoe Watch Agent. If the variable dropdown is empty, check what labels are present on DCGM_FI_DEV_GPU_UTIL by running the scrape discovery curl in the Troubleshooting section.",
       "fieldConfig": {
         "defaults": {
-          "color": {"fixedColor": "blue", "mode": "fixed"},
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
           "mappings": [],
-          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
       "id": 2,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "count(count by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
           "instant": true,
           "legendFormat": "",
@@ -109,39 +198,67 @@
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Current cluster-wide average GPU utilization across all GPUs and all nodes.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 70},
-              {"color": "red", "value": 90}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
             ]
           },
           "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
       "id": 3,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
         "orientation": "auto",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
           "instant": true,
           "legendFormat": "Avg",
@@ -152,11 +269,16 @@
       "type": "gauge"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "GPU utilization over time, averaged per node (by node label).",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -167,39 +289,73 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": {"type": "linear"},
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": true,
-            "stacking": {"group": "A", "mode": "none"},
-            "thresholdsStyle": {"mode": "off"}
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "max": 100,
           "min": 0,
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8},
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
       "id": 4,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "avg by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
           "legendFormat": "{{node}}",
           "refId": "A"
@@ -209,11 +365,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Cluster-wide GPU framebuffer memory used (stacked) vs total capacity (dashed red line). DCGM_FI_DEV_FB_USED and DCGM_FI_DEV_FB_FREE are reported in MiB.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -224,69 +385,140 @@
             "drawStyle": "line",
             "fillOpacity": 20,
             "gradientMode": "none",
-            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": {"type": "linear"},
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": true,
-            "stacking": {"group": "A", "mode": "normal"},
-            "thresholdsStyle": {"mode": "off"}
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "min": 0,
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "mebibytes"
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Total Capacity"},
+            "matcher": {
+              "id": "byName",
+              "options": "Total Capacity"
+            },
             "properties": [
-              {"id": "custom.stacking", "value": {"mode": "none"}},
-              {"id": "custom.fillOpacity", "value": 0},
-              {"id": "custom.lineStyle", "value": {"dash": [10, 10], "fill": "dash"}},
-              {"id": "custom.lineWidth", "value": 2},
-              {"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
             ]
           }
         ]
       },
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum(DCGM_FI_DEV_FB_USED{cluster_id=~\"$cluster\"})",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum(DCGM_FI_DEV_FB_USED{cluster_id=~\"$cluster\"} + DCGM_FI_DEV_FB_FREE{cluster_id=~\"$cluster\"})",
           "legendFormat": "Total Capacity",
           "refId": "B"
         }
       ],
-      "title": "Cluster GPU Memory — Used vs Total",
+      "title": "Cluster GPU Memory \u2014 Used vs Total",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Total GPU power draw per node across the cluster. DCGM_FI_DEV_POWER_USAGE is reported in watts.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -297,38 +529,72 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": {"type": "linear"},
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": true,
-            "stacking": {"group": "A", "mode": "none"},
-            "thresholdsStyle": {"mode": "off"}
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "min": 0,
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "watt"
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
           "legendFormat": "{{node}}",
           "refId": "A"
@@ -338,27 +604,46 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Top 10 nodes by current average GPU utilization. Useful for identifying hot nodes or underutilized capacity.\n\nTODO: Verify 'node' label name.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 70},
-              {"color": "red", "value": 90}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
             ]
           },
           "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 32},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
       "id": 7,
       "options": {
         "displayMode": "gradient",
@@ -366,13 +651,22 @@
         "minVizWidth": 0,
         "namePlacement": "auto",
         "orientation": "horizontal",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showUnfilled": true,
         "valueMode": "color"
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "topk(10, avg by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
           "instant": true,
           "legendFormat": "{{node}}",
@@ -381,17 +675,381 @@
       ],
       "title": "Top 10 Nodes by Avg GPU Utilization",
       "type": "bargauge"
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Hottest GPU Right Now",
+      "description": "Maximum GPU die temperature across every GPU in the selected cluster right now. Green <70\u00b0C, yellow 70-80\u00b0C, red \u226580\u00b0C.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 42,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "max(DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "gauge",
+      "title": "Cluster Avg GPU Temp",
+      "description": "Average GPU die temperature across every GPU. Gauge with thresholds: green <70\u00b0C, yellow 70-80\u00b0C, red \u226580\u00b0C.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 42,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "avg(DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "GPUs \u2265 80\u00b0C",
+      "description": "Number of GPUs currently at or above 80\u00b0C. Worth a look on any non-zero \u2014 80\u00b0C is the typical caution threshold; sustained operation above will start affecting boost behavior.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 42,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "(count(DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"} >= 80)) or vector(0)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "GPUs \u2265 85\u00b0C (slowdown)",
+      "description": "Number of GPUs currently at or above 85\u00b0C \u2014 the typical thermal-slowdown threshold on H100/B200 SXM. Any non-zero value means GPUs are throttling and your job throughput is impacted.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 42,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "(count(DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"} >= 85)) or vector(0)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "bargauge",
+      "title": "Top 10 Hottest Nodes (max GPU temp)",
+      "description": "Ten nodes whose hottest GPU is currently warmest. The bar value is the max die temp on that node \u2014 useful for narrowing thermal pressure to specific nodes vs the whole cluster.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 46,
+        "w": 24,
+        "h": 10
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(10, max by (node) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"}))",
+          "instant": true,
+          "legendFormat": "{{node}}"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Per-Node Max GPU Temp Over Time",
+      "description": "Max GPU die temperature per node over time. Hot lines visually pop above the cluster norm. Legend hidden to handle large fleets \u2014 click a line to identify the node.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 56,
+        "w": 24,
+        "h": 8
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "custom": {
+            "fillOpacity": 10,
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "max by (node) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
+          "legendFormat": "{{node}}"
+        }
+      ]
     }
   ],
   "refresh": "1m",
   "schemaVersion": 39,
-  "tags": ["crusoe", "gpu", "kubernetes"],
+  "tags": [
+    "crusoe",
+    "gpu",
+    "kubernetes"
+  ],
   "templating": {
     "list": [
       {
         "allValue": ".*",
-        "current": {},
-        "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
         "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, cluster_id)",
         "hide": 0,
         "includeAll": true,
@@ -410,11 +1068,14 @@
       }
     ]
   },
-  "time": {"from": "now-6h", "to": "now"},
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Crusoe — Cluster GPU Overview",
+  "title": "Crusoe \u2014 Cluster GPU Overview",
   "uid": "crusoe-cluster-gpu-overview",
-  "version": 1,
+  "version": 5,
   "weekStart": ""
 }

--- a/grafana-cmk/dashboards/cluster-gpu-power.json
+++ b/grafana-cmk/dashboards/cluster-gpu-power.json
@@ -11,17 +11,45 @@
   ],
   "__elements": {},
   "__requires": [
-    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "11.0.0"},
-    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"},
-    {"type": "panel", "id": "stat", "name": "Stat", "version": ""},
-    {"type": "panel", "id": "timeseries", "name": "Time series", "version": ""},
-    {"type": "panel", "id": "bargauge", "name": "Bar gauge", "version": ""}
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    }
   ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -41,7 +69,10 @@
       "icon": "arrow-left",
       "includeVars": false,
       "keepTime": true,
-      "tags": ["crusoe", "gpu"],
+      "tags": [
+        "crusoe",
+        "gpu"
+      ],
       "targetBlank": false,
       "title": "Cluster GPU Overview",
       "tooltip": "",
@@ -51,38 +82,66 @@
   ],
   "panels": [
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Total instantaneous GPU power draw across all nodes in the cluster. Sum of DCGM_FI_DEV_POWER_USAGE for all GPUs matching the selected cluster.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 5600},
-              {"color": "red", "value": 8960}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5600
+              },
+              {
+                "color": "red",
+                "value": 8960
+              }
             ]
           },
           "unit": "watt"
         },
         "overrides": []
       },
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
           "instant": true,
           "legendFormat": "",
@@ -93,38 +152,66 @@
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-      "description": "Average instantaneous power draw per GPU across the cluster. H100 SXM5 TDP is 700 W; sustained workloads typically draw 400–650 W per GPU.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "description": "Average instantaneous power draw per GPU across the cluster. H100 SXM5 TDP is 700 W; sustained workloads typically draw 400\u2013650 W per GPU.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 350},
-              {"color": "red", "value": 560}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 350
+              },
+              {
+                "color": "red",
+                "value": 560
+              }
             ]
           },
           "unit": "watt"
         },
         "overrides": []
       },
-      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
       "id": 2,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "avg(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
           "instant": true,
           "legendFormat": "",
@@ -135,38 +222,66 @@
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Peak total cluster power draw observed within the selected time range.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 5600},
-              {"color": "red", "value": 8960}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5600
+              },
+              {
+                "color": "red",
+                "value": 8960
+              }
             ]
           },
           "unit": "watt"
         },
         "overrides": []
       },
-      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
       "id": 3,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {"calcs": ["max"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
           "instant": false,
           "legendFormat": "",
@@ -177,34 +292,59 @@
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-      "description": "Total GPU energy consumed across the cluster during the selected time range. Derived from DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION (cumulative millijoules) using increase() over the dashboard range.\n\nFormula: increase(mJ) ÷ 3.6×10⁹ = kWh",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "description": "Total GPU energy consumed across the cluster during the selected time range. Derived from DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION (cumulative millijoules) using increase() over the dashboard range.\n\nFormula: increase(mJ) \u00f7 3.6\u00d710\u2079 = kWh",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "fixed", "fixedColor": "blue"},
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{"color": "blue", "value": null}]
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
           },
           "unit": "kwatth"
         },
         "overrides": []
       },
-      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
       "id": 4,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum(increase(DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{cluster_id=~\"$cluster\"}[$__range])) / 3600000000",
           "instant": true,
           "legendFormat": "",
@@ -215,11 +355,16 @@
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-      "description": "Total GPU power draw across the entire cluster over time. The dashed threshold line at 11,200 W represents 100% TDP for 16× H100 SXM5 GPUs (700 W each). Adjust if your node count or GPU model differs.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "description": "Total GPU power draw across the entire cluster over time. The dashed threshold line at 11,200 W represents 100% TDP for 16\u00d7 H100 SXM5 GPUs (700 W each). Adjust if your node count or GPU model differs.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -230,44 +375,76 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "gradientMode": "none",
-            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": {"type": "linear"},
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": true,
-            "stacking": {"group": "A", "mode": "none"},
-            "thresholdsStyle": {"mode": "dashed"}
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
           },
           "mappings": [],
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "red", "value": 11200}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 11200
+              }
             ]
           },
           "unit": "watt"
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 4},
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
           "legendFormat": "Total",
           "refId": "A"
@@ -277,11 +454,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "GPU power draw per node over time. Each line is one node (sum across all GPUs on that node). Useful for comparing nodes and detecting imbalanced workloads.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -292,38 +474,72 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": {"type": "linear"},
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": true,
-            "stacking": {"group": "A", "mode": "none"},
-            "thresholdsStyle": {"mode": "off"}
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "min": 0,
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "watt"
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
           "legendFormat": "{{node}}",
           "refId": "A"
@@ -333,27 +549,46 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-      "description": "Current power draw per node as a bar gauge. Max value is set to 5,600 W (8× H100 SXM5 at 700 W TDP each). Adjust if your node has a different GPU count or model.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "description": "Current power draw per node as a bar gauge. Max value is set to 5,600 W (8\u00d7 H100 SXM5 at 700 W TDP each). Adjust if your node has a different GPU count or model.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "max": 5600,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 2800},
-              {"color": "red", "value": 4480}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2800
+              },
+              {
+                "color": "red",
+                "value": 4480
+              }
             ]
           },
           "unit": "watt"
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
       "id": 7,
       "options": {
         "displayMode": "gradient",
@@ -361,13 +596,22 @@
         "minVizWidth": 0,
         "namePlacement": "auto",
         "orientation": "horizontal",
-        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showUnfilled": true,
         "valueMode": "color"
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
           "instant": true,
           "legendFormat": "{{node}}",
@@ -378,11 +622,16 @@
       "type": "bargauge"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "GPU power draw vs GPU utilization over time, overlaid on a dual-axis chart. A flat power line with low utilization suggests idle or memory-bound work. Rising power tracking rising utilization indicates a compute-bound workload.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -393,60 +642,117 @@
             "drawStyle": "line",
             "fillOpacity": 5,
             "gradientMode": "none",
-            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": {"type": "linear"},
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": true,
-            "stacking": {"group": "A", "mode": "none"},
-            "thresholdsStyle": {"mode": "off"}
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "min": 0,
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "watt"
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Avg Utilization %"},
+            "matcher": {
+              "id": "byName",
+              "options": "Avg Utilization %"
+            },
             "properties": [
-              {"id": "unit", "value": "percent"},
-              {"id": "max", "value": 100},
-              {"id": "custom.axisPlacement", "value": "right"},
-              {"id": "custom.axisLabel", "value": "Utilization (%)"}
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Utilization (%)"
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "Total Power W"},
+            "matcher": {
+              "id": "byName",
+              "options": "Total Power W"
+            },
             "properties": [
-              {"id": "custom.axisLabel", "value": "Power (W)"}
+              {
+                "id": "custom.axisLabel",
+                "value": "Power (W)"
+              }
             ]
           }
         ]
       },
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 20},
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
           "legendFormat": "Total Power W",
           "refId": "A"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
           "legendFormat": "Avg Utilization %",
           "refId": "B"
@@ -458,12 +764,23 @@
   ],
   "refresh": "1m",
   "schemaVersion": 39,
-  "tags": ["crusoe", "gpu", "power"],
+  "tags": [
+    "crusoe",
+    "gpu",
+    "power"
+  ],
   "templating": {
     "list": [
       {
-        "current": {},
-        "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
         "definition": "label_values(DCGM_FI_DEV_POWER_USAGE, cluster_id)",
         "hide": 0,
         "includeAll": true,
@@ -483,11 +800,14 @@
       }
     ]
   },
-  "time": {"from": "now-3h", "to": "now"},
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Crusoe — Cluster GPU Power",
+  "title": "Crusoe \u2014 Cluster GPU Power",
   "uid": "crusoe-cluster-power",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  cluster-gpu-overview.json: |
+  cluster-gpu-overview.json: |-
     {
       "__inputs": [
         {
@@ -14,18 +14,51 @@ data:
       ],
       "__elements": {},
       "__requires": [
-        {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "11.0.0"},
-        {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"},
-        {"type": "panel", "id": "stat", "name": "Stat", "version": ""},
-        {"type": "panel", "id": "gauge", "name": "Gauge", "version": ""},
-        {"type": "panel", "id": "timeseries", "name": "Time series", "version": ""},
-        {"type": "panel", "id": "bargauge", "name": "Bar gauge", "version": ""}
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "11.0.0"
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "stat",
+          "name": "Stat",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "gauge",
+          "name": "Gauge",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "timeseries",
+          "name": "Time series",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "bargauge",
+          "name": "Bar gauge",
+          "version": ""
+        }
       ],
       "annotations": {
         "list": [
           {
             "builtIn": 1,
-            "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
             "enable": true,
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
@@ -42,31 +75,59 @@ data:
       "links": [],
       "panels": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "Total number of GPU time series currently reporting. One time series per GPU device.",
           "fieldConfig": {
             "defaults": {
-              "color": {"fixedColor": "blue", "mode": "fixed"},
+              "color": {
+                "fixedColor": "blue",
+                "mode": "fixed"
+              },
               "mappings": [],
-              "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
               "unit": "short"
             },
             "overrides": []
           },
-          "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 0
+          },
           "id": 1,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
-            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
             "textMode": "auto",
             "wideLayout": true
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "count(DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
               "instant": true,
               "legendFormat": "",
@@ -77,31 +138,59 @@ data:
           "type": "stat"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "Number of distinct nodes reporting GPU metrics.\n\nThe 'node' label is the standard Prometheus scrape target label; it represents the node hostname as set by the Crusoe Watch Agent. If the variable dropdown is empty, check what labels are present on DCGM_FI_DEV_GPU_UTIL by running the scrape discovery curl in the Troubleshooting section.",
           "fieldConfig": {
             "defaults": {
-              "color": {"fixedColor": "blue", "mode": "fixed"},
+              "color": {
+                "fixedColor": "blue",
+                "mode": "fixed"
+              },
               "mappings": [],
-              "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
               "unit": "short"
             },
             "overrides": []
           },
-          "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 0
+          },
           "id": 2,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
-            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
             "textMode": "auto",
             "wideLayout": true
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "count(count by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
               "instant": true,
               "legendFormat": "",
@@ -112,39 +201,67 @@ data:
           "type": "stat"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "Current cluster-wide average GPU utilization across all GPUs and all nodes.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "thresholds"},
+              "color": {
+                "mode": "thresholds"
+              },
               "mappings": [],
               "max": 100,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  {"color": "green", "value": null},
-                  {"color": "yellow", "value": 70},
-                  {"color": "red", "value": 90}
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
                 ]
               },
               "unit": "percent"
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 0
+          },
           "id": 3,
           "options": {
             "minVizHeight": 75,
             "minVizWidth": 75,
             "orientation": "auto",
-            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
               "instant": true,
               "legendFormat": "Avg",
@@ -155,11 +272,16 @@ data:
           "type": "gauge"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "GPU utilization over time, averaged per node (by node label).",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
@@ -170,39 +292,73 @@ data:
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
-                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
-                "scaleDistribution": {"type": "linear"},
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "never",
                 "spanNulls": true,
-                "stacking": {"group": "A", "mode": "none"},
-                "thresholdsStyle": {"mode": "off"}
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "max": 100,
               "min": 0,
-              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
               "unit": "percent"
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8},
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
           "id": 4,
           "options": {
             "legend": {
-              "calcs": ["mean", "max", "lastNotNull"],
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ],
               "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
             },
-            "tooltip": {"mode": "multi", "sort": "desc"}
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "avg by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
               "legendFormat": "{{node}}",
               "refId": "A"
@@ -212,11 +368,16 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "Cluster-wide GPU framebuffer memory used (stacked) vs total capacity (dashed red line). DCGM_FI_DEV_FB_USED and DCGM_FI_DEV_FB_FREE are reported in MiB.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
@@ -227,69 +388,140 @@ data:
                 "drawStyle": "line",
                 "fillOpacity": 20,
                 "gradientMode": "none",
-                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
-                "scaleDistribution": {"type": "linear"},
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "never",
                 "spanNulls": true,
-                "stacking": {"group": "A", "mode": "normal"},
-                "thresholdsStyle": {"mode": "off"}
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "min": 0,
-              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
               "unit": "mebibytes"
             },
             "overrides": [
               {
-                "matcher": {"id": "byName", "options": "Total Capacity"},
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total Capacity"
+                },
                 "properties": [
-                  {"id": "custom.stacking", "value": {"mode": "none"}},
-                  {"id": "custom.fillOpacity", "value": 0},
-                  {"id": "custom.lineStyle", "value": {"dash": [10, 10], "fill": "dash"}},
-                  {"id": "custom.lineWidth", "value": 2},
-                  {"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}
+                  {
+                    "id": "custom.stacking",
+                    "value": {
+                      "mode": "none"
+                    }
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "dash": [
+                        10,
+                        10
+                      ],
+                      "fill": "dash"
+                    }
+                  },
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
                 ]
               }
             ]
           },
-          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
           "id": 5,
           "options": {
             "legend": {
-              "calcs": ["mean", "max", "lastNotNull"],
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ],
               "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
             },
-            "tooltip": {"mode": "multi", "sort": "desc"}
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum(DCGM_FI_DEV_FB_USED{cluster_id=~\"$cluster\"})",
               "legendFormat": "Used",
               "refId": "A"
             },
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum(DCGM_FI_DEV_FB_USED{cluster_id=~\"$cluster\"} + DCGM_FI_DEV_FB_FREE{cluster_id=~\"$cluster\"})",
               "legendFormat": "Total Capacity",
               "refId": "B"
             }
           ],
-          "title": "Cluster GPU Memory — Used vs Total",
+          "title": "Cluster GPU Memory \u2014 Used vs Total",
           "type": "timeseries"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "Total GPU power draw per node across the cluster. DCGM_FI_DEV_POWER_USAGE is reported in watts.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
@@ -300,38 +532,72 @@ data:
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
-                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
-                "scaleDistribution": {"type": "linear"},
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "never",
                 "spanNulls": true,
-                "stacking": {"group": "A", "mode": "none"},
-                "thresholdsStyle": {"mode": "off"}
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "min": 0,
-              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
               "unit": "watt"
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 24
+          },
           "id": 6,
           "options": {
             "legend": {
-              "calcs": ["mean", "max", "lastNotNull"],
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ],
               "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
             },
-            "tooltip": {"mode": "multi", "sort": "desc"}
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
               "legendFormat": "{{node}}",
               "refId": "A"
@@ -341,27 +607,46 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "Top 10 nodes by current average GPU utilization. Useful for identifying hot nodes or underutilized capacity.\n\nTODO: Verify 'node' label name.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "thresholds"},
+              "color": {
+                "mode": "thresholds"
+              },
               "mappings": [],
               "max": 100,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  {"color": "green", "value": null},
-                  {"color": "yellow", "value": 70},
-                  {"color": "red", "value": 90}
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
                 ]
               },
               "unit": "percent"
             },
             "overrides": []
           },
-          "gridPos": {"h": 10, "w": 24, "x": 0, "y": 32},
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          },
           "id": 7,
           "options": {
             "displayMode": "gradient",
@@ -369,13 +654,22 @@ data:
             "minVizWidth": 0,
             "namePlacement": "auto",
             "orientation": "horizontal",
-            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
             "showUnfilled": true,
             "valueMode": "color"
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "topk(10, avg by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
               "instant": true,
               "legendFormat": "{{node}}",
@@ -384,17 +678,381 @@ data:
           ],
           "title": "Top 10 Nodes by Avg GPU Utilization",
           "type": "bargauge"
+        },
+        {
+          "id": 8,
+          "type": "stat",
+          "title": "Hottest GPU Right Now",
+          "description": "Maximum GPU die temperature across every GPU in the selected cluster right now. Green <70\u00b0C, yellow 70-80\u00b0C, red \u226580\u00b0C.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 42,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "celsius",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "max(DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "type": "gauge",
+          "title": "Cluster Avg GPU Temp",
+          "description": "Average GPU die temperature across every GPU. Gauge with thresholds: green <70\u00b0C, yellow 70-80\u00b0C, red \u226580\u00b0C.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 6,
+            "y": 42,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "celsius",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "avg(DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "type": "stat",
+          "title": "GPUs \u2265 80\u00b0C",
+          "description": "Number of GPUs currently at or above 80\u00b0C. Worth a look on any non-zero \u2014 80\u00b0C is the typical caution threshold; sustained operation above will start affecting boost behavior.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 42,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "(count(DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"} >= 80)) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 11,
+          "type": "stat",
+          "title": "GPUs \u2265 85\u00b0C (slowdown)",
+          "description": "Number of GPUs currently at or above 85\u00b0C \u2014 the typical thermal-slowdown threshold on H100/B200 SXM. Any non-zero value means GPUs are throttling and your job throughput is impacted.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 18,
+            "y": 42,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "(count(DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"} >= 85)) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "id": 13,
+          "type": "bargauge",
+          "title": "Top 10 Hottest Nodes (max GPU temp)",
+          "description": "Ten nodes whose hottest GPU is currently warmest. The bar value is the max die temp on that node \u2014 useful for narrowing thermal pressure to specific nodes vs the whole cluster.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 46,
+            "w": 24,
+            "h": 10
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "showUnfilled": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "celsius",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "topk(10, max by (node) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"}))",
+              "instant": true,
+              "legendFormat": "{{node}}"
+            }
+          ]
+        },
+        {
+          "id": 14,
+          "type": "timeseries",
+          "title": "Per-Node Max GPU Temp Over Time",
+          "description": "Max GPU die temperature per node over time. Hot lines visually pop above the cluster norm. Legend hidden to handle large fleets \u2014 click a line to identify the node.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 56,
+            "w": 24,
+            "h": 8
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "celsius",
+              "custom": {
+                "fillOpacity": 10,
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 70
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "max by (node) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
+              "legendFormat": "{{node}}"
+            }
+          ]
         }
       ],
       "refresh": "1m",
       "schemaVersion": 39,
-      "tags": ["crusoe", "gpu", "kubernetes"],
+      "tags": [
+        "crusoe",
+        "gpu",
+        "kubernetes"
+      ],
       "templating": {
         "list": [
           {
             "allValue": ".*",
-            "current": {},
-            "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
             "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, cluster_id)",
             "hide": 0,
             "includeAll": true,
@@ -413,15 +1071,18 @@ data:
           }
         ]
       },
-      "time": {"from": "now-6h", "to": "now"},
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
       "timepicker": {},
       "timezone": "browser",
-      "title": "Crusoe — Cluster GPU Overview",
+      "title": "Crusoe \u2014 Cluster GPU Overview",
       "uid": "crusoe-cluster-gpu-overview",
-      "version": 1,
+      "version": 5,
       "weekStart": ""
     }
-  cluster-gpu-power.json: |
+  cluster-gpu-power.json: |-
     {
       "__inputs": [
         {
@@ -435,17 +1096,45 @@ data:
       ],
       "__elements": {},
       "__requires": [
-        {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "11.0.0"},
-        {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"},
-        {"type": "panel", "id": "stat", "name": "Stat", "version": ""},
-        {"type": "panel", "id": "timeseries", "name": "Time series", "version": ""},
-        {"type": "panel", "id": "bargauge", "name": "Bar gauge", "version": ""}
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "11.0.0"
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "stat",
+          "name": "Stat",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "timeseries",
+          "name": "Time series",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "bargauge",
+          "name": "Bar gauge",
+          "version": ""
+        }
       ],
       "annotations": {
         "list": [
           {
             "builtIn": 1,
-            "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
             "enable": true,
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
@@ -465,7 +1154,10 @@ data:
           "icon": "arrow-left",
           "includeVars": false,
           "keepTime": true,
-          "tags": ["crusoe", "gpu"],
+          "tags": [
+            "crusoe",
+            "gpu"
+          ],
           "targetBlank": false,
           "title": "Cluster GPU Overview",
           "tooltip": "",
@@ -475,38 +1167,66 @@ data:
       ],
       "panels": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "Total instantaneous GPU power draw across all nodes in the cluster. Sum of DCGM_FI_DEV_POWER_USAGE for all GPUs matching the selected cluster.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "thresholds"},
+              "color": {
+                "mode": "thresholds"
+              },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  {"color": "green", "value": null},
-                  {"color": "yellow", "value": 5600},
-                  {"color": "red", "value": 8960}
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5600
+                  },
+                  {
+                    "color": "red",
+                    "value": 8960
+                  }
                 ]
               },
               "unit": "watt"
             },
             "overrides": []
           },
-          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          },
           "id": 1,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
-            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
             "textMode": "auto",
             "wideLayout": true
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
               "instant": true,
               "legendFormat": "",
@@ -517,38 +1237,66 @@ data:
           "type": "stat"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "description": "Average instantaneous power draw per GPU across the cluster. H100 SXM5 TDP is 700 W; sustained workloads typically draw 400–650 W per GPU.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "description": "Average instantaneous power draw per GPU across the cluster. H100 SXM5 TDP is 700 W; sustained workloads typically draw 400\u2013650 W per GPU.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "thresholds"},
+              "color": {
+                "mode": "thresholds"
+              },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  {"color": "green", "value": null},
-                  {"color": "yellow", "value": 350},
-                  {"color": "red", "value": 560}
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 350
+                  },
+                  {
+                    "color": "red",
+                    "value": 560
+                  }
                 ]
               },
               "unit": "watt"
             },
             "overrides": []
           },
-          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          },
           "id": 2,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
-            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
             "textMode": "auto",
             "wideLayout": true
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "avg(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
               "instant": true,
               "legendFormat": "",
@@ -559,38 +1307,66 @@ data:
           "type": "stat"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "Peak total cluster power draw observed within the selected time range.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "thresholds"},
+              "color": {
+                "mode": "thresholds"
+              },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  {"color": "green", "value": null},
-                  {"color": "yellow", "value": 5600},
-                  {"color": "red", "value": 8960}
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5600
+                  },
+                  {
+                    "color": "red",
+                    "value": 8960
+                  }
                 ]
               },
               "unit": "watt"
             },
             "overrides": []
           },
-          "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 0
+          },
           "id": 3,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
-            "reduceOptions": {"calcs": ["max"], "fields": "", "values": false},
+            "reduceOptions": {
+              "calcs": [
+                "max"
+              ],
+              "fields": "",
+              "values": false
+            },
             "textMode": "auto",
             "wideLayout": true
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
               "instant": false,
               "legendFormat": "",
@@ -601,34 +1377,59 @@ data:
           "type": "stat"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "description": "Total GPU energy consumed across the cluster during the selected time range. Derived from DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION (cumulative millijoules) using increase() over the dashboard range.\n\nFormula: increase(mJ) ÷ 3.6×10⁹ = kWh",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "description": "Total GPU energy consumed across the cluster during the selected time range. Derived from DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION (cumulative millijoules) using increase() over the dashboard range.\n\nFormula: increase(mJ) \u00f7 3.6\u00d710\u2079 = kWh",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "fixed", "fixedColor": "blue"},
+              "color": {
+                "mode": "fixed",
+                "fixedColor": "blue"
+              },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{"color": "blue", "value": null}]
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
               },
               "unit": "kwatth"
             },
             "overrides": []
           },
-          "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 0
+          },
           "id": 4,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
-            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
             "textMode": "auto",
             "wideLayout": true
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum(increase(DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{cluster_id=~\"$cluster\"}[$__range])) / 3600000000",
               "instant": true,
               "legendFormat": "",
@@ -639,11 +1440,16 @@ data:
           "type": "stat"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "description": "Total GPU power draw across the entire cluster over time. The dashed threshold line at 11,200 W represents 100% TDP for 16× H100 SXM5 GPUs (700 W each). Adjust if your node count or GPU model differs.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "description": "Total GPU power draw across the entire cluster over time. The dashed threshold line at 11,200 W represents 100% TDP for 16\u00d7 H100 SXM5 GPUs (700 W each). Adjust if your node count or GPU model differs.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
@@ -654,44 +1460,76 @@ data:
                 "drawStyle": "line",
                 "fillOpacity": 15,
                 "gradientMode": "none",
-                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 2,
                 "pointSize": 5,
-                "scaleDistribution": {"type": "linear"},
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "never",
                 "spanNulls": true,
-                "stacking": {"group": "A", "mode": "none"},
-                "thresholdsStyle": {"mode": "dashed"}
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "dashed"
+                }
               },
               "mappings": [],
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  {"color": "green", "value": null},
-                  {"color": "red", "value": 11200}
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 11200
+                  }
                 ]
               },
               "unit": "watt"
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 4},
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 4
+          },
           "id": 5,
           "options": {
             "legend": {
-              "calcs": ["mean", "max", "lastNotNull"],
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ],
               "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
             },
-            "tooltip": {"mode": "multi", "sort": "desc"}
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
               "legendFormat": "Total",
               "refId": "A"
@@ -701,11 +1539,16 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "GPU power draw per node over time. Each line is one node (sum across all GPUs on that node). Useful for comparing nodes and detecting imbalanced workloads.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
@@ -716,38 +1559,72 @@ data:
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
-                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
-                "scaleDistribution": {"type": "linear"},
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "never",
                 "spanNulls": true,
-                "stacking": {"group": "A", "mode": "none"},
-                "thresholdsStyle": {"mode": "off"}
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "min": 0,
-              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
               "unit": "watt"
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
           "id": 6,
           "options": {
             "legend": {
-              "calcs": ["mean", "max", "lastNotNull"],
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ],
               "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
             },
-            "tooltip": {"mode": "multi", "sort": "desc"}
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
               "legendFormat": "{{node}}",
               "refId": "A"
@@ -757,27 +1634,46 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "description": "Current power draw per node as a bar gauge. Max value is set to 5,600 W (8× H100 SXM5 at 700 W TDP each). Adjust if your node has a different GPU count or model.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "description": "Current power draw per node as a bar gauge. Max value is set to 5,600 W (8\u00d7 H100 SXM5 at 700 W TDP each). Adjust if your node has a different GPU count or model.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "thresholds"},
+              "color": {
+                "mode": "thresholds"
+              },
               "mappings": [],
               "max": 5600,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  {"color": "green", "value": null},
-                  {"color": "yellow", "value": 2800},
-                  {"color": "red", "value": 4480}
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 2800
+                  },
+                  {
+                    "color": "red",
+                    "value": 4480
+                  }
                 ]
               },
               "unit": "watt"
             },
             "overrides": []
           },
-          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
           "id": 7,
           "options": {
             "displayMode": "gradient",
@@ -785,13 +1681,22 @@ data:
             "minVizWidth": 0,
             "namePlacement": "auto",
             "orientation": "horizontal",
-            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
             "showUnfilled": true,
             "valueMode": "color"
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
               "instant": true,
               "legendFormat": "{{node}}",
@@ -802,11 +1707,16 @@ data:
           "type": "bargauge"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
           "description": "GPU power draw vs GPU utilization over time, overlaid on a dual-axis chart. A flat power line with low utilization suggests idle or memory-bound work. Rising power tracking rising utilization indicates a compute-bound workload.",
           "fieldConfig": {
             "defaults": {
-              "color": {"mode": "palette-classic"},
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
@@ -817,60 +1727,117 @@ data:
                 "drawStyle": "line",
                 "fillOpacity": 5,
                 "gradientMode": "none",
-                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
-                "scaleDistribution": {"type": "linear"},
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "never",
                 "spanNulls": true,
-                "stacking": {"group": "A", "mode": "none"},
-                "thresholdsStyle": {"mode": "off"}
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "min": 0,
-              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
               "unit": "watt"
             },
             "overrides": [
               {
-                "matcher": {"id": "byName", "options": "Avg Utilization %"},
+                "matcher": {
+                  "id": "byName",
+                  "options": "Avg Utilization %"
+                },
                 "properties": [
-                  {"id": "unit", "value": "percent"},
-                  {"id": "max", "value": 100},
-                  {"id": "custom.axisPlacement", "value": "right"},
-                  {"id": "custom.axisLabel", "value": "Utilization (%)"}
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "max",
+                    "value": 100
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Utilization (%)"
+                  }
                 ]
               },
               {
-                "matcher": {"id": "byName", "options": "Total Power W"},
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total Power W"
+                },
                 "properties": [
-                  {"id": "custom.axisLabel", "value": "Power (W)"}
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "Power (W)"
+                  }
                 ]
               }
             ]
           },
-          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 20},
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 20
+          },
           "id": 8,
           "options": {
             "legend": {
-              "calcs": ["mean", "lastNotNull"],
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
               "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
             },
-            "tooltip": {"mode": "multi", "sort": "desc"}
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
           },
           "targets": [
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "sum(DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
               "legendFormat": "Total Power W",
               "refId": "A"
             },
             {
-              "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
               "expr": "avg(DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
               "legendFormat": "Avg Utilization %",
               "refId": "B"
@@ -882,12 +1849,23 @@ data:
       ],
       "refresh": "1m",
       "schemaVersion": 39,
-      "tags": ["crusoe", "gpu", "power"],
+      "tags": [
+        "crusoe",
+        "gpu",
+        "power"
+      ],
       "templating": {
         "list": [
           {
-            "current": {},
-            "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
             "definition": "label_values(DCGM_FI_DEV_POWER_USAGE, cluster_id)",
             "hide": 0,
             "includeAll": true,
@@ -907,12 +1885,15 @@ data:
           }
         ]
       },
-      "time": {"from": "now-3h", "to": "now"},
+      "time": {
+        "from": "now-3h",
+        "to": "now"
+      },
       "timepicker": {},
       "timezone": "browser",
-      "title": "Crusoe — Cluster GPU Power",
+      "title": "Crusoe \u2014 Cluster GPU Power",
       "uid": "crusoe-cluster-power",
-      "version": 1,
+      "version": 2,
       "weekStart": ""
     }
   cluster-ib-overview.json: |-


### PR DESCRIPTION
## Summary

Two related fixes for the Cluster GPU Overview dashboard, plus a parallel default-value fix for the Cluster GPU Power dashboard.

### 1. Thermal section in Cluster GPU Overview (7 → 13 panels)

DCGM publishes `DCGM_FI_DEV_GPU_TEMP` (1,544 series on come-scale-away — one per GPU), but the cluster dashboard didn't surface it anywhere; users had to drill into the per-node dashboard to see temperatures. Add a cluster-wide thermal section:

- **Stat row (4 panels):** Hottest GPU Right Now, Cluster Avg GPU Temp gauge (green <70 / yellow 70–80 / red ≥80), GPUs ≥ 80 °C (caution count), GPUs ≥ 85 °C (slowdown-threshold count).
- **Top 10 Hottest Nodes** bar gauge (24w) — max GPU temp per node.
- **Per-Node Max GPU Temp Over Time** line graph (24w) — legend hidden to handle large fleets.

Color thresholds (green <70 / yellow 70–80 / red ≥80) match what the existing Node GPU Detail dashboard uses for per-GPU temps. HBM memory temperature (`DCGM_FI_DEV_MEMORY_TEMP`) is published too and could be mirrored later if desired — kept this PR focused on GPU die temp.

> I initially included a Grafana **Histogram panel** for distribution shape, but with 1,544 single-value series the panel's auto-bucketing collapsed to a single flat bar and produced unreadable tooltips. The existing stats + top-10 + per-node line cover the cluster thermal story, so the histogram was removed rather than worked around with 14 hard-coded bucket queries.

### 2. Fix `\$cluster` variable defaulting to empty

Both `cluster-gpu-overview.json` and `cluster-gpu-power.json` shipped with `templating.list[].current = {}` for the `\$cluster` variable. On a fresh dashboard load Grafana couldn't resolve which value to pick and substituted `\$cluster = ""`. Every panel's `{cluster_id=~"\$cluster"}` filter then matched zero series, so the gauges showed **0% / "No data"** until the user manually picked from the dropdown — a defect inherited from the original PR #26 dashboards.

Set `current = {"text":"All","value":"\$__all","selected":true}` on both so the variable initializes to **All** (substitutes to `.+` via the existing `allValue`) on first load. Matches the pattern already used on the Storage, Slurm, and IB dashboards.

### 3. ConfigMap regenerated, README updated

`manifests/grafana-dashboards-configmap.yaml` regenerated against the updated dashboard JSONs. README's Cluster GPU Overview description expanded to list the new thermal panels.

## Test plan

Verified live on come-scale-away (B200 / 211 nodes / 1,544 GPUs):

- [x] Hottest GPU: **53 °C**; Cluster Avg: **45.8 °C**
- [x] GPUs ≥ 80 °C / ≥ 85 °C: **0 / 0** (clean fabric, no thermal pressure)
- [x] Top-3 hottest nodes all at 52–53 °C
- [x] Per-Node Max GPU Temp time series renders with one line per node
- [x] After the default fix, the **Cluster Avg GPU Utilization** gauge shows **~16%** on first load (matches direct PromQL `avg(DCGM_FI_DEV_GPU_UTIL{cluster_id=~".+"})`) instead of 0%
- [x] All 8 dashboard JSONs parse cleanly; ConfigMap YAML parses
- [x] No regressions on the other six dashboards