### PR TITLE
grafana-cmk: GPU health / slow-node detection panels on DCGM dashboard

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -268,9 +268,23 @@ All dashboards live in the `Crusoe` folder in Grafana. Most have a **Cluster** d
 
 **Cluster GPU Power (`cluster-gpu-power.json`)** — aggregate and per-node power draw across the cluster, plus per-GPU power distribution histogram.
 
-**DCGM & Xid Errors (`dcgm-xid-errors.json`)** — Xid + ECC tracking. Stat panels that turn red on any non-zero value, error rate by node over time, breakdown table by node / GPU / Xid code, and a DCGM health table for double-bit ECC and thermal violations. Xid code meanings: [NVIDIA's Xid error reference](https://docs.nvidia.com/deploy/xid-errors/).
+**DCGM & Xid Errors (`dcgm-xid-errors.json`, 18 panels)** — Xid + ECC tracking, plus a GPU Health section designed for slow-node detection during training runs.
 
-> **Note on the `xid_id` label:** Panels that break down errors by Xid code use `sum by (node, gpu, xid_id)`. This label name is confirmed on Managed Slurm clusters. If the table shows no rows, verify the label name with the discovery curl in the Troubleshooting section.
+- **Top section: Xid + DBE.** Stat cards that turn red on any non-zero value, Xid rate by node over time, breakdown table by node / GPU / Xid code, and a Health Failures table that lists any GPU with a new ECC DBE volatile increase or an uncorrectable HBM row remapping in the last 24h. Xid code meanings: [NVIDIA's Xid error reference](https://docs.nvidia.com/deploy/xid-errors/).
+- **GPU Health Indicators — Slow Node Detection.** Six headline stats (active SBE GPUs, GPUs with remapped rows, uncorrectable rows, 24 h PCIe replay delta, 24 h SBE volatile delta, cluster lifetime SBE) plus four leaderboard tables for drill-in:
+  - **Top 15 by Lifetime Aggregate SBE** — fleet-quality view; identifies GPUs whose HBM dies have produced the most single-bit corrections since first power-on. Useful for picking which nodes to drain when capacity allows or which to exclude from latency-critical jobs.
+  - **Top 15 by Correctable Remapped Rows** — GPUs with HBM rows DCGM has retired. They still work but have slightly less HBM and can be marginally slower than peers on remap-region accesses.
+  - **Top 15 by 24h SBE Volatile Growth** — who is struggling *right now*, in contrast to the lifetime view. Start here when chasing a same-day slow-node symptom.
+  - **Red Flag GPUs** — any GPU with either an uncorrectable remapped row or a non-zero PCIe replay increase in the last 24 h. Either condition warrants pulling the node from training and filing for hardware investigation.
+- **Time series for trend.** SBE volatile rate by node (top 20 over 6 h) so you can see *when* ECC pressure was happening, and Tensor Core Utilization by node (last 1 h) to spot performance outliers — a node consistently below its peers during steady-state training is the strongest "this node is dragging the collective" signal short of an outright Xid event.
+
+> **Notes & caveats:**
+>
+> 1. **Volatile vs aggregate ECC counters.** `DCGM_FI_DEV_ECC_SBE_VOL_TOTAL` resets on GPU reset/reboot — it captures "this session's" correction work. `DCGM_FI_DEV_ECC_SBE_AGG_TOTAL` accumulates over the GPU's lifetime. Both are surfaced because the questions they answer are different.
+> 2. **`DCGM_FI_DEV_CLOCK_THROTTLE_REASONS` is not collected.** The Crusoe Watch Agent does not publish this metric today, so the Health Failures panel originally combining DBE with throttle reasons was silently empty on the throttle half. It now combines DBE with uncorrectable remapped rows instead.
+> 3. **Idle and active GPUs share the SBE timeseries.** Top-20 by `rate(... [15m])` will return 20 series even on a quiet cluster — most will be flat zero. That is the healthy state.
+> 4. **Tensor utilization is per-node averaged across that node's 8 GPUs.** A single bad GPU on an 8-GPU node will only drag the average down by ~12 percentage points, but in collective workloads that's exactly enough to make it the step-time bottleneck.
+> 5. **`xid_id` label.** Panels that break down errors by Xid code use `sum by (vm_name, gpu, xid_id)`. This label name is confirmed on Managed Slurm clusters; if the table shows no rows, verify the label name with the discovery curl in the Troubleshooting section.
 
 ### InfiniBand dashboards
 

--- a/grafana-cmk/dashboards/dcgm-xid-errors.json
+++ b/grafana-cmk/dashboards/dcgm-xid-errors.json
@@ -11,17 +11,45 @@
   ],
   "__elements": {},
   "__requires": [
-    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "11.0.0"},
-    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"},
-    {"type": "panel", "id": "stat", "name": "Stat", "version": ""},
-    {"type": "panel", "id": "timeseries", "name": "Time series", "version": ""},
-    {"type": "panel", "id": "table", "name": "Table", "version": ""}
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
   ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -30,7 +58,7 @@
       }
     ]
   },
