### PR TITLE
grafana-cmk: add Network dashboards + compact GPU thermal Top-3

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -250,7 +250,7 @@ Verify the dashboards:
 
 1. Click **Dashboards** in the left sidebar.
 2. Open the **Crusoe** folder.
-3. You should see eight dashboards: Cluster GPU Overview, Node GPU Detail, DCGM & Xid Errors, Cluster GPU Power, InfiniBand Cluster View, InfiniBand Node View, Shared Storage View, and Slurm Cluster View.
+3. You should see ten dashboards: Cluster GPU Overview, Node GPU Detail, DCGM & Xid Errors, Cluster GPU Power, InfiniBand Cluster View, InfiniBand Node View, Shared Storage View, Slurm Cluster View, Network Cluster View, and Node Network Detail.
 
 ---
 
@@ -263,7 +263,7 @@ All dashboards live in the `Crusoe` folder in Grafana. Most have a **Cluster** d
 **Cluster GPU Overview (`cluster-gpu-overview.json`, 13 panels)** — cluster-wide GPU health, utilization, and thermals.
 
 - **Utilization + capacity**: Total GPUs / nodes, average utilization gauge (70%/90% thresholds), per-node utilization time series, memory used vs total, power draw by node, top-10 nodes by utilization.
-- **Thermal section**: stat row (Hottest GPU, Cluster Avg, GPUs ≥80°C, GPUs ≥85°C slowdown threshold) sourced from `DCGM_FI_DEV_GPU_TEMP`, a full-width **Top 10 Hottest Nodes** bar gauge, and a full-width **Per-Node Max GPU Temp Over Time** line graph below. Thresholds use green <70°C / yellow 70–80°C / red ≥80°C throughout. HBM memory temperature (`DCGM_FI_DEV_MEMORY_TEMP`) is available as a separate metric if you want to mirror this section for HBM later — currently surfaced only on the Node GPU Detail dashboard.
+- **Thermal section**: stat row (Hottest GPU, Cluster Avg, GPUs ≥80°C, GPUs ≥85°C slowdown threshold) sourced from `DCGM_FI_DEV_GPU_TEMP`, a compact **Top 3 Hottest Nodes** card row (node-name + temp), and a full-width **Per-Node Max GPU Temp Over Time** line graph below. Thresholds use green <70°C / yellow 70–80°C / red ≥80°C throughout. HBM memory temperature (`DCGM_FI_DEV_MEMORY_TEMP`) is available as a separate metric if you want to mirror this section for HBM later — currently surfaced only on the Node GPU Detail dashboard.
 
 **Node GPU Detail (`node-gpu-detail.json`)** — per-GPU breakdown for one node. Utilization per device, memory used, temperature with 75 °C / 85 °C thresholds, power draw, and SM/memory clocks (useful for spotting thermal throttling).
 
