### PR TITLE
grafana-cmk: secure the public LB with HTTPS on :443 (self-signed)

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -67,8 +67,8 @@ What this is not: a full observability stack. Crusoe Metrics currently exposes i
   │  │  grafana-lb Svc  │                                 │
   │  │  (LoadBalancer)  │                                 │
   └──┴────────┬─────────┴─────────────────────────────────┘
-              │ :3000
-              ▼
+              │ HTTPS :443  (TLS terminated by Caddy
+              ▼              sidecar in the pod on :8443)
          User Browser
 ```
 
@@ -206,22 +206,64 @@ Wait for an external IP to be assigned (this can take 1–2 minutes on Crusoe):
 kubectl get svc grafana-lb -n monitoring -w
 ```
 
-Once `EXTERNAL-IP` shows an IP address, Grafana is accessible at `http://<EXTERNAL-IP>:3000`.
+Once `EXTERNAL-IP` shows an IP address, the Service is listening on **`https://<EXTERNAL-IP>` (port 443)**. The pod's `crusoe-public-tls-proxy` Caddy sidecar will start crash-looping until you complete Step 4.5 below — that's expected.
 
-> **Why port 3000 and not 80?** The Grafana Helm chart's ClusterIP service ends up on port 3000 on Crusoe Managed Kubernetes regardless of the `service.port` value passed in `grafana-values.yaml`, so this repo's `grafana-service-lb.yaml` exposes 3000 to match. If you need port 80 externally, add an ingress controller (recommended for production anyway).
-
-> **Security warning:** This service exposes Grafana directly to the public internet on port 3000 with no TLS. For production use, add an ingress controller with TLS termination and an authentication proxy (e.g. [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/)). At minimum, restrict the LoadBalancer source ranges in `grafana-service-lb.yaml` to your IP range:
+> **Security note:** TLS is on by default but the cert is **self-signed and bound to the LB's IP** (no public CA, no DNS). Browsers will show a "Your connection is not private" warning that you must click through once per device. The transport is still encrypted. For a proper CA-issued cert once you have DNS, swap the `grafana-public-tls` Secret for a cert-manager-issued one — no manifest changes needed. To restrict who can reach the LB at all, add `loadBalancerSourceRanges` to `manifests/grafana-service-lb.yaml`:
 > ```yaml
 > spec:
 >   loadBalancerSourceRanges:
 >     - "203.0.113.0/24"   # replace with your CIDR
 > ```
 >
-> For a quick local test without a public IP, skip the LoadBalancer and use port-forward instead:
+> For a quick local test without a public IP, skip this step and use port-forward against Grafana's plaintext port instead:
 > ```bash
 > kubectl port-forward -n monitoring svc/grafana 3000:3000
 > # Then open http://localhost:3000
 > ```
+
+---
+
+## Step 4.5: Generate a self-signed cert for the LB IP
+
+The `crusoe-public-tls-proxy` sidecar mounts a Secret named `grafana-public-tls` (a standard `kubernetes.io/tls` Secret with `tls.crt` / `tls.key`). Without this Secret the sidecar will not start, and the LoadBalancer will refuse connections.
+
+Generate a self-signed cert whose `subjectAltName` contains the LB IP, and store it as the Secret:
+
+```bash
+LB_IP=$(kubectl get svc -n monitoring grafana-lb \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo "Grafana LB IP: $LB_IP"
+
+openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+  -keyout /tmp/grafana-tls.key -out /tmp/grafana-tls.crt \
+  -subj "/CN=grafana-cmk" \
+  -addext "subjectAltName=IP:${LB_IP}"
+
+kubectl create secret tls grafana-public-tls \
+  --namespace monitoring \
+  --cert=/tmp/grafana-tls.crt \
+  --key=/tmp/grafana-tls.key
+
+rm -f /tmp/grafana-tls.key /tmp/grafana-tls.crt
+
+# Force the sidecar to pick up the Secret immediately
+kubectl rollout restart deployment/grafana -n monitoring
+kubectl rollout status deployment/grafana -n monitoring
+```
+
+Verify the handshake:
+
+```bash
+openssl s_client -connect ${LB_IP}:443 -showcerts </dev/null 2>/dev/null \
+  | openssl x509 -noout -subject -ext subjectAltName
+# Expect: subject=CN = grafana-cmk
+# Expect: IP Address:<LB_IP>
+
+curl --insecure https://${LB_IP}/api/health
+# Expect JSON: {"database":"ok","version":"12.x.x",...}
+```
+
+> **The cert is bound to this specific IP.** If the LB is ever recreated and gets a new IP, re-run this snippet. The cert is also valid for 365 days; renew before expiry.
 
 ---
 