-  "description": "DCGM Xid errors and GPU health check failures across the cluster. Xid errors indicate GPU hardware or driver issues — see https://docs.nvidia.com/deploy/xid-errors/ for error code reference. Data sourced from Crusoe Metrics (Watch Agent provides DCGM metrics; no separate DCGM exporter installation is required).",
+  "description": "DCGM Xid errors and GPU health check failures across the cluster. Xid errors indicate GPU hardware or driver issues \u2014 see https://docs.nvidia.com/deploy/xid-errors/ for error code reference. Data sourced from Crusoe Metrics (Watch Agent provides DCGM metrics; no separate DCGM exporter installation is required). | GPU Health section added: SBE/DBE counters, remapped rows, PCIe replay, tensor-core utilization. Designed for slow-node detection during training runs.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -41,7 +69,10 @@
       "icon": "arrow-left",
       "includeVars": false,
       "keepTime": true,
-      "tags": ["crusoe", "gpu"],
+      "tags": [
+        "crusoe",
+        "gpu"
+      ],
       "targetBlank": false,
       "title": "Cluster GPU Overview",
       "tooltip": "",
@@ -51,40 +82,74 @@
   ],
   "panels": [
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Total Xid errors recorded across all GPUs in the last 24 hours. Any non-zero value warrants investigation.\n\nFor Xid error code meanings see: https://docs.nvidia.com/deploy/xid-errors/",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            {"options": {"0": {"color": "green", "index": 0, "text": "0 — Clean"}}, "type": "value"}
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "0 \u2014 Clean"
+                }
+              },
+              "type": "value"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "red", "value": 1}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {"calcs": ["sum"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum(increase(DCGM_FI_DEV_XID_ERRORS[24h]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(increase(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h]))",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -94,41 +159,78 @@
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Total ECC double-bit errors in the last 24 hours. DCGM_FI_DEV_ECC_DBE_VOL_TOTAL counts volatile (since-reset) double-bit errors. Persistent non-zero values indicate failing GPU memory.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            {"options": {"0": {"color": "green", "index": 0, "text": "0 — Clean"}}, "type": "value"}
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "0 \u2014 Clean"
+                }
+              },
+              "type": "value"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 1},
-              {"color": "red", "value": 10}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
       "id": 2,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {"calcs": ["sum"], "fields": "", "values": false},
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum(increase(DCGM_FI_DEV_ECC_DBE_VOL_TOTAL[24h]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(increase(DCGM_FI_DEV_ECC_DBE_VOL_TOTAL{cluster_id=~\"$cluster\"}[24h]))",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -138,11 +240,16 @@
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
       "description": "Xid error rate per node over time. A sudden spike typically indicates a driver crash, hardware fault, or workload-induced GPU reset.\n\nFor Xid code reference: https://docs.nvidia.com/deploy/xid-errors/",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -153,39 +260,71 @@
             "drawStyle": "bars",
             "fillOpacity": 80,
             "gradientMode": "none",
-            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": {"type": "linear"},
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": true,
-            "stacking": {"group": "A", "mode": "normal"},
-            "thresholdsStyle": {"mode": "off"}
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "min": 0,
-          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 4},
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
       "id": 3,
       "options": {
         "legend": {
-          "calcs": ["sum"],
+          "calcs": [
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum by (vm_name) (increase(DCGM_FI_DEV_XID_ERRORS[5m]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name) (increase(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[5m]))",
           "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
@@ -194,35 +333,65 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-      "description": "Recent Xid errors grouped by node, GPU, and Xid error code. For Xid code meanings see: https://docs.nvidia.com/deploy/xid-errors/\n\nNote: the xid_id label name may differ — check the actual label names with the scrape discovery curl in the Troubleshooting section if this panel shows no data.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "description": "Recent Xid errors grouped by node, GPU, and Xid error code. For Xid code meanings see: https://docs.nvidia.com/deploy/xid-errors/\n\nNote: the xid_id label name may differ \u2014 check the actual label names with the scrape discovery curl in the Troubleshooting section if this panel shows no data.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
             "align": "auto",
-            "cellOptions": {"type": "auto"},
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
           "mappings": [],
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Value"},
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
             "properties": [
-              {"id": "displayName", "value": "Error Count"},
+              {
+                "id": "displayName",
+                "value": "Error Count"
+              },
               {
                 "id": "custom.cellOptions",
-                "value": {"mode": "basic", "type": "color-background"}
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
               },
               {
                 "id": "thresholds",
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    {"color": "green", "value": null},
-                    {"color": "red", "value": 1}
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
                   ]
                 }
               }
@@ -230,23 +399,38 @@
           }
         ]
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
       "id": 4,
       "options": {
         "cellHeight": "sm",
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
-        "sortBy": [{"desc": true, "displayName": "Error Count"}]
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Error Count"
+          }
+        ]
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum by (vm_name, gpu, xid_id) (increase(DCGM_FI_DEV_XID_ERRORS[24h])) > 0",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name, gpu, xid_id) (increase(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h])) > 0",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -256,13 +440,22 @@
       "transformations": [
         {
           "id": "labelsToFields",
-          "options": {"mode": "columns"}
+          "options": {
+            "mode": "columns"
+          }
         },
         {
           "id": "organize",
           "options": {
-            "excludeByName": {"Time": true},
-            "indexByName": {"node": 0, "gpu": 1, "xid_id": 2, "Value": 3},
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "node": 0,
+              "gpu": 1,
+              "xid_id": 2,
+              "Value": 3
+            },
             "renameByName": {}
           }
         }
@@ -270,36 +463,69 @@
       "type": "table"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-      "description": "DCGM GPU health failures: ECC double-bit errors and clock throttle events per node/GPU in the last 24 hours. DCGM_FI_DEV_ECC_DBE_VOL_TOTAL is the volatile double-bit ECC error counter. DCGM_FI_DEV_CLOCK_THROTTLE_REASONS is a bitmask — any non-zero increase indicates throttling events.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "description": "Cluster-wide ECC DBE volatile increases and any GPU reporting uncorrectable HBM row remappings. Both are urgent: DBE volatile = a currently-running double-bit error correction; uncorrectable remapped rows = HBM regions DCGM has retired permanently. Either warrants pulling the node from a training run and filing for hardware investigation.",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
             "align": "auto",
-            "cellOptions": {"type": "auto"},
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
           "mappings": [],
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Value"},
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
             "properties": [
-              {"id": "displayName", "value": "Event Count"},
+              {
+                "id": "displayName",
+                "value": "Event Count"
+              },
               {
                 "id": "custom.cellOptions",
-                "value": {"mode": "basic", "type": "color-background"}
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
               },
               {
                 "id": "thresholds",
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    {"color": "green", "value": null},
-                    {"color": "yellow", "value": 1},
-                    {"color": "red", "value": 10}
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 10
+                    }
                   ]
                 }
               }
@@ -307,32 +533,50 @@
           }
         ]
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
       "id": 5,
       "options": {
         "cellHeight": "sm",
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
-        "sortBy": [{"desc": true, "displayName": "Event Count"}]
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Event Count"
+          }
+        ]
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum by (vm_name, gpu) (increase(DCGM_FI_DEV_ECC_DBE_VOL_TOTAL[24h])) > 0",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name, gpu) (increase(DCGM_FI_DEV_ECC_DBE_VOL_TOTAL{cluster_id=~\"$cluster\"}[24h])) > 0",
           "instant": true,
           "legendFormat": "ECC DBE {{vm_name}} GPU {{gpu}}",
           "refId": "A"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "crusoe-metrics"},
