### PR TITLE
grafana-cmk: strip DCGM internals from panel descriptions

### DIFF
--- a/grafana-cmk/dashboards/cluster-gpu-overview.json
+++ b/grafana-cmk/dashboards/cluster-gpu-overview.json
@@ -139,7 +139,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Distinct nodes reporting DCGM metrics. If dropdown is empty, check labels on DCGM_FI_DEV_GPU_UTIL via the discovery curl in the README.",
+      "description": "Distinct nodes reporting GPU telemetry. If the variable dropdown is empty, see the README's Troubleshooting section.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -369,7 +369,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Cluster-wide GPU framebuffer memory used (stacked) vs total capacity (dashed red line). DCGM_FI_DEV_FB_USED and DCGM_FI_DEV_FB_FREE are reported in MiB.",
+      "description": "Cluster-wide GPU framebuffer memory used (stacked) vs total capacity (dashed red line).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -513,7 +513,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Total GPU power draw per node across the cluster. DCGM_FI_DEV_POWER_USAGE is reported in watts.",
+      "description": "Total GPU power draw per node across the cluster, in watts.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1085,6 +1085,6 @@
   "timezone": "browser",
   "title": "Cluster GPU Overview",
   "uid": "crusoe-cluster-gpu-overview",
-  "version": 9,
+  "version": 10,
   "weekStart": ""
 }

--- a/grafana-cmk/dashboards/cluster-gpu-power.json
+++ b/grafana-cmk/dashboards/cluster-gpu-power.json
@@ -272,7 +272,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Total GPU energy across the dashboard time range, derived from DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION (cumulative mJ). Formula: increase(mJ) / 3.6\u00d710\u2079 = kWh.",
+      "description": "Total GPU energy consumption across the dashboard time range, in kilowatt-hours.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -771,6 +771,6 @@
   "timezone": "browser",
   "title": "Cluster GPU Power",
   "uid": "crusoe-cluster-power",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/grafana-cmk/dashboards/dcgm-xid-errors.json
+++ b/grafana-cmk/dashboards/dcgm-xid-errors.json
@@ -86,7 +86,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Distinct GPUs that fired any non-zero Xid in the last 24h (DCGM field 230). DCGM_FI_DEV_XID_ERRORS is a gauge holding the most recent Xid code per GPU \u2014 use `max_over_time(... [24h]) > 0` to detect events, not `increase()`.",
+      "description": "Distinct GPUs that fired any non-zero Xid event in the last 24h.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -163,7 +163,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Cluster-wide increase in volatile DBE (uncorrectable ECC) in the last 24h (DCGM field 311). DBEs are unrecoverable \u2014 should normally be 0.",
+      "description": "Cluster-wide increase in uncorrectable (double-bit) ECC errors in the last 24h. Should normally be 0 \u2014 DBEs are unrecoverable.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -244,7 +244,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "Most recent Xid code per node, sustained via `max_over_time` so a momentary event stays visible for the rest of the window. 0 = healthy; non-zero values are the Xid code (e.g. 119 = GSP RPC Timeout). Reference: https://docs.nvidia.com/deploy/xid-errors/",
+      "description": "Most recent Xid code per node, sustained via max_over_time so a momentary event stays visible for the rest of the window. 0 = healthy; non-zero values are the Xid code. Reference: https://docs.nvidia.com/deploy/xid-errors/",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -473,7 +473,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "GPUs with new volatile DBE (DCGM field 311) or any uncorrectable remapped rows (field 393) in the last 24h. Both warrant urgent hardware investigation.",
+      "description": "GPUs with new uncorrectable ECC events or any uncorrectable remapped HBM rows in the last 24h. Both warrant urgent hardware investigation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -614,7 +614,7 @@
       "id": 7,
       "type": "stat",
       "title": "Active SBE GPUs",
-      "description": "GPUs currently reporting non-zero volatile SBE (DCGM field 310). Means actively correcting since last reset \u2014 usually benign on its own.",
+      "description": "GPUs currently reporting non-zero volatile single-bit ECC corrections. Means actively correcting since last reset \u2014 usually benign on its own.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -682,7 +682,7 @@
       "id": 8,
       "type": "stat",
       "title": "GPUs With Remapped Rows",
