### PR TITLE
grafana-cmk: make Cluster GPU Power dashboard SKU-agnostic

### DIFF
--- a/grafana-cmk/dashboards/cluster-gpu-power.json
+++ b/grafana-cmk/dashboards/cluster-gpu-power.json
@@ -58,7 +58,7 @@
       }
     ]
   },
-  "description": "Aggregate GPU power draw and energy consumption across the cluster. Data sourced from Crusoe Metrics (DCGM_FI_DEV_POWER_USAGE in watts; DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION in millijoules cumulative). H100 SXM5 TDP is 700 W per GPU.",
+  "description": "Aggregate GPU power draw and energy consumption across the cluster. Data sourced from Crusoe Metrics \u2014 DCGM_FI_DEV_POWER_USAGE in watts, DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION in millijoules cumulative. SKU-agnostic: works for any NVIDIA GPU that DCGM reports power for.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -86,7 +86,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Total instantaneous GPU power draw across all nodes in the cluster. Sum of DCGM_FI_DEV_POWER_USAGE for all GPUs matching the selected cluster.",
+      "description": "Sum of GPU power draw across every reporting GPU in the cluster.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -99,14 +99,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 5600
-              },
-              {
-                "color": "red",
-                "value": 8960
               }
             ]
           },
@@ -156,7 +148,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Average instantaneous power draw per GPU across the cluster. H100 SXM5 TDP is 700 W; sustained workloads typically draw 400\u2013650 W per GPU.",
+      "description": "Average instantaneous power draw per GPU across the cluster.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -169,14 +161,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 350
-              },
-              {
-                "color": "red",
-                "value": 560
               }
             ]
           },
@@ -226,7 +210,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Peak total cluster power draw observed within the selected time range.",
+      "description": "Highest cluster-wide power draw observed in the selected time range.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -239,14 +223,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 5600
-              },
-              {
-                "color": "red",
-                "value": 8960
               }
             ]
           },
@@ -359,7 +335,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Total GPU power draw across the entire cluster over time. The dashed threshold line at 11,200 W represents 100% TDP for 16\u00d7 H100 SXM5 GPUs (700 W each). Adjust if your node count or GPU model differs.",
+      "description": "Cluster-wide power draw over time. Scales with cluster size and workload.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -405,10 +381,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 11200
               }
             ]
           },
@@ -553,14 +525,13 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Current power draw per node as a bar gauge. Max value is set to 5,600 W (8\u00d7 H100 SXM5 at 700 W TDP each). Adjust if your node has a different GPU count or model.",
+      "description": "Current power draw per node as a bar gauge. Gauge auto-scales to the highest current value.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "mappings": [],
-          "max": 5600,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -568,14 +539,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 2800
-              },
-              {
-                "color": "red",
-                "value": 4480
               }
             ]
           },
@@ -690,7 +653,7 @@
               },
               {
                 "id": "max",
-                "value": 100
+                "value": null
               },
               {
                 "id": "custom.axisPlacement",

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -1173,7 +1173,7 @@ data:
           }
         ]
       },
-      "description": "Aggregate GPU power draw and energy consumption across the cluster. Data sourced from Crusoe Metrics (DCGM_FI_DEV_POWER_USAGE in watts; DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION in millijoules cumulative). H100 SXM5 TDP is 700 W per GPU.",
+      "description": "Aggregate GPU power draw and energy consumption across the cluster. Data sourced from Crusoe Metrics \u2014 DCGM_FI_DEV_POWER_USAGE in watts, DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION in millijoules cumulative. SKU-agnostic: works for any NVIDIA GPU that DCGM reports power for.",
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
@@ -1201,7 +1201,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Total instantaneous GPU power draw across all nodes in the cluster. Sum of DCGM_FI_DEV_POWER_USAGE for all GPUs matching the selected cluster.",
+          "description": "Sum of GPU power draw across every reporting GPU in the cluster.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1214,14 +1214,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 5600
-                  },
-                  {
-                    "color": "red",
-                    "value": 8960
                   }
                 ]
               },
@@ -1271,7 +1263,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Average instantaneous power draw per GPU across the cluster. H100 SXM5 TDP is 700 W; sustained workloads typically draw 400\u2013650 W per GPU.",
+          "description": "Average instantaneous power draw per GPU across the cluster.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1284,14 +1276,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 350
-                  },
-                  {
-                    "color": "red",
-                    "value": 560
                   }
                 ]
               },
