### PR TITLE
grafana-cmk: split dashboards ConfigMap into one CM per dashboard

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -429,27 +429,37 @@ curl -s -G "https://api.crusoecloud.com/v1alpha5/projects/${PROJECT_ID}/metrics/
   | python3 -c "import sys,json; d=json.load(sys.stdin); [print(r['metric']) for r in d.get('data',{}).get('result',[])]"
 ```
 
-If metric names differ from what the dashboards expect, update the `expr` field in the relevant panels (or the corresponding JSON in `dashboards/`). After editing the JSON, regenerate the dashboards ConfigMap:
+If metric names differ from what the dashboards expect, update the `expr` field in the relevant panels (or the corresponding JSON in `dashboards/`). After editing the JSON, regenerate `manifests/grafana-dashboards-configmap.yaml` — one ConfigMap per dashboard, all labeled `grafana_dashboard: "1"` so the k8s-sidecar picks them up:
 
 ```bash
-kubectl create configmap crusoe-dashboards \
-  --namespace=monitoring \
-  --from-file=cluster-gpu-overview.json=dashboards/cluster-gpu-overview.json \
-  --from-file=node-gpu-detail.json=dashboards/node-gpu-detail.json \
-  --from-file=dcgm-xid-errors.json=dashboards/dcgm-xid-errors.json \
-  --from-file=cluster-gpu-power.json=dashboards/cluster-gpu-power.json \
-  --from-file=cluster-ib-overview.json=dashboards/cluster-ib-overview.json \
-  --from-file=node-ib-detail.json=dashboards/node-ib-detail.json \
-  --from-file=storage-cluster-overview.json=dashboards/storage-cluster-overview.json \
-  --from-file=slurm-cluster-overview.json=dashboards/slurm-cluster-overview.json \
-  --from-file=network-cluster-overview.json=dashboards/network-cluster-overview.json \
-  --from-file=node-network-detail.json=dashboards/node-network-detail.json \
-  --dry-run=client -o yaml \
-  | sed 's/^metadata:$/metadata:\n  labels:\n    grafana_dashboard: "1"/' \
-  | kubectl apply -f -
+cd grafana-cmk
+{
+  echo "# Auto-generated: one ConfigMap per dashboard, all labeled grafana_dashboard=\"1\"."
+  echo "# Splitting keeps each CM small enough that client-side \`kubectl apply -f\` stays"
+  echo "# under the 256 KiB per-resource annotation limit."
+} > manifests/grafana-dashboards-configmap.yaml
+first=1
+for f in dashboards/*.json; do
+  name=$(basename "$f" .json)
+  [ $first -eq 1 ] && first=0 || echo "---" >> manifests/grafana-dashboards-configmap.yaml
+  kubectl create configmap "crusoe-dashboard-$name" \
+    --namespace=monitoring \
+    --from-file="${name}.json=$f" \
+    --dry-run=client -o yaml \
+    | sed '/creationTimestamp/d' \
+    | sed 's/^metadata:$/metadata:\n  labels:\n    grafana_dashboard: "1"/' \
+    >> manifests/grafana-dashboards-configmap.yaml
+done
+kubectl apply -f manifests/grafana-dashboards-configmap.yaml
 ```
 
 The `grafana_dashboard: "1"` label is what the sidecar watches — without it, the sidecar will not pick up the ConfigMap. The sidecar reloads dashboards within a minute.
+
+> **Migrating from a pre-split deployment?** Earlier releases shipped a single combined ConfigMap named `crusoe-dashboards`. If you were on that, delete it first so the sidecar doesn't load the same dashboards twice:
+>
+> ```bash
+> kubectl delete configmap crusoe-dashboards -n monitoring --ignore-not-found
+> ```
 
 ### LoadBalancer service stuck in `<pending>` for external IP
 

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -1,3 +1,15 @@
+# Provided AS IS without warranty of any kind — see grafana-cmk/README.md → Disclaimer.
+#
+# Auto-generated: one ConfigMap per dashboard, all labeled grafana_dashboard="1".
+# The k8s-sidecar deployed alongside Grafana picks them all up by label, so splitting
+# vs. bundling makes no application-layer difference. Splitting keeps each CM small
+# enough that client-side `kubectl apply -f` stays under the 256 KiB per-resource
+# annotation limit even as individual dashboards grow.
+#
+# Migrating from an earlier release that shipped a single combined CM named
+# "crusoe-dashboards"? Delete it first to avoid duplicate dashboard loads:
+#   kubectl delete configmap crusoe-dashboards -n monitoring
+# Then apply this file.
 apiVersion: v1
 data:
   cluster-gpu-overview.json: |-
@@ -1091,6 +1103,15 @@ data:
       "version": 8,
       "weekStart": ""
     }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: crusoe-dashboard-cluster-gpu-overview
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   cluster-gpu-power.json: |-
     {
       "__inputs": [
@@ -1905,6 +1926,15 @@ data:
       "version": 2,
       "weekStart": ""
     }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: crusoe-dashboard-cluster-gpu-power
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   cluster-ib-overview.json: |-
     {
       "uid": "crusoe-ib-cluster",
@@ -2935,6 +2965,15 @@ data:
         }
       ]
     }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: crusoe-dashboard-cluster-ib-overview
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   dcgm-xid-errors.json: |
     {
       "__inputs": [
@@ -3296,6 +3335,15 @@ data:
       "version": 1,
       "weekStart": ""
     }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: crusoe-dashboard-dcgm-xid-errors
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   network-cluster-overview.json: |-
     {
       "uid": "crusoe-network-cluster",
@@ -4668,6 +4716,15 @@ data:
       ],
       "description": "Frontend ethernet RX/TX and ELB stats. Frontend NIC is `ens7` on B200 workers, `ens3` on CPU/login. ELBs are project-scoped \u2014 no cluster filter applies to them. GPU collective traffic is on the IB fabric (see IB dashboards), not here."
     }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: crusoe-dashboard-network-cluster-overview
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   node-gpu-detail.json: |
     {
       "__inputs": [
@@ -5050,6 +5107,15 @@ data:
       "version": 1,
       "weekStart": ""
     }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: crusoe-dashboard-node-gpu-detail
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   node-ib-detail.json: |-
     {
       "uid": "crusoe-ib-node",
@@ -5766,6 +5832,15 @@ data:
         }
       ]
     }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: crusoe-dashboard-node-ib-detail
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   node-network-detail.json: |-
     {
       "uid": "crusoe-node-network-detail",
@@ -6466,6 +6541,15 @@ data:
       ],
       "description": "Per-node frontend ethernet detail. Use the $node dropdown to filter to one or many vm_names; defaults to All. To see a high-traffic node, hop here from the Top-N panel on Network Cluster View by clicking the legend entry."
     }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: crusoe-dashboard-node-network-detail
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   slurm-cluster-overview.json: |-
     {
       "uid": "crusoe-slurm-cluster",
@@ -7791,6 +7875,15 @@ data:
         }
       ]
     }
+kind: ConfigMap
+metadata:
+  labels:
+    grafana_dashboard: "1"
+  name: crusoe-dashboard-slurm-cluster-overview
+  namespace: monitoring
+---
+apiVersion: v1
+data:
   storage-cluster-overview.json: |-
     {
       "uid": "crusoe-storage-cluster",
@@ -8375,5 +8468,5 @@ kind: ConfigMap
 metadata:
   labels:
     grafana_dashboard: "1"
-  name: crusoe-dashboards
+  name: crusoe-dashboard-storage-cluster-overview
   namespace: monitoring


### PR DESCRIPTION
## Why

The combined dashboards ConfigMap is bumping into the **Kubernetes 256 KiB per-resource annotation limit**. Concretely, this command — the documented deploy step in the README — fails:

```
The ConfigMap "crusoe-dashboards" is invalid:
metadata.annotations: Too long: may not be more than 262144 bytes
```

`kubectl apply` (client-side) writes the previous full resource into `kubectl.kubernetes.io/last-applied-configuration` so it can diff against the next apply. That annotation is what's hitting the cap. The combined manifest is currently ~256 KiB; the GPU Health panel work in PR #38 pushes it over.

Workarounds exist (`kubectl apply --server-side --force-conflicts`, `kubectl replace`, Helm-wrapping), but each has friction or requires a flag/refactor.

## What

Switch `manifests/grafana-dashboards-configmap.yaml` from **one ConfigMap with 10 data keys** to **one multi-doc YAML containing 10 ConfigMaps**, one per dashboard:

```
crusoe-dashboard-cluster-gpu-overview
crusoe-dashboard-cluster-gpu-power
crusoe-dashboard-cluster-ib-overview
crusoe-dashboard-dcgm-xid-errors
crusoe-dashboard-network-cluster-overview
crusoe-dashboard-node-gpu-detail
crusoe-dashboard-node-ib-detail
crusoe-dashboard-node-network-detail
crusoe-dashboard-slurm-cluster-overview
crusoe-dashboard-storage-cluster-overview
```

All carry the `grafana_dashboard: "1"` label. The k8s-sidecar selects by label, not by ConfigMap name — so the application layer is identical. Each individual CM is now 12–45 KiB, well under the 256 KiB limit with comfortable headroom for future panel growth.

## README changes

- Regen snippet replaced with a loop that produces one CM per dashboard in a single multi-doc YAML.
- Migration note added for existing deployments — they need to `kubectl delete configmap crusoe-dashboards -n monitoring` once before applying the new file, so the sidecar doesn't load duplicate dashboards.

## Migration plan (for any cluster running the pre-split version)

```bash
# 1. Remove the old combined CM. Sidecar will drop the files and Grafana
#    momentarily shows no dashboards.
kubectl delete configmap crusoe-dashboards -n monitoring --ignore-not-found

# 2. Apply the new file. Creates 10 CMs with plain client-side apply — no flags.
kubectl apply -f grafana-cmk/manifests/grafana-dashboards-configmap.yaml

# 3. Wait ~60 s for the sidecar to write the new files and trigger
#    /api/admin/provisioning/dashboards/reload.
# 4. Dashboards reappear with the same UIDs — existing URLs/bookmarks resolve.
```

Total downtime: a few seconds between the delete and the next sidecar tick. The Grafana pod itself is untouched.

## Out of scope

- No dashboard JSON content changes. The new panels in PR #38 are independent. Merge order doesn't strictly matter, but the cleaner sequence is **this PR first, then #38** — that way the manifest is already in split form when the larger DCGM dashboard JSON lands, and `kubectl apply` keeps working throughout.
- No Helm chart changes. `grafana-values.yaml` still selects dashboards by label.

## Test plan

- [ ] Pull this branch.
- [ ] If on a pre-split cluster: `kubectl delete configmap crusoe-dashboards -n monitoring --ignore-not-found`.
- [ ] `kubectl apply -f grafana-cmk/manifests/grafana-dashboards-configmap.yaml` (no flags).
- [ ] `kubectl get configmap -n monitoring -l grafana_dashboard=1` shows 10 CMs.
- [ ] Open Grafana → Crusoe folder → confirm all 10 dashboards still appear.
- [ ] `kubectl describe configmap crusoe-dashboard-dcgm-xid-errors -n monitoring` shows just that dashboard.