-      "description": "GPUs with at least one correctable HBM row remapped (DCGM field 394). Growing count over time is the classic 'HBM degrading' signal.",
+      "description": "GPUs with at least one correctable HBM row remapped. Growing count over time is the classic 'HBM degrading' signal.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -750,7 +750,7 @@
       "id": 9,
       "type": "stat",
       "title": "Uncorrectable Rows",
-      "description": "Cluster-wide count of permanently uncorrectable HBM rows (DCGM field 393). Should be 0; any non-zero value means at least one GPU has unfixable HBM.",
+      "description": "Cluster-wide count of permanently uncorrectable HBM rows. Should be 0; any non-zero value means at least one GPU has unfixable HBM.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -814,7 +814,7 @@
       "id": 10,
       "type": "stat",
       "title": "24h PCIe Replays",
-      "description": "Cluster-wide PCIe replay increase in 24h (DCGM field 202). Non-zero indicates physical-layer link issues \u2014 bus glitches, marginal connectors, or a failing bridge.",
+      "description": "Cluster-wide PCIe replay-counter increase in 24h. Non-zero indicates physical-layer link issues \u2014 bus glitches, marginal connectors, or a failing bridge.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -882,7 +882,7 @@
       "id": 11,
       "type": "stat",
       "title": "24h SBE Volatile \u0394",
-      "description": "Cluster-wide volatile SBE increase in 24h (DCGM field 310). Dozens to low thousands per GPU under sustained load is normal; runaway growth on one node is a slow-node candidate.",
+      "description": "Cluster-wide volatile single-bit ECC correction increase in 24h. Dozens to low thousands per GPU under sustained load is normal; runaway growth on one node is a slow-node candidate.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -950,7 +950,7 @@
       "id": 12,
       "type": "stat",
       "title": "Lifetime SBE (\u03a3)",
-      "description": "Fleet-wide lifetime aggregate of single-bit corrections (DCGM field 312). Reference number only \u2014 distribution matters; see leaderboard below.",
+      "description": "Fleet-wide lifetime aggregate of single-bit ECC corrections. Reference number only \u2014 distribution matters; see leaderboard below.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -1010,7 +1010,7 @@
       "id": 13,
       "type": "table",
       "title": "Top 15 GPUs by Lifetime Aggregate SBE",
-      "description": "Lifetime single-bit ECC corrections per GPU (DCGM field 312). Useful for draining decisions or excluding from latency-critical jobs.",
+      "description": "Lifetime single-bit ECC corrections per GPU. Useful for draining decisions or excluding from latency-critical jobs.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -1139,7 +1139,7 @@
       "id": 14,
       "type": "table",
       "title": "Top 15 GPUs by Correctable Remapped Rows",
-      "description": "GPUs with HBM rows already retired by DCGM (field 394). Still functional but with slightly less HBM; remap-region accesses can be marginally slower.",
+      "description": "GPUs with HBM rows already retired. Still functional but with slightly less HBM; remap-region accesses can be marginally slower.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -1268,7 +1268,7 @@
       "id": 15,
       "type": "table",
       "title": "Top 15 GPUs by 24h SBE Volatile Growth",
-      "description": "GPUs correcting hardest right now \u2014 24h delta of DCGM field 310 (volatile SBE). Start here when chasing a same-day slow-node symptom.",
+      "description": "GPUs correcting hardest right now \u2014 24h delta of the volatile single-bit ECC counter. Start here when chasing a same-day slow-node symptom.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -1397,7 +1397,7 @@
       "id": 16,
       "type": "table",
       "title": "Red Flag GPUs (Uncorrectable Rows or PCIe Replays in 24h)",
-      "description": "GPUs with an uncorrectable remapped row (DCGM field 393) OR a non-zero 24h PCIe replay increase (field 202). Either condition warrants pulling the node from training for hardware investigation.",
+      "description": "GPUs with an uncorrectable remapped HBM row OR a non-zero 24h PCIe replay increase. Either condition warrants pulling the node from training for hardware investigation.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -1526,7 +1526,7 @@
       "id": 17,
       "type": "timeseries",
       "title": "SBE Volatile Rate by Node (last 6h)",
