### PR TITLE
grafana-cmk: vm_name label cleanup + remove resolved TODO

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -88,13 +88,12 @@ What this is not: a full observability stack. Crusoe Metrics currently exposes i
   ```bash
   crusoe projects list
   ```
-- **Crusoe Metrics enabled on your project.** This feature is currently in limited availability — contact your Crusoe account team to request enablement before proceeding.
+- **Crusoe Metrics enabled on your project.** This feature is now GA and installed on all CMK clusters by default. If you wish to query metrics from standalone VMs, you will have to opt in to include the metrics agent during VM creation. 
 - **Crusoe Watch Agent installed on the cluster.** The Watch Agent collects infrastructure and DCGM metrics and forwards them to the Crusoe Metrics backend. It is installed by default on Managed Slurm clusters. For CMK clusters, verify with your account team or check for the agent DaemonSet:
   ```bash
   kubectl get daemonset -A | grep -i watch
   ```
 
-  > **Note:** The Watch Agent already provides DCGM metrics. If your cluster also runs `nvidia-dcgm-exporter` from the NVIDIA GPU Operator (the default on GPU CMK clusters), you will see some metric series reported twice — usually harmless for the dashboards in this repo, but worth knowing if you build alerts against a counter and see double the expected rate. To deduplicate, configure the Watch Agent to exclude DCGM or scope the exporter scrape with a `relabel_config` drop.
 
 ---
 
@@ -159,7 +158,7 @@ kubectl apply -f manifests/grafana-dashboards-configmap.yaml
 kubectl apply -f manifests/grafana-datasource-configmap.yaml
 ```
 
-> The datasource ConfigMap contains no secrets — it points Grafana at `http://localhost:8888`, which is the in-pod auth-injecting sidecar (`crusoe-auth-proxy`) defined in `grafana-values.yaml`. The sidecar reads `MONITORING_TOKEN` and `PROJECT_ID` from the Secret you applied in Step 2 and rewrites every outbound request to the Crusoe Metrics endpoint with the right `Authorization: Bearer …` header. This avoids a Grafana 12.3.x bug where `secureJsonData` headers are not consistently applied on the resources-API path, which broke template-variable label lookups.
+> The datasource ConfigMap contains no secrets — it points Grafana at `http://localhost:8888`, which is the in-pod auth-injecting sidecar (`crusoe-auth-proxy`) defined in `grafana-values.yaml`. The sidecar reads `MONITORING_TOKEN` and `PROJECT_ID` from the Secret you applied in Step 2 and rewrites every outbound request to the Crusoe Metrics endpoint with the right `Authorization: Bearer …` header. 
 
 Add the Grafana Helm repository and install:
 
@@ -298,9 +297,8 @@ All dashboards live in the `Crusoe` folder in Grafana. Most have a **Cluster** d
 > On Crusoe-virtualized HCAs the IB port counters surfaced through Crusoe Metrics are not a faithful realtime view of the fabric. Three issues we have observed, all upstream of this repo:
 >
 > 1. **Slow scrape cadence.** The Watch Agent refreshes IB counters far less frequently than DCGM. Measured cadence between fresh samples on the same series:
->     - H100 fleet (us-southcentral1-a): avg ~270 s, max ~300 s
->     - B200 fleet (eu-norway1-a): avg ~22 minutes, max ~23 minutes
->
+
+
 >    Because of this, every IB panel in this repo uses **`[1h]` rate windows** and the stat panels wrap bare metric references in **`last_over_time(... [1h])`**. With the typical `$__rate_interval` (~1 min) the panels would render entirely as "No data" — there are simply fewer than 2 samples per minute. The price of the wider window is temporal smoothing: a panel reading represents the average over the trailing hour, not the current second. When the Watch Agent's IB cadence drops to ≤60 s (engineering ticket open), these windows can be tightened — likely down to `$__rate_interval`.
 > 2. **Magnitude is low.** Counter deltas captured during a sustained `perftest` run measured ~10× lower than the actual bandwidth `perftest` reported on the same wire. The `line_rate` label (`gig_bit_per_sec`) also reports `128` on HCAs whose `ibstat` rate is `400`, so the utilization-% panels are calibrated against the wrong denominator.
 > 3. **No in-guest fallback.** `ibv_devinfo`, `perfquery`, and the standard `/sys/class/infiniband/.../counters/` files are not exposed inside Crusoe guest VMs, so there is no in-guest path to scrape accurate per-HCA counters today.
