### PR TITLE
grafana-cmk: pin LB nodePort to 32042 for stable Crusoe firewall rule

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -208,7 +208,9 @@ kubectl get svc grafana-lb -n monitoring -w
 
 Once `EXTERNAL-IP` shows an IP address, the Service is listening on **`https://<EXTERNAL-IP>` (port 443)**. The pod's `crusoe-public-tls-proxy` Caddy sidecar will start crash-looping until you complete Step 4.5 below — that's expected.
 
-> **Security note:** TLS is on by default but the cert is **self-signed and bound to the LB's IP** (no public CA, no DNS). Browsers will show a "Your connection is not private" warning that you must click through once per device. The transport is still encrypted. For a proper CA-issued cert once you have DNS, swap the `grafana-public-tls` Secret for a cert-manager-issued one — no manifest changes needed. To restrict who can reach the LB at all, add `loadBalancerSourceRanges` to `manifests/grafana-service-lb.yaml`:
+> **Crusoe firewall: open the nodePort, not 443.** On Crusoe Managed Kubernetes, the LB external IP DNATs public packets to a worker node's nodePort *before* the project firewall is evaluated. By the time the firewall sees the packet, the destination port has been rewritten from 443 to the nodePort. This manifest pins **nodePort `32042`** so the rule stays stable across redeploys — your Crusoe firewall rule should be `allow inbound TCP 32042 from <your CIDR>`. (On AWS/GCP you'd open 443; that intuition does not apply here.)
+>
+> **Security note:** TLS is on by default but the cert is **self-signed and bound to the LB's IP** (no public CA, no DNS). Browsers will show a "Your connection is not private" warning that you must click through once per device. The transport is still encrypted. For a proper CA-issued cert once you have DNS, swap the `grafana-public-tls` Secret for a cert-manager-issued one — no manifest changes needed. To restrict who can reach the LB at the k8s layer (in addition to the Crusoe firewall above), add `loadBalancerSourceRanges` to `manifests/grafana-service-lb.yaml`:
 > ```yaml
 > spec:
 >   loadBalancerSourceRanges:

--- a/grafana-cmk/manifests/grafana-service-lb.yaml
+++ b/grafana-cmk/manifests/grafana-service-lb.yaml
@@ -3,14 +3,22 @@
 # Public Grafana LoadBalancer with HTTPS on :443.
 #
 # Traffic flow:
-#   browser  ──HTTPS:443──▶  this LB  ──TCP:8443──▶  crusoe-public-tls-proxy
-#                                                    sidecar in the Grafana pod
-#                                                    (Caddy, terminates TLS)
-#                                                    ──HTTP:3000──▶  Grafana
+#   browser  ──HTTPS:443──▶  this LB IP  ──DNAT to nodePort 32042──▶
+#     worker node :32042  ──kube-proxy──▶  Grafana pod :8443 (Caddy TLS sidecar)
+#                                                            │
+#                                                            ▼ localhost
+#                                                       Grafana :3000
 #
 # The TLS sidecar reads `grafana-public-tls` Secret (kubernetes.io/tls type,
 # keys tls.crt and tls.key). Generate that Secret with README Step 4.5 BEFORE
 # applying this Service — otherwise the sidecar will crash-loop on missing volume.
+#
+# Crusoe firewall note:
+#   On Crusoe Managed Kubernetes, the LB external IP DNATs public packets to a
+#   worker node's nodePort BEFORE the project firewall sees the packet. That
+#   means a firewall rule "allow 443 inbound to LB" does not match — the rule
+#   actually needs to allow inbound on the nodePort. We pin nodePort = 32042
+#   below so that firewall rule stays stable across redeploys.
 #
 # WARNING: This service exposes Grafana to the public internet. The default
 # install ships with a self-signed cert (no public CA, no DNS); browsers will
@@ -43,4 +51,5 @@ spec:
     - name: https
       port: 443
       targetPort: 8443
+      nodePort: 32042   # pinned so the Crusoe firewall rule stays stable
       protocol: TCP


### PR DESCRIPTION
## Why

After PR #49 shipped HTTPS on the LB, a user found that opening "TCP 443 inbound" on their Crusoe project firewall did not let traffic through — they had to open the **nodePort** instead. That's because on Crusoe Managed Kubernetes, the LB external IP DNATs public packets to a worker node's nodePort **before** the project firewall evaluates the packet. The firewall sees `<node-IP>:<nodePort>`, not `<LB-IP>:443`.

Without a pinned nodePort, kube-proxy assigns one randomly from `30000-32767` on each Service create — meaning the firewall rule would need to be updated every time the Service is recreated.

## What

- `manifests/grafana-service-lb.yaml`: add `nodePort: 32042` to the Service port spec.
- Comment in the YAML rewritten to show the new traffic flow (browser → LB IP → DNAT → node:nodePort → pod:8443) and to explain how Crusoe's LB differs from cloud-LB intuition.
- `README.md` Step 4: new callout block titled **"Crusoe firewall: open the nodePort, not 443"** explaining the behavior and the resulting firewall rule shape (`allow inbound TCP 32042 from <CIDR>`), with a one-liner contrasting against the AWS/GCP intuition.

## Why 32042 specifically

It's the port that's already assigned on the test cluster, and any free port in the `NodePort` range works. Documenting the same number across the manifest and README means readers don't have to translate between them.

## Verified

- Live `kubectl apply` is a no-op against an existing Service where 32042 was already auto-assigned (`service/grafana-lb configured`, no port reassignment).
- `https://<LB_IP>/api/health` still returns `{"database":"ok","version":"12.3.1",...}` from inside the cluster.
- For a fresh install: kube-proxy will assign 32042 explicitly because the Service spec requests it, and the documented firewall rule will match.

## Test plan

- [ ] Pull this branch.
- [ ] `kubectl apply -f grafana-cmk/manifests/grafana-service-lb.yaml` → expect `configured` or `created`.
- [ ] `kubectl get svc -n monitoring grafana-lb -o jsonpath='{.spec.ports[0].nodePort}'` → returns `32042`.
- [ ] On a fresh deploy where 32042 is free, confirm kube-proxy honors the requested port.
- [ ] Configure the Crusoe firewall: `allow inbound TCP 32042 from <your CIDR>`. Browser at `https://<LB_IP>` reaches Grafana.