-      "description": "Per-GPU SBE correction rate, top 20 over 6h (DCGM field 310). Persistent elevation on one GPU = slow-node candidate; correlated bursts across many = HBM-stressing workload.",
+      "description": "Per-GPU single-bit ECC correction rate, top 20 over 6h. Persistent elevation on one GPU = slow-node candidate; correlated bursts across many = HBM-stressing workload.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -1587,7 +1587,7 @@
       "id": 18,
       "type": "timeseries",
       "title": "Tensor Core Utilization by Node (last 1h)",
-      "description": "Tensor-core utilization per node, averaged across that node's 8 GPUs (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE). A node consistently below its peers during steady-state training is dragging the collective.",
+      "description": "Tensor-core utilization per node, averaged across that node's GPUs. A node consistently below its peers during steady-state training is dragging the collective.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -1648,7 +1648,7 @@
       "id": 19,
       "type": "table",
       "title": "Top GPUs by Lifetime Uncorrectable ECC (DBE)",
-      "description": "Lifetime double-bit ECC error count per GPU (DCGM field 313). DBEs are unrecoverable \u2014 candidates for extra scrutiny or RMA if growing.",
+      "description": "Lifetime double-bit ECC error count per GPU. DBEs are unrecoverable \u2014 candidates for extra scrutiny or RMA if growing.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -1788,7 +1788,7 @@
       "id": 20,
       "type": "table",
       "title": "Reset Candidates (heuristic: heavy SBE + remapped rows)",
-      "description": "GPUs with 24h SBE growth >100 AND any correctable remapped rows. Canonical signal `DCGM_FI_DEV_ROW_REMAP_PENDING` (field 396) is not published by the Watch Agent, so this is a proxy.",
+      "description": "GPUs with 24h single-bit ECC growth >100 AND any correctable remapped rows. The canonical 'rows pending remap' signal is not yet collected, so this combination is a proxy.",
       "datasource": {
         "type": "prometheus",
         "uid": "crusoe-metrics"
@@ -1973,6 +1973,6 @@
   "timezone": "browser",
   "title": "DCGM & Xid Errors",
   "uid": "crusoe-dcgm-xid-errors",
-  "version": 9,
+  "version": 10,
   "weekStart": ""
 }

--- a/grafana-cmk/dashboards/node-gpu-detail.json
+++ b/grafana-cmk/dashboards/node-gpu-detail.json
@@ -170,7 +170,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "GPU framebuffer memory used per GPU on the selected node. DCGM_FI_DEV_FB_USED is in MiB.",
+      "description": "GPU framebuffer memory used per GPU on the selected node, in MiB.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -265,7 +265,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "GPU temperature per GPU on the selected node. DCGM_FI_DEV_GPU_TEMP is in Celsius.",
+      "description": "GPU temperature per GPU on the selected node, in Celsius.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -368,7 +368,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "GPU power draw per GPU on the selected node. DCGM_FI_DEV_POWER_USAGE is in watts.",
+      "description": "GPU power draw per GPU on the selected node, in watts.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -463,7 +463,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "SM clock and memory clock per GPU on the selected node. DCGM_FI_DEV_SM_CLOCK and DCGM_FI_DEV_MEM_CLOCK are in MHz. High values indicate the GPU is not being thermally throttled.",
+      "description": "SM clock and memory clock per GPU on the selected node, in MHz. High values indicate the GPU is not being thermally throttled.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1140,6 +1140,6 @@
   "timezone": "browser",
   "title": "Node Details",
   "uid": "crusoe-node-gpu-detail",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -154,7 +154,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Distinct nodes reporting DCGM metrics. If dropdown is empty, check labels on DCGM_FI_DEV_GPU_UTIL via the discovery curl in the README.",
+          "description": "Distinct nodes reporting GPU telemetry. If the variable dropdown is empty, see the README's Troubleshooting section.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -384,7 +384,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Cluster-wide GPU framebuffer memory used (stacked) vs total capacity (dashed red line). DCGM_FI_DEV_FB_USED and DCGM_FI_DEV_FB_FREE are reported in MiB.",
+          "description": "Cluster-wide GPU framebuffer memory used (stacked) vs total capacity (dashed red line).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -528,7 +528,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Total GPU power draw per node across the cluster. DCGM_FI_DEV_POWER_USAGE is reported in watts.",
+          "description": "Total GPU power draw per node across the cluster, in watts.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1100,7 +1100,7 @@ data:
       "timezone": "browser",
       "title": "Cluster GPU Overview",
       "uid": "crusoe-cluster-gpu-overview",