@@ -325,7 +323,6 @@ The dropdown is sourced from `label_values(crusoe_sdisk_disk_capacity_used_bytes
 > 2. **No in-volume usage.** `kubelet_volume_stats_used_bytes` is not in the Crusoe Metrics catalog, so the dashboard can't show "this disk is 80% full" — only `crusoe_sdisk_disk_capacity_used_bytes`, which is bytes consumed from the Crusoe-storage-service's vantage point.
 > 3. **Latency unit assumed microseconds.** `crusoe_sdisk_disk_read_latency_sum` / `_count` produce an average via `rate(sum)/rate(count)`. Magnitudes (~500 µs for cached SSD reads) match microseconds, but verify with `perftest`-style benchmarks if precision matters. Latency panels fall back to 0 when the disk has no traffic in the window (rather than the more confusing NaN/"No data").
 > 4. **`[2m]` rate windows.** Measured Watch Agent cadence on the SDisk metrics is ~60 s between fresh samples (with occasional 2–12 min outliers). The dashboard uses `[2m]` rate windows so panels update within ~1–2 min of the agent posting fresh data, balanced against the occasional empty point on a scrape gap.
-> 5. **VM-level disk I/O** (the `crusoe_vm_disk_*` family — guest-VM kernel block-device counters) is *not* shown on this dashboard. It's project-wide and node-aggregated rather than per-disk, so it didn't fit the "one disk at a time" focus. If you need it, file a follow-up to ship a separate VM Disk I/O dashboard.
 
 ### Slurm dashboard
 
@@ -345,7 +342,7 @@ The `$cluster` variable is sourced from `label_values(crusoe_slurm_nodes, cluste
 > 2. **Slurm node names don't match Crusoe `vm_name`.** Slurm uses canonical names like `come-scale-away-workers-0`; the Crusoe Metrics relay uses `np-…` for `vm_name`. The two surfaces can't be joined at the node level without an external mapping — so this dashboard doesn't link click-through to the GPU dashboards.
 > 3. **Not all installations expose every state.** Sparse states (`crusoe_slurm_nodes_planned`, `_resv`, `_unknown`, `_maint`) will simply not contribute to the stacked area on a cluster that never enters those states. That's expected — empty isn't broken.
 > 4. **No slurmdbd panel.** The `crusoe_slurm_slurmdbd_queue_size` metric is published but consistently reports 0 on slinky-based Slurm-on-CMK installations (no slurmdbd pod), so showing it was misleading. If your cluster runs Crusoe Managed Slurm with slurmdbd, the metric is meaningful and you can re-add the panel locally.
-> 5. **Single-cluster scope.** The dashboard intentionally surfaces only cluster-wide aggregates. Per-partition (`crusoe_slurm_partition_*`), per-user (`crusoe_slurm_user_jobs_*`), and per-account (`crusoe_slurm_account_jobs_*`) metrics are available and would make good follow-up dashboards if you need that breakdown.
+> 5. **Single-cluster scope.** The dashboard intentionally surfaces only cluster-wide aggregates. Per-partition (`crusoe_slurm_partition_*`), per-user (`crusoe_slurm_user_jobs_*`), and per-account (`crusoe_slurm_account_jobs_*`) metrics are available.
 
 ### Network dashboards
 
@@ -531,7 +528,6 @@ affinity:
               operator: DoesNotExist
 ```
 
-`required` is the right default because a soft preference (`preferredDuringSchedulingIgnoredDuringExecution`) empirically isn't strong enough to override the scheduler's image-cache and PVC-locality heuristics on Crusoe CMK — Grafana stays on whatever GPU node the PVC was last attached to, even when CPU nodes are wide open. Verified on come-scale-away: soft preference left Grafana on a B200; switching to required moved it to a `c2a` node on the next rollout.
 
 Standard Crusoe CMK installs ship with `c1a` / `c2a` CPU nodes for system pods (Slurm controllers, login, etc.), so the hard pin is safe in practice. If your cluster is **GPU-only**, swap the block for the soft-preference variant below.
 
@@ -578,7 +574,6 @@ kubectl get pod -n monitoring -l app.kubernetes.io/name=grafana \
   -o jsonpath='{range .items[*].status.containerStatuses[?(@.name=="grafana")]}restartCount={.restartCount} lastReason={.lastState.terminated.reason} exitCode={.lastState.terminated.exitCode}{"\n"}{end}'
 ```
 
-The OOMKill we hit during testing at 512Mi limit / 1,700 series is the calibration point — if you see `lastReason=OOMKilled` or `exitCode=137` in the second command, or a non-zero `restartCount`, double the memory limit and `helm upgrade`.
 
 If you want `kubectl top` long-term, install the [metrics-server](https://github.com/kubernetes-sigs/metrics-server) yourself; it's not part of the Crusoe Managed Kubernetes default stack.
 

--- a/grafana-cmk/dashboards/cluster-gpu-overview.json
+++ b/grafana-cmk/dashboards/cluster-gpu-overview.json
@@ -608,7 +608,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Top 10 nodes by current average GPU utilization. Useful for identifying hot nodes or underutilized capacity.\n\nTODO: Verify 'node' label name.",
+      "description": "Top 10 nodes by current average GPU utilization. Useful for identifying hot nodes or underutilized capacity.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana-cmk/dashboards/cluster-gpu-overview.json
+++ b/grafana-cmk/dashboards/cluster-gpu-overview.json
@@ -188,7 +188,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "count(count by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
+          "expr": "count(count by (vm_name) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -356,8 +356,8 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "avg by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
-          "legendFormat": "{{node}}",
+          "expr": "avg by (vm_name) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
+          "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],
@@ -595,8 +595,8 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
-          "legendFormat": "{{node}}",
+          "expr": "sum by (vm_name) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
+          "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],
@@ -667,9 +667,9 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "topk(10, avg by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
+          "expr": "topk(10, avg by (vm_name) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
           "instant": true,
-          "legendFormat": "{{node}}",
+          "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],
@@ -1033,8 +1033,8 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "max by (node) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
-          "legendFormat": "{{node}}"
+          "expr": "max by (vm_name) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
+          "legendFormat": "{{vm_name}}"
         }
       ]
     }