@@ -234,7 +276,7 @@ kubectl get secret --namespace monitoring grafana \
   -o jsonpath="{.data.admin-password}" | base64 --decode; echo
 ```
 
-Log in at `http://<EXTERNAL-IP>:3000` (or `http://localhost:3000` if using port-forward) with username `admin` and the password above. Change the password after first login.
+Log in at `https://<EXTERNAL-IP>` (or `http://localhost:3000` if using port-forward) with username `admin` and the password above. Click through the browser's "Not secure / unknown issuer" warning on first visit — the transport is encrypted, only the cert's issuer is untrusted. Change the password after first login.
 
 Verify the data source:
 
@@ -616,7 +658,7 @@ If you want `kubectl top` long-term, install the [metrics-server](https://github
 
 The repo ships a public LoadBalancer manifest for fast getting-started. Work through this checklist before pointing real users at it:
 
-- [ ] **TLS termination.** Install `cert-manager` and switch from the bare `grafana-lb` Service to an Ingress with a cert (Let's Encrypt or your CA). The current `grafana-service-lb.yaml` exposes plain HTTP on port 3000.
+- [ ] **TLS with a real CA.** The default deploy ships TLS on :443 with a self-signed cert tied to the LB IP (see Step 4.5). Once you have a hostname, replace the self-signed `grafana-public-tls` Secret with a cert-manager-issued one (same name, same keys), or migrate to ingress-nginx + cert-manager + an Ingress for the canonical pattern.
 - [ ] **Auth in front of Grafana's UI.** Three reasonable options:
   - [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) sidecar in front of the LB. Simplest if your org uses Google/GitHub/Okta SSO.
   - Grafana's native [OAuth integration](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/) (set `[auth.generic_oauth]` via `grafana.ini`).

--- a/grafana-cmk/manifests/grafana-service-lb.yaml
+++ b/grafana-cmk/manifests/grafana-service-lb.yaml
@@ -1,22 +1,33 @@
 # Provided AS IS without warranty of any kind — see grafana-cmk/README.md → Disclaimer.
 #
-# WARNING: This service exposes Grafana directly to the public internet on port 3000.
-# For production use, place Grafana behind an ingress controller with TLS termination
-# and an authentication proxy (e.g. oauth2-proxy). At minimum, change the Grafana
-# admin password from the generated default and restrict LoadBalancer source ranges:
+# Public Grafana LoadBalancer with HTTPS on :443.
+#
+# Traffic flow:
+#   browser  ──HTTPS:443──▶  this LB  ──TCP:8443──▶  crusoe-public-tls-proxy
+#                                                    sidecar in the Grafana pod
+#                                                    (Caddy, terminates TLS)
+#                                                    ──HTTP:3000──▶  Grafana
+#
+# The TLS sidecar reads `grafana-public-tls` Secret (kubernetes.io/tls type,
+# keys tls.crt and tls.key). Generate that Secret with README Step 4.5 BEFORE
+# applying this Service — otherwise the sidecar will crash-loop on missing volume.
+#
+# WARNING: This service exposes Grafana to the public internet. The default
+# install ships with a self-signed cert (no public CA, no DNS); browsers will
+# show a "Not secure" warning that you must click through. The transport is
+# still encrypted. For a proper cert once you have DNS, swap the Secret for a
+# cert-manager-issued one (no manifest changes needed).
+#
+# At minimum, change the Grafana admin password from the generated default
+# and consider restricting LoadBalancer source ranges to your IP CIDR:
 #
 #   spec:
 #     loadBalancerSourceRanges:
 #       - "203.0.113.0/24"   # your office CIDR
 #
-# For an internal-only deployment, skip this file and use `kubectl port-forward` instead:
-#   kubectl port-forward -n monitoring svc/grafana 3000:3000
-#
-# Note: port is 3000 (not 80) because the Grafana Helm chart's ClusterIP service
-# ends up on port 3000 on Crusoe Managed Kubernetes regardless of the
-# `service.port` value passed in `grafana-values.yaml`. Keeping both this LB and
-# the chart-created svc on port 3000 keeps `kubectl port-forward svc/grafana 3000:3000`
-# working uniformly.
+# For an internal-only deployment, skip this file and use `kubectl port-forward`
+# directly against the pod's :8443 (Caddy) or :3000 (Grafana plaintext) port:
+#   kubectl port-forward -n monitoring svc/grafana 3000:3000   # plaintext
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,7 +40,7 @@ spec:
   selector:
     app.kubernetes.io/name: grafana
   ports:
-    - name: http
-      port: 3000
-      targetPort: 3000
+    - name: https
+      port: 443
+      targetPort: 8443
       protocol: TCP

--- a/grafana-cmk/manifests/grafana-values.yaml
+++ b/grafana-cmk/manifests/grafana-values.yaml
@@ -152,3 +152,53 @@ extraContainers: |
       initialDelaySeconds: 10
       periodSeconds: 30
       failureThreshold: 3
+
+  # Public-facing TLS terminator. Listens on :8443 with a TLS cert mounted from
+  # the `grafana-public-tls` Secret (kubernetes.io/tls type, keys tls.crt and
+  # tls.key). Reverse-proxies plaintext to localhost:3000 where Grafana is
+  # listening. The LoadBalancer Service forwards public :443 to this container's
+  # :8443. The cert is self-signed and generated against the LB's public IP —
+  # see README Step 4.5 for the openssl bootstrap. auto_https is OFF because
+  # there is no public DNS and public CAs do not issue certs for bare IPs.
+  - name: crusoe-public-tls-proxy
+    image: caddy:2-alpine
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        cat > /tmp/Caddyfile <<'EOF'
+        {
+          admin off
+          auto_https off
+          persist_config off
+        }
+        :8443 {
+          tls /etc/caddy/tls/tls.crt /etc/caddy/tls/tls.key
+          reverse_proxy localhost:3000
+        }
+        EOF
+        exec caddy run --config /tmp/Caddyfile --adapter caddyfile
+    ports:
+      - name: public-tls
+        containerPort: 8443
+    volumeMounts:
+      - name: public-tls-cert
+        mountPath: /etc/caddy/tls
+        readOnly: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+    # No livenessProbe — Caddy on :8443 expects TLS clients, and probes do not
+    # speak TLS without extra config. Process health is sufficient here.
+
+# Mount the TLS secret as a volume that the crusoe-public-tls-proxy sidecar
+# above consumes. The Secret is created by README Step 4.5 — Grafana will
+# crash-loop on first install until the Secret exists, which is the intended
+# fail-fast.
+extraContainerVolumes:
+  - name: public-tls-cert
+    secret:
+      secretName: grafana-public-tls


### PR DESCRIPTION
## Why

The default install shipped Grafana on plain HTTP :3000 through a public LoadBalancer. The README already flagged this as a production gap and pointed at ingress + cert-manager — but most users (including the one driving this change) don't have public DNS or a hostname pointing at the LB yet. Public CAs don't issue certs for bare IPs, so any ACME flow is off the table.

Encrypt the bytes in flight now, with no DNS prereqs, using only the OSS pieces already familiar in this deploy.

## What

Add a second Caddy sidecar (`crusoe-public-tls-proxy`) next to the existing `crusoe-auth-proxy`. New container:
- listens on `:8443`
- terminates TLS using a Secret-mounted cert (standard `kubernetes.io/tls` shape, `tls.crt` + `tls.key`)
- reverse-proxies plaintext to `localhost:3000` (Grafana, unchanged)

The LoadBalancer Service forwards public `:443` to the sidecar's `:8443`. Grafana itself stays on plain HTTP internally — no `grafana.ini` mutation, no healthcheck rewrites, no datasource-side TLS plumbing.

The cert is generated once by a 4-line `openssl` one-liner in **README Step 4.5** that:
1. Reads the LB external IP from `kubectl get svc`.
2. Generates a 4096-bit self-signed cert with the IP in `subjectAltName`, valid 365 days.
3. Stores it as the `grafana-public-tls` Secret in the `monitoring` namespace.
4. Restarts the deployment so the sidecar picks up the volume.

## Files

| File | Change |
| --- | --- |
| `manifests/grafana-values.yaml` | Add `crusoe-public-tls-proxy` to `extraContainers`. Add the TLS Secret volume to `extraContainerVolumes`. |
| `manifests/grafana-service-lb.yaml` | Port `443` → `targetPort 8443` (was `3000` → `3000`). Comment rewritten for the new traffic flow. |
| `README.md` | Insert Step 4.5, update Step 4/Step 5 URLs from `http://...:3000` to `https://...`, update the architecture diagram, tighten the Production-hardening TLS bullet. |

## Verified live

Tested end-to-end on a fresh CMK cluster:

```
1) Cert SAN binds to the LB IP:
   subject=CN=grafana-cmk
   X509v3 Subject Alternative Name:
       IP Address:<LB_IP>

2) HTTPS GET /api/health:
   {"database":"ok","version":"12.3.1",...}

3) Plain HTTP :3000 from the public IP:
   wget: download timed out  ✓ port 3000 closed at the LB
```

## Alternatives considered

- **Grafana native TLS** (`protocol=https` + cert mount) — works but requires editing `grafana.ini`, rewriting probes, and breaks the consistent-sidecar-pattern property. Higher blast radius for a transport-only change.
- **ingress-nginx + cert-manager + ClusterIssuer** — canonical k8s production pattern, but overkill without DNS and would require two cluster-wide Helm installs.
- **Service-mesh mTLS (Linkerd / Istio)** — doesn't address the browser-facing edge.

## Migration once DNS is available

Drop the self-signed Secret, replace it with a cert-manager-issued cert under the same name (`grafana-public-tls`) and same keys (`tls.crt`, `tls.key`). No sidecar or Service changes needed.

## Test plan

- [ ] Pull this branch.
- [ ] If you already have Grafana installed: `helm upgrade grafana grafana/grafana --namespace monitoring --values manifests/grafana-values.yaml`. Otherwise follow Step 3 in the README.
- [ ] `kubectl apply -f manifests/grafana-service-lb.yaml` — port becomes 443.
- [ ] The Grafana pod will be in `Init` / `PodInitializing` waiting for the `grafana-public-tls` Secret — this is intentional.
- [ ] Run the README Step 4.5 snippet. Pod becomes 5/5 Ready within ~30 s.
- [ ] `curl --insecure https://<LB_IP>/api/health` → 200 with the Grafana version JSON.
- [ ] Browser at `https://<LB_IP>` → "Not secure" warning → click through → Grafana login on encrypted transport.
- [ ] `curl http://<LB_IP>:3000/api/health` → times out (port 3000 is gone from the public LB).