### PR TITLE
grafana-cmk: production hardening — node affinity, sizing, deployment checklist

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -539,13 +539,21 @@ The default `resources` block in `grafana-values.yaml` (200m / 512Mi requests, 1
 
 If you don't know your series count: `count(DCGM_FI_DEV_GPU_UTIL)` from the discovery curl in Troubleshooting gives a rough scale.
 
-Watch Grafana's own resource use after a load:
+Watch Grafana's own resource use after a load. Crusoe Managed Kubernetes does **not** ship a metrics-server by default, so `kubectl top` is unavailable. Two alternatives:
 
 ```bash
-kubectl top pod -n monitoring -l app.kubernetes.io/name=grafana --containers
+# 1. Read live cgroup stats from inside the Grafana container (no metrics-server needed):
+kubectl exec -n monitoring deployment/grafana -c grafana -- sh -c \
+  'echo "rss bytes: $(cat /sys/fs/cgroup/memory.current 2>/dev/null || cat /sys/fs/cgroup/memory/memory.usage_in_bytes)"'
+
+# 2. Or check the pod's last termination state for OOMKill evidence:
+kubectl get pod -n monitoring -l app.kubernetes.io/name=grafana \
+  -o jsonpath='{range .items[*].status.containerStatuses[?(@.name=="grafana")]}restartCount={.restartCount} lastReason={.lastState.terminated.reason} exitCode={.lastState.terminated.exitCode}{"\n"}{end}'
 ```
 
-The OOMKill we hit during testing at 512Mi limit / 1,700 series is the calibration point — if you see repeated container restarts or 137 exit codes in `kubectl describe pod`, double the memory limit and `helm upgrade`.
+The OOMKill we hit during testing at 512Mi limit / 1,700 series is the calibration point — if you see `lastReason=OOMKilled` or `exitCode=137` in the second command, or a non-zero `restartCount`, double the memory limit and `helm upgrade`.
+
+If you want `kubectl top` long-term, install the [metrics-server](https://github.com/kubernetes-sigs/metrics-server) yourself; it's not part of the Crusoe Managed Kubernetes default stack.
 
 ### Before exposing publicly
 
@@ -571,6 +579,12 @@ The repo ships a public LoadBalancer manifest for fast getting-started. Work thr
 - [ ] **`allowUiUpdates: false`** is already set in `grafana-values.yaml` so in-browser edits to provisioned dashboards aren't persisted across pod restarts. Don't change it unless you understand the trade-off.
 - [ ] **Decide on a backup strategy for `/var/lib/grafana/grafana.db`.** The PVC is single-replica RWO — if you lose the SSD or the namespace, all dashboard tweaks, alert rules, users, and annotations are gone. The repo's dashboards re-provision from `dashboards/*.json` on the next install, but UI-side changes don't. A nightly `kubectl exec ... sqlite3 .dump` to object storage is the lightweight option; switching Grafana to an external Postgres database is the durable option.
 - [ ] **Plan for token rotation.** Monitoring tokens don't auto-expire today, but treat them as rotatable. The Troubleshooting section's token-rotation steps are tested and survive a Grafana restart.
+
+---
+
+## Disclaimer
+
+This solution is provided **AS IS, WITHOUT WARRANTY OF ANY KIND**, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. The manifests, dashboards, scripts, and documentation in this directory are reference implementations intended to help you get started — they are not a supported Crusoe product and may not be appropriate for every deployment without customization. Use at your own risk; review the manifests against your security and operational requirements before applying them to production clusters.
 
 ---
 

--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -486,6 +486,94 @@ kubectl delete storageclass crusoe-csi-driver-ssd-sc   # optional — only if no
 
 ---
 
+## Production hardening
+
+Before exposing this Grafana to a team or running it long-term, work through this checklist. The defaults shipped in this repo are tuned for a getting-started install, not for production.
+
+### Pinning Grafana to CPU nodes
+
+By default, Kubernetes will schedule Grafana on whatever node has capacity — including expensive GPU workers. The `grafana-values.yaml` in this repo ships with a **hard nodeAffinity** that keeps Grafana off GPU nodes:
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: nvidia.com/gpu.present   # set by NVIDIA GPU Operator on every Crusoe GPU node
+              operator: DoesNotExist
+```
+
+`required` is the right default because a soft preference (`preferredDuringSchedulingIgnoredDuringExecution`) empirically isn't strong enough to override the scheduler's image-cache and PVC-locality heuristics on Crusoe CMK — Grafana stays on whatever GPU node the PVC was last attached to, even when CPU nodes are wide open. Verified on come-scale-away: soft preference left Grafana on a B200; switching to required moved it to a `c2a` node on the next rollout.
+
+Standard Crusoe CMK installs ship with `c1a` / `c2a` CPU nodes for system pods (Slurm controllers, login, etc.), so the hard pin is safe in practice. If your cluster is **GPU-only**, swap the block for the soft-preference variant below.
+
+**Variants depending on how strict you want to be:**
+
+| Goal | Replace the `affinity:` block above with |
+|---|---|
+| Soft preference (GPU-only clusters) | `preferredDuringSchedulingIgnoredDuringExecution` with `weight: 100` and the same `matchExpressions` wrapped under a `preference:` key. Grafana ranks non-GPU nodes higher but won't refuse to schedule on a GPU node. Use only if you have no non-GPU nodes — note that on the test cluster this didn't actually move Grafana off the GPU node, so use this knowing it may be a no-op. |
+| Pin to specific Crusoe CPU instance classes | Match on `crusoe.ai/instance.class` with `operator: In` and a `values: [c1a, c2a]` list (the current Crusoe CPU classes — see the [Crusoe Cloud VM overview](https://docs.crusoecloud.com/compute/virtual-machines/overview#cpu-vms) for the up-to-date list). More explicit; needs updating when Crusoe introduces new CPU instance types. |
+| Pin to a single instance type | Set `nodeSelector: {node.kubernetes.io/instance-type: c2a.8x}` instead of `affinity`. Simplest; least flexible. |
+
+Verify after a `helm upgrade`:
+
+```bash
+kubectl get pod -n monitoring -l app.kubernetes.io/name=grafana \
+  -o jsonpath='{.items[*].spec.nodeName}{"\n"}'
+kubectl get node <node-name> -o jsonpath='{.metadata.labels.node\.kubernetes\.io/instance-type}{"\n"}'
+```
+
+Grafana's pod should land on a node whose instance type doesn't start with `b200`, `h100`, `a100`, etc.
+
+### Sizing resource requests / limits
+
+The default `resources` block in `grafana-values.yaml` (200m / 512Mi requests, 1 CPU / 2Gi limit) was tuned for the come-scale-away test cluster (~1,700 DCGM series, 8 dashboards). For other fleet sizes:
+
+| Fleet size (DCGM series) | Suggested `requests` | Suggested `limits` |
+|---|---|---|
+| < 500 (one or two GPU nodes) | `100m` / `256Mi` | `500m` / `1Gi` |
+| 500 – 2,000 (small/medium) | `200m` / `512Mi` (default) | `1` / `2Gi` (default) |
+| 2,000 – 10,000 | `500m` / `1Gi` | `2` / `4Gi` |
+| 10,000+ | `1` / `2Gi` | `4` / `8Gi`, plus consider sharding |
+
+If you don't know your series count: `count(DCGM_FI_DEV_GPU_UTIL)` from the discovery curl in Troubleshooting gives a rough scale.
+
+Watch Grafana's own resource use after a load:
+
+```bash
+kubectl top pod -n monitoring -l app.kubernetes.io/name=grafana --containers
+```
+
+The OOMKill we hit during testing at 512Mi limit / 1,700 series is the calibration point — if you see repeated container restarts or 137 exit codes in `kubectl describe pod`, double the memory limit and `helm upgrade`.
+
+### Before exposing publicly
+
+The repo ships a public LoadBalancer manifest for fast getting-started. Work through this checklist before pointing real users at it:
+
+- [ ] **TLS termination.** Install `cert-manager` and switch from the bare `grafana-lb` Service to an Ingress with a cert (Let's Encrypt or your CA). The current `grafana-service-lb.yaml` exposes plain HTTP on port 3000.
+- [ ] **Auth in front of Grafana's UI.** Three reasonable options:
+  - [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) sidecar in front of the LB. Simplest if your org uses Google/GitHub/Okta SSO.
+  - Grafana's native [OAuth integration](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/) (set `[auth.generic_oauth]` via `grafana.ini`).
+  - Grafana's native [LDAP integration](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/ldap/).
+- [ ] **Restrict the LoadBalancer source range.** Edit `manifests/grafana-service-lb.yaml`:
+  ```yaml
+  spec:
+    loadBalancerSourceRanges:
+      - "<your-office-CIDR>"
+  ```
+  Once you have an authenticated ingress, you can relax this; until then it's the only thing between Grafana and the internet.
+- [ ] **Rotate the admin password.** The auto-generated default is fine for first login; change it via Grafana UI → admin → Edit profile, or:
+  ```bash
+  kubectl exec -n monitoring deployment/grafana -c grafana -- \
+    grafana-cli admin reset-admin-password '<new-password>'
+  ```
+- [ ] **`allowUiUpdates: false`** is already set in `grafana-values.yaml` so in-browser edits to provisioned dashboards aren't persisted across pod restarts. Don't change it unless you understand the trade-off.
+- [ ] **Decide on a backup strategy for `/var/lib/grafana/grafana.db`.** The PVC is single-replica RWO — if you lose the SSD or the namespace, all dashboard tweaks, alert rules, users, and annotations are gone. The repo's dashboards re-provision from `dashboards/*.json` on the next install, but UI-side changes don't. A nightly `kubectl exec ... sqlite3 .dump` to object storage is the lightweight option; switching Grafana to an external Postgres database is the durable option.
+- [ ] **Plan for token rotation.** Monitoring tokens don't auto-expire today, but treat them as rotatable. The Troubleshooting section's token-rotation steps are tested and survive a Grafana restart.
+
+---
+
 ## Limitations and next steps
 
 - **Minimum query interval is 60 seconds.** Crusoe Metrics collects samples every 60 seconds; querying more frequently returns the same data.
@@ -493,4 +581,4 @@ kubectl delete storageclass crusoe-csi-driver-ssd-sc   # optional — only if no
 - **Metrics only.** Logs and distributed traces are not available via Crusoe Metrics. For log aggregation on CMK, see the [CMK logs to GCP](../crusoe-managed-kubernetes-logs-to-gcp) solution in this repository.
 - **Label names.** Dashboards use the `node` label to identify nodes and the `gpu` label for GPU index. These are confirmed correct for Crusoe Metrics on Managed Slurm clusters. If variable dropdowns appear empty on a different cluster type, run the discovery curl in the Troubleshooting section to confirm the actual label names.
 - **Per-partition / per-user Slurm breakdown.** The Slurm Cluster View aggregates to the cluster level. `crusoe_slurm_partition_*`, `crusoe_slurm_user_jobs_*`, and `crusoe_slurm_account_jobs_*` series are available with `partition`, `username`, and `account` labels respectively — good follow-up dashboards if you need to slice by partition, user, or accounting group.
-- **Production hardening.** Before exposing this to a team, add TLS via cert-manager + ingress, configure LDAP or SSO in `grafana.ini`, and set `allowUiUpdates: false` on the dashboard provider (already set in `grafana-values.yaml`) to prevent in-browser changes from being overwritten on pod restart.
+- **Production hardening.** See the dedicated [Production hardening](#production-hardening) section above for the full checklist: node-affinity / CPU pinning, resource sizing, TLS, SSO, source-range restriction, password rotation, and backups.

--- a/grafana-cmk/manifests/grafana-datasource-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-datasource-configmap.yaml
@@ -1,3 +1,5 @@
+# Provided AS IS without warranty of any kind — see grafana-cmk/README.md → Disclaimer.
+#
 # Grafana datasource — provisioned via the k8s-sidecar (label grafana_datasource="1").
 #
 # This ConfigMap intentionally contains NO secrets. The bearer token is injected

--- a/grafana-cmk/manifests/grafana-pvc.yaml
+++ b/grafana-cmk/manifests/grafana-pvc.yaml
@@ -1,3 +1,5 @@
+# Provided AS IS without warranty of any kind — see grafana-cmk/README.md → Disclaimer.
+#
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/grafana-cmk/manifests/grafana-service-lb.yaml
+++ b/grafana-cmk/manifests/grafana-service-lb.yaml
@@ -1,3 +1,5 @@
+# Provided AS IS without warranty of any kind — see grafana-cmk/README.md → Disclaimer.
+#
 # WARNING: This service exposes Grafana directly to the public internet on port 3000.
 # For production use, place Grafana behind an ingress controller with TLS termination
 # and an authentication proxy (e.g. oauth2-proxy). At minimum, change the Grafana

--- a/grafana-cmk/manifests/grafana-values.yaml
+++ b/grafana-cmk/manifests/grafana-values.yaml
@@ -1,3 +1,5 @@
+# Provided AS IS without warranty of any kind — see grafana-cmk/README.md → Disclaimer.
+#
 # Helm values for grafana/grafana chart (chart 10.5.x, Grafana 12.x)
 #
 # Install:

--- a/grafana-cmk/manifests/grafana-values.yaml
+++ b/grafana-cmk/manifests/grafana-values.yaml
@@ -68,7 +68,28 @@ resources:
 # 512Mi memory / 500m cpu (chart default) OOMKills when rendering multiple
 # dashboards against a cluster with thousands of metric series — observed on
 # come-scale-away (~1700 DCGM series, 6 dashboards). 2Gi is comfortable for
-# both query rendering and the small Caddy sidecar.
+# both query rendering and the small Caddy sidecar. See README → "Production
+# hardening" for sizing guidance at other fleet sizes.
+
+# Keep Grafana off GPU worker nodes. Match key `nvidia.com/gpu.present` is set
+# by the NVIDIA GPU Operator on every Crusoe GPU node, so DoesNotExist matches
+# only CPU nodes (Slurm controllers, login nodes, etc.). This is a HARD
+# requirement — empirically a soft preference isn't strong enough to override
+# the scheduler's image-cache / PVC-locality heuristics on Crusoe CMK, so
+# Grafana stays on a GPU node even when CPU nodes are wide open.
+#
+# Required assumes your cluster always has at least one non-GPU node with
+# capacity for Grafana (~200m CPU / 512Mi memory). Every standard Crusoe CMK
+# install has c1a / c2a nodes for system pods, so this is safe in practice.
+# If your cluster is GPU-only, see README → "Production hardening" → "Pinning
+# Grafana to CPU nodes" for a soft-preference variant.
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: nvidia.com/gpu.present
+              operator: DoesNotExist
 
 # Auth-injecting sidecar: Grafana points its datasource at http://localhost:8888
 # (no auth headers in Grafana's own config), and this Caddy sidecar adds the

--- a/grafana-cmk/manifests/monitoring-token-secret.yaml.example
+++ b/grafana-cmk/manifests/monitoring-token-secret.yaml.example
@@ -1,3 +1,5 @@
+# Provided AS IS without warranty of any kind — see grafana-cmk/README.md → Disclaimer.
+#
 # Copy this file to monitoring-token-secret.yaml and fill in your values.
 #
 #   cp manifests/monitoring-token-secret.yaml.example manifests/monitoring-token-secret.yaml

--- a/grafana-cmk/manifests/namespace.yaml
+++ b/grafana-cmk/manifests/namespace.yaml
@@ -1,3 +1,5 @@
+# Provided AS IS without warranty of any kind — see grafana-cmk/README.md → Disclaimer.
+#
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/grafana-cmk/manifests/ssd-storageclass.yaml
+++ b/grafana-cmk/manifests/ssd-storageclass.yaml
@@ -1,3 +1,5 @@
+# Provided AS IS without warranty of any kind — see grafana-cmk/README.md → Disclaimer.
+#
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:


### PR DESCRIPTION
## Summary

Three closely related additions aimed at making the install actually production-ready instead of just getting-started-ready.

### 1. Pin Grafana off GPU nodes (the original ask)

By default Kubernetes schedules Grafana on whatever node has capacity, including expensive GPU workers. On the come-scale-away test cluster, Grafana had been running on a `b200-180gb-sxm-ib.8x` — a high-SKU node hosting a service that needs 200m CPU and 512Mi memory.

Add a **required nodeAffinity** to `manifests/grafana-values.yaml` keyed on `nvidia.com/gpu.present` (set by the NVIDIA GPU Operator on every Crusoe GPU node):

```yaml
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
        - matchExpressions:
            - key: nvidia.com/gpu.present
              operator: DoesNotExist
```

> I initially shipped the soft-preference variant (`preferredDuringSchedulingIgnoredDuringExecution`) on the theory that it was the safer default, but a live test showed it was a no-op: with image-cache and PVC-locality factors in play, the scheduler kept Grafana on the GPU node even with 5 `c2a.8x` nodes wide open. The required pin moved Grafana to a `c2a.8x` on the next rollout.

Standard Crusoe CMK installs always have `c1a` / `c2a` nodes for system pods, so required is safe in practice. README documents the soft-preference fallback (for GPU-only clusters), the instance-class allow-list variant, and the nodeSelector variant.

### 2. Resource-sizing guidance

The current `200m` / `512Mi` requests and `1 CPU` / `2Gi` limits were chosen to survive the 1,700-DCGM-series load on come-scale-away after we hit a 512Mi OOMKill. README now has a sizing table for four fleet-size buckets (`< 500` series → `100m` / `256Mi` up to `10,000+` series → `1` / `2Gi` requests + sharding consideration) plus a pointer to `kubectl top pod` and the 137-exit-code OOMKill symptom so users know how to recalibrate.

### 3. Pre-public-exposure checklist

Replaces the one-line "Production hardening" bullet in the Limitations section with a proper checklist under a new "Before exposing publicly" subsection:

- TLS via cert-manager + ingress
- Auth in front (oauth2-proxy / Grafana OAuth / Grafana LDAP)
- `loadBalancerSourceRanges` restriction
- Admin password rotation (with concrete `grafana-cli` command)
- `allowUiUpdates: false` confirmation (already set, but documented)
- Backup strategy for `/var/lib/grafana/grafana.db`
- Token rotation plan

The old Limitations bullet now just points at the new section.

## Test plan

Live verification on come-scale-away (B200 / 211 nodes / 5 × c2a.8x system nodes):

- [x] **Before**: Grafana pod on `np-0d84c372-220` (`b200-180gb-sxm-ib.8x`, `gpu.present=true`)
- [x] **After**: Grafana pod on `np-3e34b0e9-1` (`c2a.8x`, `gpu.present` absent)
- [x] All 8 dashboards still render against the rescheduled pod
- [x] Auth-proxy sidecar still healthy after the reschedule
- [x] No regressions in datasource queries — proxy still returns 200
- [x] `helm upgrade` succeeded without any manual intervention; PVC re-attached on the new node automatically (CSI driver is zonal, not node-pinned)