### PR TITLE
grafana-cmk: fix Xid panels — gauge semantics + correct label name

### DIFF
--- a/grafana-cmk/dashboards/dcgm-xid-errors.json
+++ b/grafana-cmk/dashboards/dcgm-xid-errors.json
@@ -86,7 +86,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Cluster-wide increase in Xid events in the last 24h (DCGM field 230). Any non-zero value is a hard hardware/driver event \u2014 drill into the breakdown table below.",
+      "description": "Distinct GPUs that fired any non-zero Xid in the last 24h (DCGM field 230). DCGM_FI_DEV_XID_ERRORS is a gauge holding the most recent Xid code per GPU \u2014 use `max_over_time(... [24h]) > 0` to detect events, not `increase()`.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -149,13 +149,13 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(increase(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h]))",
+          "expr": "count(max_over_time(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h]) > 0) or vector(0)",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Total Xid Errors (Last 24h)",
+      "title": "GPUs With Xid Events (Last 24h)",
       "type": "stat"
     },
     {
@@ -244,7 +244,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Per-node Xid rate over time (DCGM field 230). Spikes identify which node experienced the event; correlate timing with workload logs.",
+      "description": "Most recent Xid code per node, sustained via `max_over_time` so a momentary event stays visible for the rest of the window. 0 = healthy; non-zero values are the Xid code (e.g. 119 = GSP RPC Timeout). Reference: https://docs.nvidia.com/deploy/xid-errors/",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -324,12 +324,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (increase(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[5m]))",
+          "expr": "max by (vm_name) (max_over_time(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[$__range])) > 0",
           "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],
-      "title": "Xid Error Rate by Node",
+      "title": "Xid Code by Node Over Time",
       "type": "timeseries"
     },
     {
@@ -337,7 +337,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Breakdown of Xid events in the last 24h by node, GPU, and Xid code. Xid code reference: https://docs.nvidia.com/deploy/xid-errors/",
+      "description": "GPUs with any non-zero Xid in the last 24h, broken down by node, GPU, and Xid code. Xid code reference: https://docs.nvidia.com/deploy/xid-errors/",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -430,13 +430,13 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name, gpu, xid_id) (increase(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h])) > 0",
+          "expr": "max by (vm_name, gpu, err_code, err_msg) (max_over_time(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h])) > 0",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Xid Errors by Node / GPU / Code (Last 24h)",
+      "title": "Xid Events by Node / GPU / Code (Last 24h)",
       "transformations": [
         {
           "id": "labelsToFields",
@@ -451,12 +451,18 @@
               "Time": true
             },
             "indexByName": {
-              "node": 0,
+              "vm_name": 0,
               "gpu": 1,
-              "xid_id": 2,
-              "Value": 3
+              "err_code": 2,
+              "err_msg": 3,
+              "Value": 4
             },
-            "renameByName": {}
+            "renameByName": {
+              "vm_name": "Node",
+              "gpu": "GPU",
+              "err_code": "Xid Code",
+              "err_msg": "Xid Message"
+            }
           }
         }
       ],
@@ -1967,6 +1973,6 @@
   "timezone": "browser",
   "title": "DCGM & Xid Errors",
   "uid": "crusoe-dcgm-xid-errors",
-  "version": 7,
+  "version": 9,
   "weekStart": ""
 }

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -3155,7 +3155,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Cluster-wide increase in Xid events in the last 24h (DCGM field 230). Any non-zero value is a hard hardware/driver event \u2014 drill into the breakdown table below.",
+          "description": "Distinct GPUs that fired any non-zero Xid in the last 24h (DCGM field 230). DCGM_FI_DEV_XID_ERRORS is a gauge holding the most recent Xid code per GPU \u2014 use `max_over_time(... [24h]) > 0` to detect events, not `increase()`.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3218,13 +3218,13 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(increase(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h]))",
+              "expr": "count(max_over_time(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h]) > 0) or vector(0)",
               "instant": true,
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "title": "Total Xid Errors (Last 24h)",
+          "title": "GPUs With Xid Events (Last 24h)",
           "type": "stat"
         },
         {
@@ -3313,7 +3313,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Per-node Xid rate over time (DCGM field 230). Spikes identify which node experienced the event; correlate timing with workload logs.",
+          "description": "Most recent Xid code per node, sustained via `max_over_time` so a momentary event stays visible for the rest of the window. 0 = healthy; non-zero values are the Xid code (e.g. 119 = GSP RPC Timeout). Reference: https://docs.nvidia.com/deploy/xid-errors/",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3393,12 +3393,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (increase(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[5m]))",
+              "expr": "max by (vm_name) (max_over_time(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[$__range])) > 0",
               "legendFormat": "{{vm_name}}",
               "refId": "A"
             }
           ],