-      "version": 9,
+      "version": 10,
       "weekStart": ""
     }
 kind: ConfigMap
@@ -1387,7 +1387,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Total GPU energy across the dashboard time range, derived from DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION (cumulative mJ). Formula: increase(mJ) / 3.6\u00d710\u2079 = kWh.",
+          "description": "Total GPU energy consumption across the dashboard time range, in kilowatt-hours.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1886,7 +1886,7 @@ data:
       "timezone": "browser",
       "title": "Cluster GPU Power",
       "uid": "crusoe-cluster-power",
-      "version": 3,
+      "version": 4,
       "weekStart": ""
     }
 kind: ConfigMap
@@ -3155,7 +3155,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Distinct GPUs that fired any non-zero Xid in the last 24h (DCGM field 230). DCGM_FI_DEV_XID_ERRORS is a gauge holding the most recent Xid code per GPU \u2014 use `max_over_time(... [24h]) > 0` to detect events, not `increase()`.",
+          "description": "Distinct GPUs that fired any non-zero Xid event in the last 24h.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3232,7 +3232,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Cluster-wide increase in volatile DBE (uncorrectable ECC) in the last 24h (DCGM field 311). DBEs are unrecoverable \u2014 should normally be 0.",
+          "description": "Cluster-wide increase in uncorrectable (double-bit) ECC errors in the last 24h. Should normally be 0 \u2014 DBEs are unrecoverable.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3313,7 +3313,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "Most recent Xid code per node, sustained via `max_over_time` so a momentary event stays visible for the rest of the window. 0 = healthy; non-zero values are the Xid code (e.g. 119 = GSP RPC Timeout). Reference: https://docs.nvidia.com/deploy/xid-errors/",
+          "description": "Most recent Xid code per node, sustained via max_over_time so a momentary event stays visible for the rest of the window. 0 = healthy; non-zero values are the Xid code. Reference: https://docs.nvidia.com/deploy/xid-errors/",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3542,7 +3542,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "GPUs with new volatile DBE (DCGM field 311) or any uncorrectable remapped rows (field 393) in the last 24h. Both warrant urgent hardware investigation.",
+          "description": "GPUs with new uncorrectable ECC events or any uncorrectable remapped HBM rows in the last 24h. Both warrant urgent hardware investigation.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3683,7 +3683,7 @@ data:
           "id": 7,
           "type": "stat",
           "title": "Active SBE GPUs",
-          "description": "GPUs currently reporting non-zero volatile SBE (DCGM field 310). Means actively correcting since last reset \u2014 usually benign on its own.",
+          "description": "GPUs currently reporting non-zero volatile single-bit ECC corrections. Means actively correcting since last reset \u2014 usually benign on its own.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -3751,7 +3751,7 @@ data:
           "id": 8,
           "type": "stat",
           "title": "GPUs With Remapped Rows",
-          "description": "GPUs with at least one correctable HBM row remapped (DCGM field 394). Growing count over time is the classic 'HBM degrading' signal.",
+          "description": "GPUs with at least one correctable HBM row remapped. Growing count over time is the classic 'HBM degrading' signal.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -3819,7 +3819,7 @@ data:
           "id": 9,
           "type": "stat",
           "title": "Uncorrectable Rows",
-          "description": "Cluster-wide count of permanently uncorrectable HBM rows (DCGM field 393). Should be 0; any non-zero value means at least one GPU has unfixable HBM.",
+          "description": "Cluster-wide count of permanently uncorrectable HBM rows. Should be 0; any non-zero value means at least one GPU has unfixable HBM.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -3883,7 +3883,7 @@ data:
           "id": 10,
           "type": "stat",
           "title": "24h PCIe Replays",
-          "description": "Cluster-wide PCIe replay increase in 24h (DCGM field 202). Non-zero indicates physical-layer link issues \u2014 bus glitches, marginal connectors, or a failing bridge.",
+          "description": "Cluster-wide PCIe replay-counter increase in 24h. Non-zero indicates physical-layer link issues \u2014 bus glitches, marginal connectors, or a failing bridge.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -3951,7 +3951,7 @@ data:
           "id": 11,
           "type": "stat",
           "title": "24h SBE Volatile \u0394",