--- a/grafana-cmk/dashboards/cluster-gpu-power.json
+++ b/grafana-cmk/dashboards/cluster-gpu-power.json
@@ -540,8 +540,8 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
-          "legendFormat": "{{node}}",
+          "expr": "sum by (vm_name) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
+          "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],
@@ -612,9 +612,9 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
+          "expr": "sum by (vm_name) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
           "instant": true,
-          "legendFormat": "{{node}}",
+          "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],

--- a/grafana-cmk/dashboards/dcgm-xid-errors.json
+++ b/grafana-cmk/dashboards/dcgm-xid-errors.json
@@ -185,8 +185,8 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum by (node) (increase(DCGM_FI_DEV_XID_ERRORS[5m]))",
-          "legendFormat": "{{node}}",
+          "expr": "sum by (vm_name) (increase(DCGM_FI_DEV_XID_ERRORS[5m]))",
+          "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],
@@ -246,7 +246,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum by (node, gpu, xid_id) (increase(DCGM_FI_DEV_XID_ERRORS[24h])) > 0",
+          "expr": "sum by (vm_name, gpu, xid_id) (increase(DCGM_FI_DEV_XID_ERRORS[24h])) > 0",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -323,16 +323,16 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum by (node, gpu) (increase(DCGM_FI_DEV_ECC_DBE_VOL_TOTAL[24h])) > 0",
+          "expr": "sum by (vm_name, gpu) (increase(DCGM_FI_DEV_ECC_DBE_VOL_TOTAL[24h])) > 0",
           "instant": true,
-          "legendFormat": "ECC DBE {{node}} GPU {{gpu}}",
+          "legendFormat": "ECC DBE {{vm_name}} GPU {{gpu}}",
           "refId": "A"
         },
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum by (node, gpu) (increase(DCGM_FI_DEV_CLOCK_THROTTLE_REASONS[24h])) > 0",
+          "expr": "sum by (vm_name, gpu) (increase(DCGM_FI_DEV_CLOCK_THROTTLE_REASONS[24h])) > 0",
           "instant": true,
-          "legendFormat": "Throttle {{node}} GPU {{gpu}}",
+          "legendFormat": "Throttle {{vm_name}} GPU {{gpu}}",
           "refId": "B"
         }
       ],

--- a/grafana-cmk/dashboards/node-gpu-detail.json
+++ b/grafana-cmk/dashboards/node-gpu-detail.json
@@ -97,7 +97,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "DCGM_FI_DEV_GPU_UTIL{node=\"$node\"}",
+          "expr": "DCGM_FI_DEV_GPU_UTIL{vm_name=\"$node\"}",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
         }
@@ -153,7 +153,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "DCGM_FI_DEV_FB_USED{node=\"$node\"}",
+          "expr": "DCGM_FI_DEV_FB_USED{vm_name=\"$node\"}",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
         }
@@ -218,7 +218,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "DCGM_FI_DEV_GPU_TEMP{node=\"$node\"}",
+          "expr": "DCGM_FI_DEV_GPU_TEMP{vm_name=\"$node\"}",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
         }