-          "title": "Xid Error Rate by Node",
+          "title": "Xid Code by Node Over Time",
           "type": "timeseries"
         },
         {
@@ -3406,7 +3406,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Breakdown of Xid events in the last 24h by node, GPU, and Xid code. Xid code reference: https://docs.nvidia.com/deploy/xid-errors/",
+          "description": "GPUs with any non-zero Xid in the last 24h, broken down by node, GPU, and Xid code. Xid code reference: https://docs.nvidia.com/deploy/xid-errors/",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3499,13 +3499,13 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name, gpu, xid_id) (increase(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h])) > 0",
+              "expr": "max by (vm_name, gpu, err_code, err_msg) (max_over_time(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h])) > 0",
               "instant": true,
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "title": "Xid Errors by Node / GPU / Code (Last 24h)",
+          "title": "Xid Events by Node / GPU / Code (Last 24h)",
           "transformations": [
             {
               "id": "labelsToFields",
@@ -3520,12 +3520,18 @@ data:
                   "Time": true
                 },
                 "indexByName": {
-                  "node": 0,
+                  "vm_name": 0,
                   "gpu": 1,
-                  "xid_id": 2,
-                  "Value": 3
+                  "err_code": 2,
+                  "err_msg": 3,
+                  "Value": 4
                 },
-                "renameByName": {}
+                "renameByName": {
+                  "vm_name": "Node",
+                  "gpu": "GPU",
+                  "err_code": "Xid Code",
+                  "err_msg": "Xid Message"
+                }
               }
             }
           ],
@@ -5036,7 +5042,7 @@ data:
       "timezone": "browser",
       "title": "DCGM & Xid Errors",
       "uid": "crusoe-dcgm-xid-errors",
-      "version": 7,
+      "version": 9,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
## Why

Real Xid events were silently missing from the DCGM dashboard. A user reported an active Xid on a B200 node that the dashboard showed as zero. Two bugs in the Xid panels:

### Bug 1: gauge treated as a counter

`DCGM_FI_DEV_XID_ERRORS` is a **gauge** holding the most recent Xid code per GPU (0 = healthy, otherwise the Xid code number like 79 or 119). All three Xid panels used `increase(... [24h])`, which is the wrong PromQL primitive for a gauge — when a Xid fires the value transitions `0 → code → 0`, and `increase()` treats the drop as a counter reset, returning ~0. Net effect: the panels rendered zero even when a real event was visible in the underlying data.

### Bug 2: wrong label name

The "by code" breakdown table grouped on `xid_id`, but the actual label is **`err_code`** (paired with `err_msg` for the human-readable text like `"GSP RPC Timeout"`). Querying `/api/v1/label/xid_id/values` returns `[]` — the label doesn't exist.

## What changed

| Panel | Was | Now |
| --- | --- | --- |
| `Total Xid Errors (Last 24h)` stat | `sum(increase(DCGM_FI_DEV_XID_ERRORS[24h]))` | `count(max_over_time(... [24h]) > 0)` — counts distinct GPUs that fired any non-zero Xid. Renamed to **GPUs With Xid Events (Last 24h)**. |
| `Xid Error Rate by Node` timeseries | `sum by (vm_name) (increase(... [5m]))` | `max by (vm_name) (max_over_time(... [$__range]))` — sustains a momentary Xid spike across the panel time range so events stay visible retrospectively. Renamed to **Xid Code by Node Over Time**. |
| `Xid Errors by Node / GPU / Code` table | `sum by (vm_name, gpu, xid_id) (increase(... [24h])) > 0` | `max by (vm_name, gpu, err_code, err_msg) (max_over_time(... [24h])) > 0` — correct labels, gauge-appropriate primitive. Now also surfaces `err_msg` so the human-readable description appears alongside the code. |

## Semantic change

The headline stat goes from "sum of events" to "count of GPUs affected". I'd argue this is more useful anyway — one GPU firing 5 Xids isn't 5× worse than firing 1, you still drain the node. If you want raw event count, the table below shows every (node, gpu, code) row that fired.

## Verified

Tested live with an actual Xid 119 ("GSP RPC Timeout") event on a B200 node. **Before:** all three panels showed zero. **After:**

- Stat → `1` (one GPU affected)
- Timeseries → plateau at 119 on the affected node
- Table → one row: Node | GPU 0 | Xid Code 119 | Message "GSP RPC Timeout"

## Test plan

- [ ] Pull this branch.
- [ ] `kubectl apply -f grafana-cmk/manifests/grafana-dashboards-configmap.yaml`.
- [ ] Open Grafana → Crusoe → DCGM & Xid Errors.
- [ ] If your cluster has had any Xid event in the panel's time range, the new stat shows a non-zero count, the breakdown table populates with the Xid code AND message, and the timeseries shows a plateau on the affected node.
- [ ] If your cluster has had no Xid events, all three panels render empty/zero — which is now correct (healthy).