@@ -347,6 +347,31 @@ The `$cluster` variable is sourced from `label_values(crusoe_slurm_nodes, cluste
 > 4. **No slurmdbd panel.** The `crusoe_slurm_slurmdbd_queue_size` metric is published but consistently reports 0 on slinky-based Slurm-on-CMK installations (no slurmdbd pod), so showing it was misleading. If your cluster runs Crusoe Managed Slurm with slurmdbd, the metric is meaningful and you can re-add the panel locally.
 > 5. **Single-cluster scope.** The dashboard intentionally surfaces only cluster-wide aggregates. Per-partition (`crusoe_slurm_partition_*`), per-user (`crusoe_slurm_user_jobs_*`), and per-account (`crusoe_slurm_account_jobs_*`) metrics are available and would make good follow-up dashboards if you need that breakdown.
 
+### Network dashboards
+
+**Network Cluster View (`network-cluster-overview.json`)** — frontend ethernet RX/TX across the cluster plus Elastic Load Balancer (ELB) stats.
+
+- **Header stats**: cluster-wide RX / TX rate, count of VMs with active traffic, count of frontend NICs reporting.
+- **Cluster bandwidth over time**: RX and TX time series, side by side.
+- **Top-N nodes**: bar gauges for top 10 nodes by total bandwidth, top 10 egress (TX), and top 10 ingress (RX) — color-stepped at 100 MB/s yellow and 1 GB/s red.
+- **Per-nodepool breakdown**: stacked time series so worker / login / controller pools are distinguishable.
+- **Per-rail-pod breakdown**: stacked time series grouped by `pod_id` (Crusoe rail pod — the set of nodes connected to a single InfiniBand switch). One pod spiking on the frontend usually means storage activity concentrated on those nodes; collectives stay on IB.
+- **ELB section**: aggregate in/out bandwidth and active-flow counts plus per-LB time series of bytes (in/out), packets (in/out), active flows, and new-flows rate. A `Top ELBs by Total Bandwidth (In+Out)` bar gauge labels each row with `{elb_name} :{vip_port}/{proto}` so it's easy to tell e.g. SSH (`22/tcp`) from a Grafana LB (`3000/tcp`).
+
+**Node Network Detail (`node-network-detail.json`)** — drill-in for one or many nodes via a multi-select `$node` dropdown.
+
+- Stat header: current RX, current TX, lifetime RX (counter total), lifetime TX (counter total) for the current selection.
+- Side-by-side per-node RX and TX time series, plus a stacked combined RX+TX view.
+- `increase()` over 1h windows for retrospective bandwidth-volume analysis.
+- Snapshot table of the currently-selected nodes with their RX+TX rate, sortable by column.
+
+> **Network dashboard caveats:**
+>
+> 1. **Frontend NIC only — not the IB fabric.** `crusoe_vm_network_*` reports the guest-VM frontend interface (`ens7` on B200 workers, `ens3` on CPU/login). GPU-to-GPU collective traffic (NCCL allreduce, etc.) traverses InfiniBand and shows up only on the IB dashboards. During a typical training run these dashboards will look almost idle — that is expected.
+> 2. **No packet / error / drop counters on the frontend NIC.** Crusoe Metrics only exposes RX and TX byte counters per VM-device. If you need per-packet rate, retransmits, TCP-level stats, or interface errors, those need a node-exporter sidecar that this solution does not deploy.
+> 3. **ELB metrics are project-scoped, not cluster-scoped.** `crusoe_elb_*` series carry `project_id` but no `cluster_id` label, so the `$cluster` dropdown does not filter the ELB section — every ELB in the project shows up. If you run multiple clusters in one project they share this view.
+> 4. **No node-to-node flow map.** RX/TX are aggregate counters, not per-peer. You can see "node A is moving a lot of data" but not "node A is talking to node B" — for that you would need flow data the Crusoe relay doesn't currently expose.
+
 ---
 
 ## Troubleshooting
@@ -420,6 +445,8 @@ kubectl create configmap crusoe-dashboards \
   --from-file=node-ib-detail.json=dashboards/node-ib-detail.json \
   --from-file=storage-cluster-overview.json=dashboards/storage-cluster-overview.json \
   --from-file=slurm-cluster-overview.json=dashboards/slurm-cluster-overview.json \
+  --from-file=network-cluster-overview.json=dashboards/network-cluster-overview.json \
+  --from-file=node-network-detail.json=dashboards/node-network-detail.json \
   --dry-run=client -o yaml \
   | sed 's/^metadata:$/metadata:\n  labels:\n    grafana_dashboard: "1"/' \
   | kubectl apply -f -

--- a/grafana-cmk/dashboards/cluster-gpu-overview.json
+++ b/grafana-cmk/dashboards/cluster-gpu-overview.json
@@ -907,9 +907,9 @@
     },
     {
       "id": 13,
-      "type": "bargauge",
-      "title": "Top 10 Hottest Nodes (max GPU temp)",
-      "description": "Ten nodes whose hottest GPU is currently warmest. The bar value is the max die temp on that node \u2014 useful for narrowing thermal pressure to specific nodes vs the whole cluster.",
+      "type": "stat",
+      "title": "Top 3 Hottest Nodes (max GPU temp)",
+      "description": "The three nodes with the hottest GPU right now (max across all GPUs per node). Cards display node-name + temp, ordered hottest \u2192 coolest left-to-right. Thresholds: green <70\u00b0C / yellow 70\u201380\u00b0C / red \u226580\u00b0C.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -918,21 +918,28 @@
         "x": 0,
         "y": 46,
         "w": 24,
-        "h": 10
+        "h": 4
       },
       "options": {
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
-          ]
+          ],
+          "fields": "",
+          "values": true
         },
         "orientation": "horizontal",
-        "displayMode": "gradient",
-        "showUnfilled": true
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
       },
       "fieldConfig": {
         "defaults": {
           "unit": "celsius",
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -950,7 +957,8 @@
               }
             ]
           }
-        }
+        },
+        "overrides": []
       },
       "targets": [
         {
@@ -958,9 +966,10 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "topk(10, max by (node) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"}))",
+          "expr": "topk(3, max by (vm_name) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"}))",
+          "legendFormat": "{{vm_name}}",
           "instant": true,
-          "legendFormat": "{{node}}"
+          "refId": "A"
         }
       ]
     },
@@ -975,7 +984,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 56,
+        "y": 50,
         "w": 24,
         "h": 8
       },
@@ -1076,6 +1085,6 @@
   "timezone": "browser",
   "title": "Crusoe \u2014 Cluster GPU Overview",
   "uid": "crusoe-cluster-gpu-overview",
-  "version": 5,
+  "version": 8,
   "weekStart": ""
 }

--- a/grafana-cmk/dashboards/cluster-gpu-overview.json
+++ b/grafana-cmk/dashboards/cluster-gpu-overview.json
@@ -1083,7 +1083,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Crusoe \u2014 Cluster GPU Overview",
+  "title": "Cluster GPU Overview",
   "uid": "crusoe-cluster-gpu-overview",
   "version": 8,
   "weekStart": ""

--- a/grafana-cmk/dashboards/cluster-gpu-power.json
+++ b/grafana-cmk/dashboards/cluster-gpu-power.json
@@ -806,7 +806,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Crusoe \u2014 Cluster GPU Power",
+  "title": "Cluster GPU Power",
   "uid": "crusoe-cluster-power",
   "version": 2,
   "weekStart": ""

--- a/grafana-cmk/dashboards/cluster-ib-overview.json
+++ b/grafana-cmk/dashboards/cluster-ib-overview.json
@@ -1,6 +1,6 @@
 {
   "uid": "crusoe-ib-cluster",
-  "title": "Crusoe \u2014 InfiniBand Cluster View",
+  "title": "InfiniBand Cluster View",
   "description": "Cluster-wide InfiniBand fabric health and activity. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
   "tags": [
     "crusoe",

--- a/grafana-cmk/dashboards/dcgm-xid-errors.json
+++ b/grafana-cmk/dashboards/dcgm-xid-errors.json
@@ -353,7 +353,7 @@
   "time": {"from": "now-24h", "to": "now"},
   "timepicker": {},
   "timezone": "browser",
-  "title": "Crusoe — DCGM & Xid Errors",
+  "title": "DCGM & Xid Errors",
   "uid": "crusoe-dcgm-xid-errors",
   "version": 1,
   "weekStart": ""

--- a/grafana-cmk/dashboards/network-cluster-overview.json
+++ b/grafana-cmk/dashboards/network-cluster-overview.json
@@ -1,6 +1,6 @@
 {
   "uid": "crusoe-network-cluster",
-  "title": "Crusoe \u2014 Network Cluster View",
+  "title": "Network Cluster View",
   "tags": [
     "crusoe",
     "network",

--- a/grafana-cmk/dashboards/network-cluster-overview.json
+++ b/grafana-cmk/dashboards/network-cluster-overview.json
@@ -1,0 +1,1371 @@
+{
+  "uid": "crusoe-network-cluster",
+  "title": "Crusoe \u2014 Network Cluster View",
+  "tags": [
+    "crusoe",
+    "network",
+    "frontend",
+    "elb"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "fiscalYearStartMonth": 0,
+  "liveNow": false,
+  "weekStart": "",
+  "annotations": {
+    "list": []
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "query": {
+          "query": "label_values(crusoe_vm_network_receive_bytes_total, cluster_id)",
+          "refId": "A"
+        },
+        "definition": "label_values(crusoe_vm_network_receive_bytes_total, cluster_id)",
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".+",
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Cluster Frontend RX",
+      "description": "Aggregate frontend ethernet RX across all VMs in the selected cluster. NOTE: GPU-to-GPU collective traffic uses InfiniBand (see IB dashboards); the frontend NIC carries storage pulls, container images, control plane, and SSH.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Cluster Frontend TX",
+      "description": "Aggregate frontend ethernet TX across all VMs in the selected cluster.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "VMs With Traffic",
+      "description": "Count of VMs with non-zero RX rate in the current interval. Baseline ~all VMs; idle bandwidth is dominated by kubelet/control-plane chatter.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "count(rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]) > 0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Frontend NIC Count",
+      "description": "Number of VM-device pairs reporting frontend NIC counters. B200 workers have ens7; CPU workers/login have ens3.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "count(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Cluster Frontend Bandwidth Over Time (RX + TX)",
+      "description": "Total RX + TX across the cluster's frontend NIC. Use to spot storage/checkpoint stampedes or unexpected egress.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 24,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "RX (in)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "TX (out)"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "bargauge",
+      "title": "Top 10 Nodes by Total Frontend Bandwidth (RX+TX)",
+      "description": "Per-VM frontend NIC throughput, sum of RX and TX. Storage hotspots and checkpoint-pull outliers will surface here. Drill into Node Network Detail to see RX/TX split for a specific node.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 13,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 10,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 104857600
+              },
+              {
+                "color": "red",
+                "value": 1073741824
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(10, (rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval])))",
+          "legendFormat": "{{vm_name}} ({{nodepool_name}})"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "RX+TX by Nodepool",
+      "description": "Frontend NIC bandwidth grouped by Kubernetes nodepool. Useful for distinguishing GPU-worker storage activity from login-node SSH / API traffic.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 13,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (nodepool_name) (rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{nodepool_name}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Frontend RX+TX by Rail Pod (pod_id)",
+      "description": "Aggregate frontend NIC bandwidth per rail pod (set of nodes on the same InfiniBand switch in the rail-optimized topology). One rail pod spiking on the frontend usually indicates storage activity concentrated on that switch's nodes, not collective traffic \u2014 collectives stay on IB.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 23,
+        "w": 24,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (pod_id) (rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{pod_id}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "bargauge",
+      "title": "Top 10 Egress (TX) Nodes",
+      "description": "Nodes pushing the most data out via frontend NIC \u2014 typical sources: checkpoint uploads, log shippers, S3 pushes, egress to external services.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 10,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 104857600
+              },
+              {
+                "color": "red",
+                "value": 1073741824
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(10, rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{vm_name}} ({{nodepool_name}})"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "bargauge",
+      "title": "Top 10 Ingress (RX) Nodes",
+      "description": "Nodes pulling the most data in via frontend NIC \u2014 typical sources: container image pulls, dataset/checkpoint downloads, S3 pulls.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 32,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 10,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 104857600
+              },
+              {
+                "color": "red",
+                "value": 1073741824
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(10, rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+          "legendFormat": "{{vm_name}} ({{nodepool_name}})"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Load Balancer (ELB)",
+      "gridPos": {
+        "x": 0,
+        "y": 42,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Active ELBs (project)",
+      "description": "Number of distinct Crusoe Elastic Load Balancers reporting metrics in this project. ELB metrics do NOT carry a cluster_id label \u2014 this section shows project-wide LB activity, regardless of the $cluster filter above.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 43,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "count(count by (elb_name) (crusoe_elb_bytes_in))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "ELB Aggregate RX (in)",
+      "description": "Sum of LB ingress traffic across all ELBs in this project.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 43,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_elb_bytes_in[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "ELB Aggregate TX (out)",
+      "description": "Sum of LB egress traffic across all ELBs in this project.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 43,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_elb_bytes_out[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "stat",
+      "title": "ELB Active Flows",
+      "description": "Concurrent flows tracked across all ELBs.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 43,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_elb_active_flows)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "ELB Bandwidth In by elb_name",
+      "description": "Per-LB ingress bandwidth. Hover legend to identify each LB (slurm-login, grafana, etc.).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 47,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (elb_name) (rate(crusoe_elb_bytes_in[$__rate_interval]))",
+          "legendFormat": "{{elb_name}}"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "ELB Bandwidth Out by elb_name",
+      "description": "Per-LB egress bandwidth.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 47,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (elb_name) (rate(crusoe_elb_bytes_out[$__rate_interval]))",
+          "legendFormat": "{{elb_name}}"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "ELB Packets In by elb_name",
+      "description": "Per-LB inbound packet rate. Helps spot small-packet floods that may not show on bytes alone.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 57,
+        "w": 12,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (elb_name) (rate(crusoe_elb_in_packets[$__rate_interval]))",
+          "legendFormat": "{{elb_name}}"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "ELB Packets Out by elb_name",
+      "description": "Per-LB outbound packet rate.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 57,
+        "w": 12,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (elb_name) (rate(crusoe_elb_out_packets[$__rate_interval]))",
+          "legendFormat": "{{elb_name}}"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "ELB Active Flows by elb_name",
+      "description": "Concurrent flow count per LB. Spikes correlate with new client sessions or long-lived connection bursts.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 66,
+        "w": 12,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (elb_name) (crusoe_elb_active_flows)",
+          "legendFormat": "{{elb_name}}"
+        }
+      ]
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "ELB New Flows Rate by elb_name",
+      "description": "New flows per second arriving at each LB \u2014 connection-setup pressure indicator.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 66,
+        "w": 12,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (elb_name) (rate(crusoe_elb_new_flows[$__rate_interval]))",
+          "legendFormat": "{{elb_name}}"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "bargauge",
+      "title": "Top ELBs by Total Bandwidth (In+Out)",
+      "description": "LBs ranked by total bandwidth. Legend shows the VIP port and protocol so you can tell e.g. SSH (22/tcp) from API (3000/tcp).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 75,
+        "w": 24,
+        "h": 8
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 10,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 104857600
+              },
+              {
+                "color": "red",
+                "value": 1073741824
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(10, sum by (elb_name, vip_port, proto) (rate(crusoe_elb_bytes_in[$__rate_interval]) + rate(crusoe_elb_bytes_out[$__rate_interval])))",
+          "legendFormat": "{{elb_name}} :{{vip_port}}/{{proto}}"
+        }
+      ]
+    }
+  ],
+  "description": "Frontend ethernet RX/TX and ELB stats. Frontend NIC is `ens7` on B200 workers, `ens3` on CPU/login. ELBs are project-scoped \u2014 no cluster filter applies to them. GPU collective traffic is on the IB fabric (see IB dashboards), not here."
+}

--- a/grafana-cmk/dashboards/node-gpu-detail.json
+++ b/grafana-cmk/dashboards/node-gpu-detail.json
@@ -374,7 +374,7 @@
   "time": {"from": "now-6h", "to": "now"},
   "timepicker": {},
   "timezone": "browser",
-  "title": "Crusoe — Node GPU Detail",
+  "title": "Node GPU Detail",
   "uid": "crusoe-node-gpu-detail",
   "version": 1,
   "weekStart": ""

--- a/grafana-cmk/dashboards/node-ib-detail.json
+++ b/grafana-cmk/dashboards/node-ib-detail.json
@@ -1,6 +1,6 @@
 {
   "uid": "crusoe-ib-node",
-  "title": "Crusoe \u2014 InfiniBand Node View",
+  "title": "InfiniBand Node View",
   "description": "Per-HCA InfiniBand detail for selected nodes. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
   "tags": [
     "crusoe",

--- a/grafana-cmk/dashboards/node-network-detail.json
+++ b/grafana-cmk/dashboards/node-network-detail.json
@@ -1,0 +1,699 @@
+{
+  "uid": "crusoe-node-network-detail",
+  "title": "Crusoe \u2014 Node Network Detail",
+  "tags": [
+    "crusoe",
+    "network",
+    "node",
+    "frontend"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "fiscalYearStartMonth": 0,
+  "liveNow": false,
+  "weekStart": "",
+  "annotations": {
+    "list": []
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "query": {
+          "query": "label_values(crusoe_vm_network_receive_bytes_total, cluster_id)",
+          "refId": "A"
+        },
+        "definition": "label_values(crusoe_vm_network_receive_bytes_total, cluster_id)",
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".+",
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "node",
+        "label": "Node",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "query": {
+          "query": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}, vm_name)",
+          "refId": "B"
+        },
+        "definition": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}, vm_name)",
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".+",
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Selected RX (current)",
+      "description": "Current aggregate RX across the selected vm_name(s). If multiple nodes are selected, this is the sum.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Selected TX (current)",
+      "description": "Current aggregate TX across the selected vm_name(s).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Lifetime RX (counter)",
+      "description": "Total bytes received over the lifetime of the underlying counter (resets on host reboot or counter wraparound).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"})",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Lifetime TX (counter)",
+      "description": "Total bytes transmitted over the lifetime of the underlying counter.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"})",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "RX by Node",
+      "description": "Per-node receive bandwidth. One line per selected vm_name; legend includes the interface device (ens7 on B200 workers, ens3 on CPU/login).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 12,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+          "legendFormat": "{{vm_name}} ({{device}})"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "TX by Node",
+      "description": "Per-node transmit bandwidth.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 4,
+        "w": 12,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+          "legendFormat": "{{vm_name}} ({{device}})"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "RX + TX Combined by Node (stacked)",
+      "description": "Stacked view of RX and TX per selected node, useful when you want to see total NIC pressure including both directions.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 13,
+        "w": 24,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+          "legendFormat": "RX {{vm_name}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+          "legendFormat": "TX {{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "RX bytes increase (last 1h)",
+      "description": "Bytes received in trailing 1h windows. Smoother than rate() \u2014 useful when correlating with longer-running activity like a checkpoint pull.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "increase(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[1h])",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "TX bytes increase (last 1h)",
+      "description": "Bytes transmitted in trailing 1h windows.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 22,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "increase(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[1h])",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "table",
+      "title": "Per-Node Bandwidth Table",
+      "description": "Snapshot table of currently-selected nodes with their RX+TX rate. Columns: vm_name, device, nodepool_name, pod_id, value (Bps). Sort and resize columns as needed.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 30,
+        "w": 24,
+        "h": 10
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(50, sort_desc(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])))",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "description": "Per-node frontend ethernet detail. Use the $node dropdown to filter to one or many vm_names; defaults to All. To see a high-traffic node, hop here from the Top-N panel on Network Cluster View by clicking the legend entry."
+}

--- a/grafana-cmk/dashboards/node-network-detail.json
+++ b/grafana-cmk/dashboards/node-network-detail.json
@@ -1,6 +1,6 @@
 {
   "uid": "crusoe-node-network-detail",
-  "title": "Crusoe \u2014 Node Network Detail",
+  "title": "Node Network Detail",
   "tags": [
     "crusoe",
     "network",

--- a/grafana-cmk/dashboards/slurm-cluster-overview.json
+++ b/grafana-cmk/dashboards/slurm-cluster-overview.json
@@ -1,6 +1,6 @@
 {
   "uid": "crusoe-slurm-cluster",
-  "title": "Crusoe \u2014 Slurm Cluster View",
+  "title": "Slurm Cluster View",
   "description": "Slurm scheduler state: node states, job states, capacity utilization, scheduler/backfill health, error counters.",
   "tags": [
     "crusoe",

--- a/grafana-cmk/dashboards/storage-cluster-overview.json
+++ b/grafana-cmk/dashboards/storage-cluster-overview.json
@@ -1,6 +1,6 @@
 {
   "uid": "crusoe-storage-cluster",
-  "title": "Crusoe \u2014 Shared Storage View",
+  "title": "Shared Storage View",
   "description": "Crusoe-provisioned block-storage (SDisk) health: per-disk capacity, throughput, IOPS, and latency. Project-scoped \u2014 all disks in the project are listed; pick one from the Crusoe SDisk (by Crusoe ID) dropdown to drill in. The bar gauge always shows every disk for context.",
   "tags": [
     "crusoe",

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -1086,7 +1086,7 @@ data:
       },
       "timepicker": {},
       "timezone": "browser",
-      "title": "Crusoe \u2014 Cluster GPU Overview",
+      "title": "Cluster GPU Overview",
       "uid": "crusoe-cluster-gpu-overview",
       "version": 8,
       "weekStart": ""
@@ -1900,7 +1900,7 @@ data:
       },
       "timepicker": {},
       "timezone": "browser",
-      "title": "Crusoe \u2014 Cluster GPU Power",
+      "title": "Cluster GPU Power",
       "uid": "crusoe-cluster-power",
       "version": 2,
       "weekStart": ""
@@ -1908,7 +1908,7 @@ data:
   cluster-ib-overview.json: |-
     {
       "uid": "crusoe-ib-cluster",
-      "title": "Crusoe \u2014 InfiniBand Cluster View",
+      "title": "InfiniBand Cluster View",
       "description": "Cluster-wide InfiniBand fabric health and activity. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
       "tags": [
         "crusoe",
@@ -3291,7 +3291,7 @@ data:
       "time": {"from": "now-24h", "to": "now"},
       "timepicker": {},
       "timezone": "browser",
-      "title": "Crusoe — DCGM & Xid Errors",
+      "title": "DCGM & Xid Errors",
       "uid": "crusoe-dcgm-xid-errors",
       "version": 1,
       "weekStart": ""
@@ -3299,7 +3299,7 @@ data:
   network-cluster-overview.json: |-
     {
       "uid": "crusoe-network-cluster",
-      "title": "Crusoe \u2014 Network Cluster View",
+      "title": "Network Cluster View",
       "tags": [
         "crusoe",
         "network",
@@ -5045,7 +5045,7 @@ data:
       "time": {"from": "now-6h", "to": "now"},
       "timepicker": {},
       "timezone": "browser",
-      "title": "Crusoe — Node GPU Detail",
+      "title": "Node GPU Detail",
       "uid": "crusoe-node-gpu-detail",
       "version": 1,
       "weekStart": ""
@@ -5053,7 +5053,7 @@ data:
   node-ib-detail.json: |-
     {
       "uid": "crusoe-ib-node",
-      "title": "Crusoe \u2014 InfiniBand Node View",
+      "title": "InfiniBand Node View",
       "description": "Per-HCA InfiniBand detail for selected nodes. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
       "tags": [
         "crusoe",
@@ -5769,7 +5769,7 @@ data:
   node-network-detail.json: |-
     {
       "uid": "crusoe-node-network-detail",
-      "title": "Crusoe \u2014 Node Network Detail",
+      "title": "Node Network Detail",
       "tags": [
         "crusoe",
         "network",
@@ -6469,7 +6469,7 @@ data:
   slurm-cluster-overview.json: |-
     {
       "uid": "crusoe-slurm-cluster",
-      "title": "Crusoe \u2014 Slurm Cluster View",
+      "title": "Slurm Cluster View",
       "description": "Slurm scheduler state: node states, job states, capacity utilization, scheduler/backfill health, error counters.",
       "tags": [
         "crusoe",
@@ -7794,7 +7794,7 @@ data:
   storage-cluster-overview.json: |-
     {
       "uid": "crusoe-storage-cluster",
-      "title": "Crusoe \u2014 Shared Storage View",
+      "title": "Shared Storage View",
       "description": "Crusoe-provisioned block-storage (SDisk) health: per-disk capacity, throughput, IOPS, and latency. Project-scoped \u2014 all disks in the project are listed; pick one from the Crusoe SDisk (by Crusoe ID) dropdown to drill in. The bar gauge always shows every disk for context.",
       "tags": [
         "crusoe",

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -910,9 +910,9 @@ data:
         },
         {
           "id": 13,
-          "type": "bargauge",
-          "title": "Top 10 Hottest Nodes (max GPU temp)",
-          "description": "Ten nodes whose hottest GPU is currently warmest. The bar value is the max die temp on that node \u2014 useful for narrowing thermal pressure to specific nodes vs the whole cluster.",
+          "type": "stat",
+          "title": "Top 3 Hottest Nodes (max GPU temp)",
+          "description": "The three nodes with the hottest GPU right now (max across all GPUs per node). Cards display node-name + temp, ordered hottest \u2192 coolest left-to-right. Thresholds: green <70\u00b0C / yellow 70\u201380\u00b0C / red \u226580\u00b0C.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -921,21 +921,28 @@ data:
             "x": 0,
             "y": 46,
             "w": 24,
-            "h": 10
+            "h": 4
           },
           "options": {
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"
-              ]
+              ],
+              "fields": "",
+              "values": true
             },
             "orientation": "horizontal",
-            "displayMode": "gradient",
-            "showUnfilled": true
+            "textMode": "value_and_name",
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto"
           },
           "fieldConfig": {
             "defaults": {
               "unit": "celsius",
+              "color": {
+                "mode": "thresholds"
+              },
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -953,7 +960,8 @@ data:
                   }
                 ]
               }
-            }
+            },
+            "overrides": []
           },
           "targets": [
             {
@@ -961,9 +969,10 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "topk(10, max by (node) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"}))",
+              "expr": "topk(3, max by (vm_name) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"}))",
+              "legendFormat": "{{vm_name}}",
               "instant": true,
-              "legendFormat": "{{node}}"
+              "refId": "A"
             }
           ]
         },
@@ -978,7 +987,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 56,
+            "y": 50,
             "w": 24,
             "h": 8
           },
@@ -1079,7 +1088,7 @@ data:
       "timezone": "browser",
       "title": "Crusoe \u2014 Cluster GPU Overview",
       "uid": "crusoe-cluster-gpu-overview",
-      "version": 5,
+      "version": 8,
       "weekStart": ""
     }
   cluster-gpu-power.json: |-
@@ -3287,6 +3296,1378 @@ data:
       "version": 1,
       "weekStart": ""
     }
+  network-cluster-overview.json: |-
+    {
+      "uid": "crusoe-network-cluster",
+      "title": "Crusoe \u2014 Network Cluster View",
+      "tags": [
+        "crusoe",
+        "network",
+        "frontend",
+        "elb"
+      ],
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timezone": "browser",
+      "editable": true,
+      "graphTooltip": 1,
+      "fiscalYearStartMonth": 0,
+      "liveNow": false,
+      "weekStart": "",
+      "annotations": {
+        "list": []
+      },
+      "templating": {
+        "list": [
+          {
+            "name": "cluster",
+            "label": "Cluster",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
+            "query": {
+              "query": "label_values(crusoe_vm_network_receive_bytes_total, cluster_id)",
+              "refId": "A"
+            },
+            "definition": "label_values(crusoe_vm_network_receive_bytes_total, cluster_id)",
+            "includeAll": true,
+            "multi": true,
+            "allValue": ".+",
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            },
+            "options": [],
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "hide": 0,
+            "skipUrlSync": false
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Cluster Frontend RX",
+          "description": "Aggregate frontend ethernet RX across all VMs in the selected cluster. NOTE: GPU-to-GPU collective traffic uses InfiniBand (see IB dashboards); the frontend NIC carries storage pulls, container images, control plane, and SSH.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Cluster Frontend TX",
+          "description": "Aggregate frontend ethernet TX across all VMs in the selected cluster.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 6,
+            "y": 0,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "VMs With Traffic",
+          "description": "Count of VMs with non-zero RX rate in the current interval. Baseline ~all VMs; idle bandwidth is dominated by kubelet/control-plane chatter.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 0,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "count(rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]) > 0)",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Frontend NIC Count",
+          "description": "Number of VM-device pairs reporting frontend NIC counters. B200 workers have ens7; CPU workers/login have ens3.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 18,
+            "y": 0,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "count(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"})",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "type": "timeseries",
+          "title": "Cluster Frontend Bandwidth Over Time (RX + TX)",
+          "description": "Total RX + TX across the cluster's frontend NIC. Use to spot storage/checkpoint stampedes or unexpected egress.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 4,
+            "w": 24,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "legendFormat": "RX (in)"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "legendFormat": "TX (out)"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "type": "bargauge",
+          "title": "Top 10 Nodes by Total Frontend Bandwidth (RX+TX)",
+          "description": "Per-VM frontend NIC throughput, sum of RX and TX. Storage hotspots and checkpoint-pull outliers will surface here. Drill into Node Network Detail to see RX/TX split for a specific node.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 13,
+            "w": 12,
+            "h": 10
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "valueMode": "color",
+            "showUnfilled": true,
+            "minVizWidth": 0,
+            "minVizHeight": 10,
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 104857600
+                  },
+                  {
+                    "color": "red",
+                    "value": 1073741824
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "topk(10, (rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval])))",
+              "legendFormat": "{{vm_name}} ({{nodepool_name}})"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "RX+TX by Nodepool",
+          "description": "Frontend NIC bandwidth grouped by Kubernetes nodepool. Useful for distinguishing GPU-worker storage activity from login-node SSH / API traffic.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 13,
+            "w": 12,
+            "h": 10
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 30,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "normal"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (nodepool_name) (rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "legendFormat": "{{nodepool_name}}"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Frontend RX+TX by Rail Pod (pod_id)",
+          "description": "Aggregate frontend NIC bandwidth per rail pod (set of nodes on the same InfiniBand switch in the rail-optimized topology). One rail pod spiking on the frontend usually indicates storage activity concentrated on that switch's nodes, not collective traffic \u2014 collectives stay on IB.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 23,
+            "w": 24,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 30,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "normal"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (pod_id) (rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "legendFormat": "{{pod_id}}"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "type": "bargauge",
+          "title": "Top 10 Egress (TX) Nodes",
+          "description": "Nodes pushing the most data out via frontend NIC \u2014 typical sources: checkpoint uploads, log shippers, S3 pushes, egress to external services.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 32,
+            "w": 12,
+            "h": 10
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "valueMode": "color",
+            "showUnfilled": true,
+            "minVizWidth": 0,
+            "minVizHeight": 10,
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 104857600
+                  },
+                  {
+                    "color": "red",
+                    "value": 1073741824
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "topk(10, rate(crusoe_vm_network_transmit_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "legendFormat": "{{vm_name}} ({{nodepool_name}})"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "type": "bargauge",
+          "title": "Top 10 Ingress (RX) Nodes",
+          "description": "Nodes pulling the most data in via frontend NIC \u2014 typical sources: container image pulls, dataset/checkpoint downloads, S3 pulls.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 32,
+            "w": 12,
+            "h": 10
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "valueMode": "color",
+            "showUnfilled": true,
+            "minVizWidth": 0,
+            "minVizHeight": 10,
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 104857600
+                  },
+                  {
+                    "color": "red",
+                    "value": 1073741824
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "topk(10, rate(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}[$__rate_interval]))",
+              "legendFormat": "{{vm_name}} ({{nodepool_name}})"
+            }
+          ]
+        },
+        {
+          "id": 11,
+          "type": "row",
+          "title": "Load Balancer (ELB)",
+          "gridPos": {
+            "x": 0,
+            "y": 42,
+            "w": 24,
+            "h": 1
+          },
+          "collapsed": false,
+          "panels": []
+        },
+        {
+          "id": 12,
+          "type": "stat",
+          "title": "Active ELBs (project)",
+          "description": "Number of distinct Crusoe Elastic Load Balancers reporting metrics in this project. ELB metrics do NOT carry a cluster_id label \u2014 this section shows project-wide LB activity, regardless of the $cluster filter above.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 43,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "count(count by (elb_name) (crusoe_elb_bytes_in))",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 13,
+          "type": "stat",
+          "title": "ELB Aggregate RX (in)",
+          "description": "Sum of LB ingress traffic across all ELBs in this project.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 6,
+            "y": 43,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_elb_bytes_in[$__rate_interval]))",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 14,
+          "type": "stat",
+          "title": "ELB Aggregate TX (out)",
+          "description": "Sum of LB egress traffic across all ELBs in this project.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 43,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_elb_bytes_out[$__rate_interval]))",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 15,
+          "type": "stat",
+          "title": "ELB Active Flows",
+          "description": "Concurrent flows tracked across all ELBs.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 18,
+            "y": 43,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_elb_active_flows)",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 16,
+          "type": "timeseries",
+          "title": "ELB Bandwidth In by elb_name",
+          "description": "Per-LB ingress bandwidth. Hover legend to identify each LB (slurm-login, grafana, etc.).",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 47,
+            "w": 12,
+            "h": 10
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (elb_name) (rate(crusoe_elb_bytes_in[$__rate_interval]))",
+              "legendFormat": "{{elb_name}}"
+            }
+          ]
+        },
+        {
+          "id": 17,
+          "type": "timeseries",
+          "title": "ELB Bandwidth Out by elb_name",
+          "description": "Per-LB egress bandwidth.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 47,
+            "w": 12,
+            "h": 10
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (elb_name) (rate(crusoe_elb_bytes_out[$__rate_interval]))",
+              "legendFormat": "{{elb_name}}"
+            }
+          ]
+        },
+        {
+          "id": 18,
+          "type": "timeseries",
+          "title": "ELB Packets In by elb_name",
+          "description": "Per-LB inbound packet rate. Helps spot small-packet floods that may not show on bytes alone.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 57,
+            "w": 12,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "pps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (elb_name) (rate(crusoe_elb_in_packets[$__rate_interval]))",
+              "legendFormat": "{{elb_name}}"
+            }
+          ]
+        },
+        {
+          "id": 19,
+          "type": "timeseries",
+          "title": "ELB Packets Out by elb_name",
+          "description": "Per-LB outbound packet rate.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 57,
+            "w": 12,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "pps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (elb_name) (rate(crusoe_elb_out_packets[$__rate_interval]))",
+              "legendFormat": "{{elb_name}}"
+            }
+          ]
+        },
+        {
+          "id": 20,
+          "type": "timeseries",
+          "title": "ELB Active Flows by elb_name",
+          "description": "Concurrent flow count per LB. Spikes correlate with new client sessions or long-lived connection bursts.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 66,
+            "w": 12,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (elb_name) (crusoe_elb_active_flows)",
+              "legendFormat": "{{elb_name}}"
+            }
+          ]
+        },
+        {
+          "id": 21,
+          "type": "timeseries",
+          "title": "ELB New Flows Rate by elb_name",
+          "description": "New flows per second arriving at each LB \u2014 connection-setup pressure indicator.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 66,
+            "w": 12,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum by (elb_name) (rate(crusoe_elb_new_flows[$__rate_interval]))",
+              "legendFormat": "{{elb_name}}"
+            }
+          ]
+        },
+        {
+          "id": 22,
+          "type": "bargauge",
+          "title": "Top ELBs by Total Bandwidth (In+Out)",
+          "description": "LBs ranked by total bandwidth. Legend shows the VIP port and protocol so you can tell e.g. SSH (22/tcp) from API (3000/tcp).",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 75,
+            "w": 24,
+            "h": 8
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "valueMode": "color",
+            "showUnfilled": true,
+            "minVizWidth": 0,
+            "minVizHeight": 10,
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 104857600
+                  },
+                  {
+                    "color": "red",
+                    "value": 1073741824
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "topk(10, sum by (elb_name, vip_port, proto) (rate(crusoe_elb_bytes_in[$__rate_interval]) + rate(crusoe_elb_bytes_out[$__rate_interval])))",
+              "legendFormat": "{{elb_name}} :{{vip_port}}/{{proto}}"
+            }
+          ]
+        }
+      ],
+      "description": "Frontend ethernet RX/TX and ELB stats. Frontend NIC is `ens7` on B200 workers, `ens3` on CPU/login. ELBs are project-scoped \u2014 no cluster filter applies to them. GPU collective traffic is on the IB fabric (see IB dashboards), not here."
+    }
   node-gpu-detail.json: |
     {
       "__inputs": [
@@ -4384,6 +5765,706 @@ data:
           ]
         }
       ]
+    }
+  node-network-detail.json: |-
+    {
+      "uid": "crusoe-node-network-detail",
+      "title": "Crusoe \u2014 Node Network Detail",
+      "tags": [
+        "crusoe",
+        "network",
+        "node",
+        "frontend"
+      ],
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timezone": "browser",
+      "editable": true,
+      "graphTooltip": 1,
+      "fiscalYearStartMonth": 0,
+      "liveNow": false,
+      "weekStart": "",
+      "annotations": {
+        "list": []
+      },
+      "templating": {
+        "list": [
+          {
+            "name": "cluster",
+            "label": "Cluster",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
+            "query": {
+              "query": "label_values(crusoe_vm_network_receive_bytes_total, cluster_id)",
+              "refId": "A"
+            },
+            "definition": "label_values(crusoe_vm_network_receive_bytes_total, cluster_id)",
+            "includeAll": true,
+            "multi": true,
+            "allValue": ".+",
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            },
+            "options": [],
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "hide": 0,
+            "skipUrlSync": false
+          },
+          {
+            "name": "node",
+            "label": "Node",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
+            "query": {
+              "query": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}, vm_name)",
+              "refId": "B"
+            },
+            "definition": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}, vm_name)",
+            "includeAll": true,
+            "multi": true,
+            "allValue": ".+",
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            },
+            "options": [],
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "hide": 0,
+            "skipUrlSync": false
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Selected RX (current)",
+          "description": "Current aggregate RX across the selected vm_name(s). If multiple nodes are selected, this is the sum.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval]))",
+              "legendFormat": ""
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Selected TX (current)",
+          "description": "Current aggregate TX across the selected vm_name(s).",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 6,
+            "y": 0,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval]))",
+              "legendFormat": ""
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Lifetime RX (counter)",
+          "description": "Total bytes received over the lifetime of the underlying counter (resets on host reboot or counter wraparound).",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 0,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"})",
+              "legendFormat": ""
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Lifetime TX (counter)",
+          "description": "Total bytes transmitted over the lifetime of the underlying counter.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 18,
+            "y": 0,
+            "w": 6,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"})",
+              "legendFormat": ""
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "type": "timeseries",
+          "title": "RX by Node",
+          "description": "Per-node receive bandwidth. One line per selected vm_name; legend includes the interface device (ens7 on B200 workers, ens3 on CPU/login).",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 4,
+            "w": 12,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+              "legendFormat": "{{vm_name}} ({{device}})"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "type": "timeseries",
+          "title": "TX by Node",
+          "description": "Per-node transmit bandwidth.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 4,
+            "w": 12,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+              "legendFormat": "{{vm_name}} ({{device}})"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "RX + TX Combined by Node (stacked)",
+          "description": "Stacked view of RX and TX per selected node, useful when you want to see total NIC pressure including both directions.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 13,
+            "w": 24,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 30,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "normal"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+              "legendFormat": "RX {{vm_name}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+              "legendFormat": "TX {{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "RX bytes increase (last 1h)",
+          "description": "Bytes received in trailing 1h windows. Smoother than rate() \u2014 useful when correlating with longer-running activity like a checkpoint pull.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 22,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "increase(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[1h])",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "TX bytes increase (last 1h)",
+          "description": "Bytes transmitted in trailing 1h windows.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 22,
+            "w": 12,
+            "h": 8
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "increase(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[1h])",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "type": "table",
+          "title": "Per-Node Bandwidth Table",
+          "description": "Snapshot table of currently-selected nodes with their RX+TX rate. Columns: vm_name, device, nodepool_name, pod_id, value (Bps). Sort and resize columns as needed.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 30,
+            "w": 24,
+            "h": 10
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": false
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "topk(50, sort_desc(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])))",
+              "format": "table",
+              "instant": true
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Per-node frontend ethernet detail. Use the $node dropdown to filter to one or many vm_names; defaults to All. To see a high-traffic node, hop here from the Top-N panel on Network Cluster View by clicking the legend entry."
     }
   slurm-cluster-overview.json: |-
     {


### PR DESCRIPTION
## Summary

- **Two new dashboards** for frontend ethernet + Crusoe ELB visibility:
  - **Network Cluster View** — cluster-wide RX/TX, top-N nodes, per-nodepool and per-rail-pod stacked breakdowns, full ELB section (bytes/packets in+out, active flows, new-flow rate, top-LB bar gauge labelled `{elb_name} :{vip_port}/{proto}`).
  - **Node Network Detail** — per-node RX/TX, stacked combined view, 1h `increase()` retrospective panels, sortable snapshot table; multi-select `$node` dropdown.
- **Cluster GPU Overview refactor**: replace the full-width `Top 10 Hottest Nodes` bar gauge (mostly empty whitespace at idle) with a compact 3-card horizontal stat row. Saves 6 grid rows; the Per-Node Max GPU Temp timeseries slides up underneath.
- **Drop redundant `Crusoe — ` prefix** from every dashboard title — Grafana already groups them under the `Crusoe` folder. UIDs are unchanged so existing links keep working.
- **README**: bumps dashboard count to 10, adds the Network dashboards subsection with four caveats (frontend NIC ≠ IB fabric, no packet/error counters, ELB is project-scoped not cluster-scoped, no node-to-node flow map), and adds the two new files to the configmap-regen snippet.

## Source metrics

- `crusoe_vm_network_receive_bytes_total` / `_transmit_bytes_total` — guest-VM frontend NIC counters. Device names: `ens7` on B200 workers, `ens3` on CPU/login. ~60 s cadence.
- `crusoe_elb_bytes_in` / `_bytes_out` / `_in_packets` / `_out_packets` / `_active_flows` / `_new_flows` — Crusoe Elastic Load Balancer per-VIP counters. Project-scoped (no `cluster_id` label).

## Verified on a live B200 cluster

- Frontend NIC counters reporting on B200 workers (`ens7`) and the c2a CPU control-plane / login nodes (`ens3`); ~60 s sample cadence.
- Multiple ELBs visible end-to-end (Grafana LB, slurm-login LBs, ingress-nginx, etc.) with non-zero bytes in/out and active-flow counts.
- Under an active training workload the frontend NIC stays comparatively quiet — login/controller pools dominate frontend traffic; GPU workers stay near baseline. Confirms collectives stay on InfiniBand and don't bleed onto the frontend.
- Top-3 GPU thermal cards render correctly in the compact card row.

## Test plan

- [ ] Pull this branch; `kubectl apply -f grafana-cmk/manifests/grafana-dashboards-configmap.yaml` against a cluster with Crusoe Metrics provisioned.
- [ ] Open Grafana → Crusoe folder → confirm `Network Cluster View` and `Node Network Detail` render with live data.
- [ ] Open `Cluster GPU Overview` → confirm the thermal section now shows three compact horizontal cards instead of the full bar gauge, and the Per-Node Max GPU Temp timeseries sits directly underneath.
- [ ] Confirm every title in the Crusoe folder no longer starts with `Crusoe — ` while old URLs (by UID) still resolve.
- [ ] In Node Network Detail, pick a single `$node` from the dropdown — verify all panels narrow to that node only.
- [ ] Verify the ELB section populates regardless of the `$cluster` filter (it's project-scoped).