@@ -274,7 +274,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "DCGM_FI_DEV_POWER_USAGE{node=\"$node\"}",
+          "expr": "DCGM_FI_DEV_POWER_USAGE{vm_name=\"$node\"}",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
         }
@@ -330,13 +330,13 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "DCGM_FI_DEV_SM_CLOCK{node=\"$node\"}",
+          "expr": "DCGM_FI_DEV_SM_CLOCK{vm_name=\"$node\"}",
           "legendFormat": "SM GPU {{gpu}}",
           "refId": "A"
         },
         {
           "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "DCGM_FI_DEV_MEM_CLOCK{node=\"$node\"}",
+          "expr": "DCGM_FI_DEV_MEM_CLOCK{vm_name=\"$node\"}",
           "legendFormat": "Mem GPU {{gpu}}",
           "refId": "B"
         }
@@ -353,7 +353,7 @@
       {
         "current": {},
         "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-        "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, node)",
+        "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, vm_name)",
         "hide": 0,
         "includeAll": false,
         "label": "Node",
@@ -361,7 +361,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(DCGM_FI_DEV_GPU_UTIL, node)",
+          "query": "label_values(DCGM_FI_DEV_GPU_UTIL, vm_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -611,7 +611,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Top 10 nodes by current average GPU utilization. Useful for identifying hot nodes or underutilized capacity.\n\nTODO: Verify 'node' label name.",
+          "description": "Top 10 nodes by current average GPU utilization. Useful for identifying hot nodes or underutilized capacity.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -191,7 +191,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "count(count by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
+              "expr": "count(count by (vm_name) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
               "instant": true,
               "legendFormat": "",
               "refId": "A"
@@ -359,8 +359,8 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "avg by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
-              "legendFormat": "{{node}}",
+              "expr": "avg by (vm_name) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"})",
+              "legendFormat": "{{vm_name}}",
               "refId": "A"
             }
           ],
@@ -598,8 +598,8 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
-              "legendFormat": "{{node}}",
+              "expr": "sum by (vm_name) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
+              "legendFormat": "{{vm_name}}",
               "refId": "A"
             }
           ],
@@ -670,9 +670,9 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "topk(10, avg by (node) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
+              "expr": "topk(10, avg by (vm_name) (DCGM_FI_DEV_GPU_UTIL{cluster_id=~\"$cluster\"}))",
               "instant": true,
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{vm_name}}",
               "refId": "A"
             }
           ],
@@ -1036,8 +1036,8 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "max by (node) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
-              "legendFormat": "{{node}}"
+              "expr": "max by (vm_name) (DCGM_FI_DEV_GPU_TEMP{cluster_id=~\"$cluster\"})",
+              "legendFormat": "{{vm_name}}"
             }
           ]
         }
@@ -1634,8 +1634,8 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
-              "legendFormat": "{{node}}",
+              "expr": "sum by (vm_name) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
+              "legendFormat": "{{vm_name}}",
               "refId": "A"
             }
           ],
@@ -1706,9 +1706,9 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (node) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
+              "expr": "sum by (vm_name) (DCGM_FI_DEV_POWER_USAGE{cluster_id=~\"$cluster\"})",
               "instant": true,
-              "legendFormat": "{{node}}",
+              "legendFormat": "{{vm_name}}",
               "refId": "A"
             }
           ],
@@ -3123,8 +3123,8 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "sum by (node) (increase(DCGM_FI_DEV_XID_ERRORS[5m]))",
-              "legendFormat": "{{node}}",
+              "expr": "sum by (vm_name) (increase(DCGM_FI_DEV_XID_ERRORS[5m]))",
+              "legendFormat": "{{vm_name}}",
               "refId": "A"
             }
           ],
@@ -3184,7 +3184,7 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "sum by (node, gpu, xid_id) (increase(DCGM_FI_DEV_XID_ERRORS[24h])) > 0",
+              "expr": "sum by (vm_name, gpu, xid_id) (increase(DCGM_FI_DEV_XID_ERRORS[24h])) > 0",
               "instant": true,
               "legendFormat": "",
               "refId": "A"
@@ -3261,16 +3261,16 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "sum by (node, gpu) (increase(DCGM_FI_DEV_ECC_DBE_VOL_TOTAL[24h])) > 0",
+              "expr": "sum by (vm_name, gpu) (increase(DCGM_FI_DEV_ECC_DBE_VOL_TOTAL[24h])) > 0",
               "instant": true,