-          "description": "Cluster-wide volatile SBE increase in 24h (DCGM field 310). Dozens to low thousands per GPU under sustained load is normal; runaway growth on one node is a slow-node candidate.",
+          "description": "Cluster-wide volatile single-bit ECC correction increase in 24h. Dozens to low thousands per GPU under sustained load is normal; runaway growth on one node is a slow-node candidate.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -4019,7 +4019,7 @@ data:
           "id": 12,
           "type": "stat",
           "title": "Lifetime SBE (\u03a3)",
-          "description": "Fleet-wide lifetime aggregate of single-bit corrections (DCGM field 312). Reference number only \u2014 distribution matters; see leaderboard below.",
+          "description": "Fleet-wide lifetime aggregate of single-bit ECC corrections. Reference number only \u2014 distribution matters; see leaderboard below.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -4079,7 +4079,7 @@ data:
           "id": 13,
           "type": "table",
           "title": "Top 15 GPUs by Lifetime Aggregate SBE",
-          "description": "Lifetime single-bit ECC corrections per GPU (DCGM field 312). Useful for draining decisions or excluding from latency-critical jobs.",
+          "description": "Lifetime single-bit ECC corrections per GPU. Useful for draining decisions or excluding from latency-critical jobs.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -4208,7 +4208,7 @@ data:
           "id": 14,
           "type": "table",
           "title": "Top 15 GPUs by Correctable Remapped Rows",
-          "description": "GPUs with HBM rows already retired by DCGM (field 394). Still functional but with slightly less HBM; remap-region accesses can be marginally slower.",
+          "description": "GPUs with HBM rows already retired. Still functional but with slightly less HBM; remap-region accesses can be marginally slower.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -4337,7 +4337,7 @@ data:
           "id": 15,
           "type": "table",
           "title": "Top 15 GPUs by 24h SBE Volatile Growth",
-          "description": "GPUs correcting hardest right now \u2014 24h delta of DCGM field 310 (volatile SBE). Start here when chasing a same-day slow-node symptom.",
+          "description": "GPUs correcting hardest right now \u2014 24h delta of the volatile single-bit ECC counter. Start here when chasing a same-day slow-node symptom.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -4466,7 +4466,7 @@ data:
           "id": 16,
           "type": "table",
           "title": "Red Flag GPUs (Uncorrectable Rows or PCIe Replays in 24h)",
-          "description": "GPUs with an uncorrectable remapped row (DCGM field 393) OR a non-zero 24h PCIe replay increase (field 202). Either condition warrants pulling the node from training for hardware investigation.",
+          "description": "GPUs with an uncorrectable remapped HBM row OR a non-zero 24h PCIe replay increase. Either condition warrants pulling the node from training for hardware investigation.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -4595,7 +4595,7 @@ data:
           "id": 17,
           "type": "timeseries",
           "title": "SBE Volatile Rate by Node (last 6h)",
-          "description": "Per-GPU SBE correction rate, top 20 over 6h (DCGM field 310). Persistent elevation on one GPU = slow-node candidate; correlated bursts across many = HBM-stressing workload.",
+          "description": "Per-GPU single-bit ECC correction rate, top 20 over 6h. Persistent elevation on one GPU = slow-node candidate; correlated bursts across many = HBM-stressing workload.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -4656,7 +4656,7 @@ data:
           "id": 18,
           "type": "timeseries",
           "title": "Tensor Core Utilization by Node (last 1h)",
-          "description": "Tensor-core utilization per node, averaged across that node's 8 GPUs (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE). A node consistently below its peers during steady-state training is dragging the collective.",
+          "description": "Tensor-core utilization per node, averaged across that node's GPUs. A node consistently below its peers during steady-state training is dragging the collective.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -4717,7 +4717,7 @@ data:
           "id": 19,
           "type": "table",
           "title": "Top GPUs by Lifetime Uncorrectable ECC (DBE)",
-          "description": "Lifetime double-bit ECC error count per GPU (DCGM field 313). DBEs are unrecoverable \u2014 candidates for extra scrutiny or RMA if growing.",
+          "description": "Lifetime double-bit ECC error count per GPU. DBEs are unrecoverable \u2014 candidates for extra scrutiny or RMA if growing.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -4857,7 +4857,7 @@ data:
           "id": 20,
           "type": "table",
           "title": "Reset Candidates (heuristic: heavy SBE + remapped rows)",