@@ -1341,7 +1325,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Peak total cluster power draw observed within the selected time range.",
+          "description": "Highest cluster-wide power draw observed in the selected time range.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1354,14 +1338,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 5600
-                  },
-                  {
-                    "color": "red",
-                    "value": 8960
                   }
                 ]
               },
@@ -1474,7 +1450,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Total GPU power draw across the entire cluster over time. The dashed threshold line at 11,200 W represents 100% TDP for 16\u00d7 H100 SXM5 GPUs (700 W each). Adjust if your node count or GPU model differs.",
+          "description": "Cluster-wide power draw over time. Scales with cluster size and workload.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1520,10 +1496,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 11200
                   }
                 ]
               },
@@ -1668,14 +1640,13 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Current power draw per node as a bar gauge. Max value is set to 5,600 W (8\u00d7 H100 SXM5 at 700 W TDP each). Adjust if your node has a different GPU count or model.",
+          "description": "Current power draw per node as a bar gauge. Gauge auto-scales to the highest current value.",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
               "mappings": [],
-              "max": 5600,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
@@ -1683,14 +1654,6 @@ data:
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 2800
-                  },
-                  {
-                    "color": "red",
-                    "value": 4480
                   }
                 ]
               },
@@ -1805,7 +1768,7 @@ data:
                   },
                   {
                     "id": "max",
-                    "value": 100
+                    "value": null
                   },
                   {
                     "id": "custom.axisPlacement",


### PR DESCRIPTION
## Why

The Cluster GPU Power dashboard had H100 SXM5 assumptions baked into descriptions, thresholds, and a hardcoded gauge ceiling — even though `DCGM_FI_DEV_POWER_USAGE` is a generic metric that reports for any NVIDIA GPU. Problems on non-H100 fleets:

| Panel | H100-locked value | What breaks |
| --- | --- | --- |
| Total Cluster Power | yellow 5,600 W / red 8,960 W | Designed for 1 node × 8 H100. Always red on real clusters. |
| Total Cluster Power over Time | dashed line at 11,200 W | "100% TDP for 16× H100". Always red at any non-trivial scale. |
| Avg Power per GPU | yellow 350 W / red 560 W | 50/80% of 700 W. Wrong scale for B200 (1 kW+) and A100 (400 W). |
| Current Power by Node | yellow 2,800 W / red 4,480 W; **max 5,600 W** | Gauge pegs at 5,600 for any B200 or 1-kW-class node. |

Descriptions also mentioned "H100 SXM5" and specific 700 W TDP figures.

## What this PR changes

- **Dashboard description** rewritten neutrally: "Works for any NVIDIA GPU that DCGM reports power for."
- **5 panel descriptions** rewritten to drop all H100 / SXM5 / 700 W / 8× / 16× references.
- **Every absolute-watt threshold** stripped from all 8 panels (33 threshold steps total). Stat panels and time-series render with a single neutral color.
- **`max: 5600`** cap removed from the "Current Power by Node" bar gauge so it auto-scales to whatever the highest-drawing node reports.

Outlier detection moves to relative-to-peer comparison. The dashboard already has "Power by Node" (per-node time-series) and "Current Power by Node" (bar gauge) so any node materially above its peers is still visible without absolute thresholds.

## What's not changed

- Metrics, queries, or layout — none.
- Panel titles — none.
- Threshold approach for **other** dashboards — DCGM, IB, and the rest still use the appropriate per-metric thresholds because their signals (Xid count, ECC events, link errors) are SKU-invariant.

## Test plan

- [ ] Pull this branch.
- [ ] `kubectl apply -f grafana-cmk/manifests/grafana-dashboards-configmap.yaml`.
- [ ] Open Grafana → Crusoe → Cluster GPU Power.
- [ ] Confirm: no "H100" / "SXM5" / "700 W" text in any panel info icon.
- [ ] Confirm: stat panels show a single neutral color regardless of value.
- [ ] Confirm: per-node bar gauge auto-scales — node with highest current draw fills the bar.
- [ ] Confirm: time-series no longer has the dashed 11.2 kW reference line; ranges auto-scale.