-              "legendFormat": "ECC DBE {{node}} GPU {{gpu}}",
+              "legendFormat": "ECC DBE {{vm_name}} GPU {{gpu}}",
               "refId": "A"
             },
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "sum by (node, gpu) (increase(DCGM_FI_DEV_CLOCK_THROTTLE_REASONS[24h])) > 0",
+              "expr": "sum by (vm_name, gpu) (increase(DCGM_FI_DEV_CLOCK_THROTTLE_REASONS[24h])) > 0",
               "instant": true,
-              "legendFormat": "Throttle {{node}} GPU {{gpu}}",
+              "legendFormat": "Throttle {{vm_name}} GPU {{gpu}}",
               "refId": "B"
             }
           ],
@@ -4768,7 +4768,7 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "DCGM_FI_DEV_GPU_UTIL{node=\"$node\"}",
+              "expr": "DCGM_FI_DEV_GPU_UTIL{vm_name=\"$node\"}",
               "legendFormat": "GPU {{gpu}}",
               "refId": "A"
             }
@@ -4824,7 +4824,7 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "DCGM_FI_DEV_FB_USED{node=\"$node\"}",
+              "expr": "DCGM_FI_DEV_FB_USED{vm_name=\"$node\"}",
               "legendFormat": "GPU {{gpu}}",
               "refId": "A"
             }
@@ -4889,7 +4889,7 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "DCGM_FI_DEV_GPU_TEMP{node=\"$node\"}",
+              "expr": "DCGM_FI_DEV_GPU_TEMP{vm_name=\"$node\"}",
               "legendFormat": "GPU {{gpu}}",
               "refId": "A"
             }
@@ -4945,7 +4945,7 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "DCGM_FI_DEV_POWER_USAGE{node=\"$node\"}",
+              "expr": "DCGM_FI_DEV_POWER_USAGE{vm_name=\"$node\"}",
               "legendFormat": "GPU {{gpu}}",
               "refId": "A"
             }
@@ -5001,13 +5001,13 @@ data:
           "targets": [
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "DCGM_FI_DEV_SM_CLOCK{node=\"$node\"}",
+              "expr": "DCGM_FI_DEV_SM_CLOCK{vm_name=\"$node\"}",
               "legendFormat": "SM GPU {{gpu}}",
               "refId": "A"
             },
             {
               "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-              "expr": "DCGM_FI_DEV_MEM_CLOCK{node=\"$node\"}",
+              "expr": "DCGM_FI_DEV_MEM_CLOCK{vm_name=\"$node\"}",
               "legendFormat": "Mem GPU {{gpu}}",
               "refId": "B"
             }
@@ -5024,7 +5024,7 @@ data:
           {
             "current": {},
             "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-            "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, node)",
+            "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, vm_name)",
             "hide": 0,
             "includeAll": false,
             "label": "Node",
@@ -5032,7 +5032,7 @@ data:
             "name": "node",
             "options": [],
             "query": {
-              "query": "label_values(DCGM_FI_DEV_GPU_UTIL, node)",
+              "query": "label_values(DCGM_FI_DEV_GPU_UTIL, vm_name)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,


### PR DESCRIPTION
Follow-up to PR #36. Two small cleanup commits that landed on the network-dashboards branch after the merge had already happened, so they need their own PR.

## Summary

- **Group GPU dashboards by `vm_name` instead of FQDN `node` label.** DCGM metrics expose both labels; the short form keeps legends compact and consistent with the rest of the dashboard set (the network and thermal Top-N panels already use vm_name). Affects Cluster GPU Overview, Cluster GPU Power, DCGM & Xid Errors, and Node GPU Detail. The `$node` template variable name is preserved so URL params still resolve; only the values it lists change from FQDNs to short names. Slurm dashboard is untouched — its `node` label is the Slurm canonical name with no `vm_name` cross-walk.
- **Remove resolved TODO** on the Top-10 Nodes by Avg GPU Utilization panel description. The TODO asked to verify the `node` label existed on `DCGM_FI_DEV_GPU_UTIL`; verified live against the Crusoe Metrics API. Now redundant since the panel was switched to `vm_name` in the same PR.

## Test plan

- [ ] Pull this branch and `kubectl apply -f grafana-cmk/manifests/grafana-dashboards-configmap.yaml`.
- [ ] Open the GPU dashboards, confirm legends now read as short `np-…` names instead of fully-qualified `np-…compute.internal`.
- [ ] Open Node GPU Detail, confirm the Node dropdown lists short vm_names and the per-GPU panels populate when one is selected.
- [ ] Confirm 192 unique vm_names show up across the affected metric families.