-          "description": "GPUs with 24h SBE growth >100 AND any correctable remapped rows. Canonical signal `DCGM_FI_DEV_ROW_REMAP_PENDING` (field 396) is not published by the Watch Agent, so this is a proxy.",
+          "description": "GPUs with 24h single-bit ECC growth >100 AND any correctable remapped rows. The canonical 'rows pending remap' signal is not yet collected, so this combination is a proxy.",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
@@ -5042,7 +5042,7 @@ data:
       "timezone": "browser",
       "title": "DCGM & Xid Errors",
       "uid": "crusoe-dcgm-xid-errors",
-      "version": 9,
+      "version": 10,
       "weekStart": ""
     }
 kind: ConfigMap
@@ -6608,7 +6608,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "GPU framebuffer memory used per GPU on the selected node. DCGM_FI_DEV_FB_USED is in MiB.",
+          "description": "GPU framebuffer memory used per GPU on the selected node, in MiB.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6703,7 +6703,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "GPU temperature per GPU on the selected node. DCGM_FI_DEV_GPU_TEMP is in Celsius.",
+          "description": "GPU temperature per GPU on the selected node, in Celsius.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6806,7 +6806,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "GPU power draw per GPU on the selected node. DCGM_FI_DEV_POWER_USAGE is in watts.",
+          "description": "GPU power draw per GPU on the selected node, in watts.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6901,7 +6901,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "SM clock and memory clock per GPU on the selected node. DCGM_FI_DEV_SM_CLOCK and DCGM_FI_DEV_MEM_CLOCK are in MHz. High values indicate the GPU is not being thermally throttled.",
+          "description": "SM clock and memory clock per GPU on the selected node, in MHz. High values indicate the GPU is not being thermally throttled.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -7578,7 +7578,7 @@ data:
       "timezone": "browser",
       "title": "Node Details",
       "uid": "crusoe-node-gpu-detail",
-      "version": 3,
+      "version": 4,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
## Why

Panel descriptions referenced internal DCGM field IDs (e.g. *"field 310"*, *"field 393"*) and exporter metric names (e.g. *"DCGM_FI_DEV_FB_USED is in MiB"*). These are implementation details the dashboard's audience doesn't need to know about — they belong in the source code, not in tooltips.

## What

Rewrote 27 panel descriptions across 4 dashboards to describe what each panel measures in plain language:

| Dashboard | Panels touched |
| --- | ---: |
| Cluster GPU Overview | 3 |
| Cluster GPU Power | 1 |
| DCGM & Xid Errors | 19 |
| Node Details | 4 |

Each new description follows the same shape: one short sentence saying what the panel shows + a unit or actionable cue if relevant.

### Examples

| Was | Now |
| --- | --- |
| "Cluster-wide PCIe replay increase in 24h (DCGM field 202). Non-zero indicates physical-layer link issues…" | "Cluster-wide PCIe replay-counter increase in 24h. Non-zero indicates physical-layer link issues…" |
| "GPU framebuffer memory used per GPU on the selected node. DCGM_FI_DEV_FB_USED is in MiB." | "GPU framebuffer memory used per GPU on the selected node, in MiB." |
| "Tensor-core utilization per node, averaged across that node's 8 GPUs (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE)." | "Tensor-core utilization per node, averaged across that node's GPUs." |

### Note on merge ordering with PR #46

PR #46 (Xid panels gauge fix) renames three Xid panels. This cleanup covers both the pre-PR-#46 and post-PR-#46 panel titles so it can merge in either order without conflict on the descriptions themselves. The bundled manifest will conflict on whichever PR merges second — same trivial regen we did for PRs #44/#45.

## No behavioral change

No metric, query, threshold, or layout edits. Tooltip text only.

## Test plan

- [ ] Pull this branch.
- [ ] `kubectl apply -f grafana-cmk/manifests/grafana-dashboards-configmap.yaml`.
- [ ] Open any dashboard → hover the info icon on any panel.
- [ ] Confirm no "DCGM field N" or "DCGM_FI_DEV_*" strings in the tooltip text.
- [ ] Confirm the description still tells you what the panel measures.