-          "expr": "sum by (vm_name, gpu) (increase(DCGM_FI_DEV_CLOCK_THROTTLE_REASONS[24h])) > 0",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name, gpu) (DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS{cluster_id=~\"$cluster\"}) > 0",
           "instant": true,
-          "legendFormat": "Throttle {{vm_name}} GPU {{gpu}}",
+          "legendFormat": "Uncorrectable Remap {{vm_name}} GPU {{gpu}}",
           "refId": "B"
         }
       ],
@@ -340,21 +584,1109 @@
       "transformations": [
         {
           "id": "labelsToFields",
-          "options": {"mode": "columns"}
+          "options": {
+            "mode": "columns"
+          }
         }
       ],
       "type": "table"
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "GPU Health Indicators \u2014 Slow Node Detection",
+      "gridPos": {
+        "x": 0,
+        "y": 20,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Active SBE GPUs",
+      "description": "Count of GPUs currently reporting a non-zero ECC single-bit error volatile counter. A non-zero volatile counter means the GPU is actively correcting SBEs since its last reset \u2014 usually benign on its own, but worth knowing when a slow-node hunt is underway.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "count(DCGM_FI_DEV_ECC_SBE_VOL_TOTAL{cluster_id=~\"$cluster\"} > 0) or vector(0)",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "GPUs With Remapped Rows",
+      "description": "Count of GPUs that have any correctable HBM row remapping recorded. Once a row is remapped DCGM routes around it; the GPU still works but capacity is reduced and remapped-row accesses are slower. A growing count over time is the classic 'HBM is degrading' signal.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 21,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "count(DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS{cluster_id=~\"$cluster\"} > 0) or vector(0)",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Uncorrectable Rows",
+      "description": "Cluster-total of HBM rows DCGM has marked uncorrectable. Should be 0. Any non-zero value means at least one GPU has bad HBM that cannot be remapped \u2014 the GPU should be drained and replaced.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 21,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS{cluster_id=~\"$cluster\"}) or vector(0)",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "24h PCIe Replays",
+      "description": "Cluster-wide increase in PCIe replay events over the last 24h. Non-zero indicates physical-layer PCIe link issues \u2014 bus glitches, marginal connectors, or a failing host bridge. Even small numbers (10s/day) can indicate a developing problem.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 21,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(increase(DCGM_FI_DEV_PCIE_REPLAY_COUNTER{cluster_id=~\"$cluster\"}[24h])) or vector(0)",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "24h SBE Volatile \u0394",
+      "description": "Cluster-wide increase in single-bit ECC corrections in the last 24h. Per-GPU rates of dozens to low thousands per day under sustained load are normal on healthy HBM; runaway growth on one node is a slow-node candidate.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 21,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(increase(DCGM_FI_DEV_ECC_SBE_VOL_TOTAL{cluster_id=~\"$cluster\"}[24h])) or vector(0)",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Lifetime SBE (\u03a3)",
+      "description": "Fleet-wide lifetime aggregate of single-bit ECC corrections (across all HBM dies on all GPUs). Mainly useful as a reference point; the distribution (which GPUs contribute most) is what matters \u2014 see the leaderboard below.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 21,
+        "w": 4,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(DCGM_FI_DEV_ECC_SBE_AGG_TOTAL{cluster_id=~\"$cluster\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "table",
+      "title": "Top 15 GPUs by Lifetime Aggregate SBE",
+      "description": "Fleet quality leaderboard. GPUs at the top of this list have HBM dies that have produced the most single-bit corrections since first power-on. They are not necessarily failing, but are statistically more likely to slow down or degrade further. Useful for picking which nodes to drain when capacity allows or which to exclude from latency-critical jobs.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 25,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "displayName": "Lifetime SBE",
+            "desc": true
+          }
+        ]
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Lifetime SBE"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(15, sum by (vm_name, gpu) (DCGM_FI_DEV_ECC_SBE_AGG_TOTAL{cluster_id=~\"$cluster\"}))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "cluster_id": true,
+              "device": true,
+              "Hostname": true,
+              "UUID": true,
+              "container": true,
+              "namespace": true,
+              "pod": true,
+              "crusoe_resource": true,
+              "location": true,
+              "metrics_source": true,
+              "nodepool": true,
+              "ib_network_id": true,
+              "ib_network_name": true,
+              "modelName": true,
+              "pci_bus_id": true,
+              "vm_id": true,
+              "DCGM_FI_DRIVER_VERSION": true,
+              "node_id": true,
+              "organization_id": true,
+              "project_id": true,
+              "vm_instance_type": true,
+              "vpc_network_id": true,
+              "pod_id": true,
+              "nodepool_name": true,
+              "node": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "table",
+      "title": "Top 15 GPUs by Correctable Remapped Rows",
+      "description": "GPUs that currently have correctable HBM rows remapped. Each remapped row is a region DCGM has retired because of repeated correctable errors. The GPU still works but has slightly less usable HBM, and accesses to the remap-region can be marginally slower than peers. Sudden increases or unusually high counts are reasons to drain.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 25,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "displayName": "Remapped Rows",
+            "desc": true
+          }
+        ]
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Remapped Rows"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(15, sum by (vm_name, gpu) (DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS{cluster_id=~\"$cluster\"}) > 0)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "cluster_id": true,
+              "device": true,
+              "Hostname": true,
+              "UUID": true,
+              "container": true,
+              "namespace": true,
+              "pod": true,
+              "crusoe_resource": true,
+              "location": true,
+              "metrics_source": true,
+              "nodepool": true,
+              "ib_network_id": true,
+              "ib_network_name": true,
+              "modelName": true,
+              "pci_bus_id": true,
+              "vm_id": true,
+              "DCGM_FI_DRIVER_VERSION": true,
+              "node_id": true,
+              "organization_id": true,
+              "project_id": true,
+              "vm_instance_type": true,
+              "vpc_network_id": true,
+              "pod_id": true,
+              "nodepool_name": true,
+              "node": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "table",
+      "title": "Top 15 GPUs by 24h SBE Volatile Growth",
+      "description": "Which GPUs are doing the most ECC correction work in the last 24h. This is the 'who is struggling right now' view, in contrast to the lifetime leaderboard. If you're chasing a slow-node symptom that emerged today, start here.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 35,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "displayName": "24h SBE \u0394",
+            "desc": true
+          }
+        ]
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "24h SBE \u0394"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(15, sum by (vm_name, gpu) (increase(DCGM_FI_DEV_ECC_SBE_VOL_TOTAL{cluster_id=~\"$cluster\"}[24h])) > 0)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "cluster_id": true,
+              "device": true,
+              "Hostname": true,
+              "UUID": true,
+              "container": true,
+              "namespace": true,
+              "pod": true,
+              "crusoe_resource": true,
+              "location": true,
+              "metrics_source": true,
+              "nodepool": true,
+              "ib_network_id": true,
+              "ib_network_name": true,
+              "modelName": true,
+              "pci_bus_id": true,
+              "vm_id": true,
+              "DCGM_FI_DRIVER_VERSION": true,
+              "node_id": true,
+              "organization_id": true,
+              "project_id": true,
+              "vm_instance_type": true,
+              "vpc_network_id": true,
+              "pod_id": true,
+              "nodepool_name": true,
+              "node": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "table",
+      "title": "Red Flag GPUs (Uncorrectable Rows or PCIe Replays in 24h)",
+      "description": "GPUs with at least one of: an uncorrectable remapped row right now, or a non-zero PCIe replay-counter increase in the last 24h. Either condition warrants pulling the node from training and filing for hardware investigation \u2014 uncorrectable rows can manifest as silent data corruption, and sustained PCIe replays cap effective per-GPU bandwidth.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 35,
+        "w": 12,
+        "h": 10
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "displayName": "Severity (uncorrectable + 24h replay)",
+            "desc": true
+          }
+        ]
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Severity (uncorrectable + 24h replay)"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum by (vm_name, gpu) (DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS{cluster_id=~\"$cluster\"} + increase(DCGM_FI_DEV_PCIE_REPLAY_COUNTER{cluster_id=~\"$cluster\"}[24h])) > 0",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "cluster_id": true,
+              "device": true,
+              "Hostname": true,
+              "UUID": true,
+              "container": true,
+              "namespace": true,
+              "pod": true,
+              "crusoe_resource": true,
+              "location": true,
+              "metrics_source": true,
+              "nodepool": true,
+              "ib_network_id": true,
+              "ib_network_name": true,
+              "modelName": true,
+              "pci_bus_id": true,
+              "vm_id": true,
+              "DCGM_FI_DRIVER_VERSION": true,
+              "node_id": true,
+              "organization_id": true,
+              "project_id": true,
+              "vm_instance_type": true,
+              "vpc_network_id": true,
+              "pod_id": true,
+              "nodepool_name": true,
+              "node": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "SBE Volatile Rate by Node (last 6h)",
+      "description": "Per-GPU SBE correction rate (15m windows, top 20). Spikes correlate with periods of heavy HBM bandwidth pressure \u2014 e.g., the gradient-allreduce of a training step. Persistently elevated rate on a single GPU is a slow-node candidate; correlated bursts across many GPUs usually mean the workload itself is HBM-stressing.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 45,
+        "w": 24,
+        "h": 8
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "topk(20, rate(DCGM_FI_DEV_ECC_SBE_VOL_TOTAL{cluster_id=~\"$cluster\"}[15m]))",
+          "legendFormat": "{{vm_name}} GPU {{gpu}}"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Tensor Core Utilization by Node (last 1h)",
+      "description": "Tensor-core utilization per node (avg across that node's GPUs). On a B200 under matmul-heavy training, healthy nodes typically average 50\u201380% during the steady-state of a step. A node consistently 20+ percentage points below its peers, while the rest are pushing tensors, is the strongest 'this node is dragging the collective' signal short of an outright Xid event.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 53,
+        "w": 24,
+        "h": 8
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "avg by (vm_name) (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{cluster_id=~\"$cluster\"})",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
     }
   ],
   "refresh": "5m",
   "schemaVersion": 39,
-  "tags": ["crusoe", "gpu", "dcgm", "xid"],
-  "templating": {"list": []},
-  "time": {"from": "now-24h", "to": "now"},
+  "tags": [
+    "crusoe",
+    "gpu",
+    "dcgm",
+    "xid"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "query": {
+          "query": "label_values(DCGM_FI_DEV_GPU_UTIL, cluster_id)",
+          "refId": "A"
+        },
+        "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, cluster_id)",
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".+",
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "DCGM & Xid Errors",
   "uid": "crusoe-dcgm-xid-errors",
-  "version": 1,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

Expands the DCGM & Xid Errors dashboard from 5 → 18 panels with a new **GPU Health Indicators** section designed for finding slow nodes during training, and fixes two latent bugs along the way.

### New panels

**Headline stats** (six 4w cards):
- Active SBE GPUs · GPUs With Remapped Rows · Uncorrectable Rows · 24 h PCIe Replays · 24 h SBE Volatile Δ · Lifetime SBE Σ

**Leaderboard tables**:
- **Top 15 by Lifetime Aggregate SBE** — fleet quality view; surfaces HBM dies that have done the most correction work since first power-on.
- **Top 15 by Correctable Remapped Rows** — current HBM degradation per GPU.
- **Top 15 by 24 h SBE Volatile Growth** — who is correcting *right now*.
- **Red Flag GPUs** — any GPU with an uncorrectable row OR a non-zero PCIe replay delta in 24 h. Both warrant pulling the node from training.

**Time view**:
- **SBE Volatile Rate by Node** (top 20, 6 h) — see when ECC pressure spiked.
- **Tensor Core Utilization by Node** (last 1 h) — the strongest performance-side slow-node signal. A node averaging well below its peers during steady-state training is the bottleneck for collective ops.

### Bug fixes

1. **The original Health Failures panel was silently empty.** It queried `DCGM_FI_DEV_CLOCK_THROTTLE_REASONS`, which the Crusoe Watch Agent does not collect. Replaced with `DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS`, which IS collected and matches the panel's urgent-hardware-attention purpose.
2. **Every panel on this dashboard was filtering on `{cluster_id=~"$cluster"}` without the variable being defined.** Grafana substituted an empty string, so every filter became `{cluster_id=~""}` and matched nothing. Added the `$cluster` variable, sourced from `label_values(DCGM_FI_DEV_GPU_UTIL, cluster_id)`, defaulting to "All" — same pattern as the other GPU dashboards.

## README updates

- Dashboard description: full panel inventory + four caveats covering volatile vs aggregate ECC, the missing `CLOCK_THROTTLE_REASONS` metric, idle GPUs in the SBE timeseries, and tensor-utilization averaging math.

## Out of scope — see follow-up PR

The bundled `manifests/grafana-dashboards-configmap.yaml` is **not** updated by this PR. With the new panels, the combined ConfigMap exceeds the 256 KiB per-resource annotation limit on client-side `kubectl apply`. A follow-up PR restructures the manifest from one combined ConfigMap into one ConfigMap per dashboard (still labeled `grafana_dashboard=1`, still picked up by the k8s-sidecar). After both PRs merge, regenerate the manifest with the snippet in README's Troubleshooting section.

## Test plan

- [ ] Pull this branch.
- [ ] Open the dashboard JSON in your editor and confirm 18 panels are present.
- [ ] Apply the dashboard via whichever deploy method you use (the follow-up PR makes the manifest re-apply ergonomic; until then either `kubectl apply --server-side --force-conflicts` or per-dashboard regen).
- [ ] Open Grafana → Crusoe → DCGM & Xid Errors. Confirm the **Cluster** dropdown appears at the top and panels populate.
- [ ] Headline stat row populates (numbers may be zero on a quiet cluster — that's healthy).
- [ ] Top-15 lifetime SBE leaderboard sorts descending.
- [ ] The Health Failures table no longer references `CLOCK_THROTTLE_REASONS`.