### PR TITLE
grafana-cmk: Xid Events table — drop cluster filter, full-width

### DIFF
--- a/grafana-cmk/dashboards/dcgm-xid-errors.json
+++ b/grafana-cmk/dashboards/dcgm-xid-errors.json
@@ -419,8 +419,8 @@
         "showHeader": true,
         "sortBy": [
           {
-            "desc": true,
-            "displayName": "Error Count"
+            "displayName": "Xid Code",
+            "desc": true
           }
         ]
       },
@@ -433,22 +433,18 @@
           "expr": "max by (vm_name, gpu, err_code, err_msg) (max_over_time(DCGM_FI_DEV_XID_ERRORS[24h])) > 0",
           "instant": true,
           "legendFormat": "",
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
         }
       ],
       "title": "Xid Events by Node / GPU / Code (Last 24h)",
       "transformations": [
         {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
           "id": "organize",
           "options": {
             "excludeByName": {
-              "Time": true
+              "Time": true,
+              "__name__": true
             },
             "indexByName": {
               "vm_name": 0,
@@ -461,8 +457,29 @@
               "vm_name": "Node",
               "gpu": "GPU",
               "err_code": "Xid Code",
-              "err_msg": "Xid Message"
+              "err_msg": "Xid Message",
+              "Value": "Last Value"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Xid Code",
+                "desc": true
+              },
+              {
+                "field": "Node",
+                "desc": false
+              },
+              {
+                "field": "GPU",
+                "desc": false
+              }
+            ]
           }
         }
       ],
@@ -1973,6 +1990,6 @@
   "timezone": "browser",
   "title": "DCGM & Xid Errors",
   "uid": "crusoe-dcgm-xid-errors",
-  "version": 11,
+  "version": 12,
   "weekStart": ""
 }

--- a/grafana-cmk/dashboards/dcgm-xid-errors.json
+++ b/grafana-cmk/dashboards/dcgm-xid-errors.json
@@ -337,7 +337,7 @@
         "type": "prometheus",
         "uid": "crusoe-metrics"
       },
-      "description": "GPUs with any non-zero Xid in the last 24h, broken down by node, GPU, and Xid code. Xid code reference: https://docs.nvidia.com/deploy/xid-errors/",
+      "description": "All GPUs that fired any non-zero Xid in the last 24h, broken down by node, GPU, and Xid code. Intentionally does not filter by the $cluster dropdown \u2014 this table always shows every GPU with an error so nothing gets hidden by a dropdown selection. Xid code reference: https://docs.nvidia.com/deploy/xid-errors/",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -400,10 +400,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
-        "y": 12
+        "y": 12,
+        "w": 24,
+        "h": 10
       },
       "id": 4,
       "options": {
@@ -430,7 +430,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "max by (vm_name, gpu, err_code, err_msg) (max_over_time(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h])) > 0",
+          "expr": "max by (vm_name, gpu, err_code, err_msg) (max_over_time(DCGM_FI_DEV_XID_ERRORS[24h])) > 0",
           "instant": true,
           "legendFormat": "",
           "refId": "A"
@@ -540,10 +540,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 12
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 6
       },
       "id": 5,
       "options": {
@@ -603,7 +603,7 @@
       "title": "GPU Health Indicators \u2014 Slow Node Detection",
       "gridPos": {
         "x": 0,
-        "y": 20,
+        "y": 30,
         "w": 24,
         "h": 1
       },
@@ -621,7 +621,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 21,
+        "y": 31,
         "w": 4,
         "h": 4
       },
@@ -689,7 +689,7 @@
       },
       "gridPos": {
         "x": 4,
-        "y": 21,
+        "y": 31,
         "w": 4,
         "h": 4
       },
@@ -757,7 +757,7 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 21,
+        "y": 31,
         "w": 4,
         "h": 4
       },
@@ -821,7 +821,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 21,
+        "y": 31,
         "w": 4,
         "h": 4
       },
@@ -889,7 +889,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 21,
+        "y": 31,
         "w": 4,
         "h": 4
       },
@@ -957,7 +957,7 @@
       },
       "gridPos": {
         "x": 20,
-        "y": 21,
+        "y": 31,
         "w": 4,
         "h": 4
       },
@@ -1017,7 +1017,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 35,
+        "y": 45,
         "w": 12,
         "h": 10
       },
@@ -1146,7 +1146,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 35,
+        "y": 45,
         "w": 12,
         "h": 10
       },
@@ -1275,7 +1275,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 45,
+        "y": 55,
         "w": 12,
         "h": 10
       },
@@ -1404,7 +1404,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 45,
+        "y": 55,
         "w": 12,
         "h": 10
       },
@@ -1533,7 +1533,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 65,
+        "y": 75,
         "w": 24,
         "h": 8
       },
@@ -1594,7 +1594,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 73,
+        "y": 83,
         "w": 24,
         "h": 8
       },
@@ -1655,7 +1655,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 25,
+        "y": 35,
         "w": 24,
         "h": 10
       },
@@ -1795,7 +1795,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 55,
+        "y": 65,
         "w": 24,
         "h": 10
       },
@@ -1973,6 +1973,6 @@
   "timezone": "browser",
   "title": "DCGM & Xid Errors",
   "uid": "crusoe-dcgm-xid-errors",
-  "version": 10,
+  "version": 11,
   "weekStart": ""
 }

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -3488,8 +3488,8 @@ data:
             "showHeader": true,
             "sortBy": [
               {
-                "desc": true,
-                "displayName": "Error Count"
+                "displayName": "Xid Code",
+                "desc": true
               }
             ]
           },
@@ -3502,22 +3502,18 @@ data:
               "expr": "max by (vm_name, gpu, err_code, err_msg) (max_over_time(DCGM_FI_DEV_XID_ERRORS[24h])) > 0",
               "instant": true,
               "legendFormat": "",
-              "refId": "A"
+              "refId": "A",
+              "format": "table"
             }
           ],
           "title": "Xid Events by Node / GPU / Code (Last 24h)",
           "transformations": [
             {
-              "id": "labelsToFields",
-              "options": {
-                "mode": "columns"
-              }
-            },
-            {
               "id": "organize",
               "options": {
                 "excludeByName": {
-                  "Time": true
+                  "Time": true,
+                  "__name__": true
                 },
                 "indexByName": {
                   "vm_name": 0,
@@ -3530,8 +3526,29 @@ data:
                   "vm_name": "Node",
                   "gpu": "GPU",
                   "err_code": "Xid Code",
-                  "err_msg": "Xid Message"
+                  "err_msg": "Xid Message",
+                  "Value": "Last Value"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "field": "Xid Code",
+                    "desc": true
+                  },
+                  {
+                    "field": "Node",
+                    "desc": false
+                  },
+                  {
+                    "field": "GPU",
+                    "desc": false
+                  }
+                ]
               }
             }
           ],
@@ -5042,7 +5059,7 @@ data:
       "timezone": "browser",
       "title": "DCGM & Xid Errors",
       "uid": "crusoe-dcgm-xid-errors",
-      "version": 11,
+      "version": 12,
       "weekStart": ""
     }
 kind: ConfigMap

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -3406,7 +3406,7 @@ data:
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "description": "GPUs with any non-zero Xid in the last 24h, broken down by node, GPU, and Xid code. Xid code reference: https://docs.nvidia.com/deploy/xid-errors/",
+          "description": "All GPUs that fired any non-zero Xid in the last 24h, broken down by node, GPU, and Xid code. Intentionally does not filter by the $cluster dropdown \u2014 this table always shows every GPU with an error so nothing gets hidden by a dropdown selection. Xid code reference: https://docs.nvidia.com/deploy/xid-errors/",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3469,10 +3469,10 @@ data:
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 12,
             "x": 0,
-            "y": 12
+            "y": 12,
+            "w": 24,
+            "h": 10
           },
           "id": 4,
           "options": {
@@ -3499,7 +3499,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "max by (vm_name, gpu, err_code, err_msg) (max_over_time(DCGM_FI_DEV_XID_ERRORS{cluster_id=~\"$cluster\"}[24h])) > 0",
+              "expr": "max by (vm_name, gpu, err_code, err_msg) (max_over_time(DCGM_FI_DEV_XID_ERRORS[24h])) > 0",
               "instant": true,
               "legendFormat": "",
               "refId": "A"
@@ -3609,10 +3609,10 @@ data:
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 12
+            "x": 0,
+            "y": 22,
+            "w": 24,
+            "h": 6
           },
           "id": 5,
           "options": {
@@ -3672,7 +3672,7 @@ data:
           "title": "GPU Health Indicators \u2014 Slow Node Detection",
           "gridPos": {
             "x": 0,
-            "y": 20,
+            "y": 30,
             "w": 24,
             "h": 1
           },
@@ -3690,7 +3690,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 21,
+            "y": 31,
             "w": 4,
             "h": 4
           },
@@ -3758,7 +3758,7 @@ data:
           },
           "gridPos": {
             "x": 4,
-            "y": 21,
+            "y": 31,
             "w": 4,
             "h": 4
           },
@@ -3826,7 +3826,7 @@ data:
           },
           "gridPos": {
             "x": 8,
-            "y": 21,
+            "y": 31,
             "w": 4,
             "h": 4
           },
@@ -3890,7 +3890,7 @@ data:
           },
           "gridPos": {
             "x": 12,
-            "y": 21,
+            "y": 31,
             "w": 4,
             "h": 4
           },
@@ -3958,7 +3958,7 @@ data:
           },
           "gridPos": {
             "x": 16,
-            "y": 21,
+            "y": 31,
             "w": 4,
             "h": 4
           },
@@ -4026,7 +4026,7 @@ data:
           },
           "gridPos": {
             "x": 20,
-            "y": 21,
+            "y": 31,
             "w": 4,
             "h": 4
           },
@@ -4086,7 +4086,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 35,
+            "y": 45,
             "w": 12,
             "h": 10
           },
@@ -4215,7 +4215,7 @@ data:
           },
           "gridPos": {
             "x": 12,
-            "y": 35,
+            "y": 45,
             "w": 12,
             "h": 10
           },
@@ -4344,7 +4344,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 45,
+            "y": 55,
             "w": 12,
             "h": 10
           },
@@ -4473,7 +4473,7 @@ data:
           },
           "gridPos": {
             "x": 12,
-            "y": 45,
+            "y": 55,
             "w": 12,
             "h": 10
           },
@@ -4602,7 +4602,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 65,
+            "y": 75,
             "w": 24,
             "h": 8
           },
@@ -4663,7 +4663,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 73,
+            "y": 83,
             "w": 24,
             "h": 8
           },
@@ -4724,7 +4724,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 25,
+            "y": 35,
             "w": 24,
             "h": 10
           },
@@ -4864,7 +4864,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 55,
+            "y": 65,
             "w": 24,
             "h": 10
           },
@@ -5042,7 +5042,7 @@ data:
       "timezone": "browser",
       "title": "DCGM & Xid Errors",
       "uid": "crusoe-dcgm-xid-errors",
-      "version": 10,
+      "version": 11,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
## Why

Users reported that the cluster dropdown at the top of the DCGM dashboard could hide GPUs from the **Xid Events by Node / GPU / Code (Last 24h)** breakdown table. This is the *one* table people use to figure out "which GPUs have actually fired Xid errors right now" — it shouldn't be filterable away by a dropdown selection.

The table was also half-width (`w=12`), which constrains how many rows can be shown before scrolling. With 16+ GPUs firing Xid on busy clusters (e.g. a distributed training crash takes out all 8 ranks on a node × N nodes), half-width hides the tail.

## What

1. **Drop the cluster filter** on the table's query:
   ```promql
   max by (vm_name, gpu, err_code, err_msg)
     (max_over_time(DCGM_FI_DEV_XID_ERRORS[24h])) > 0
   ```
   (was `DCGM_FI_DEV_XID_ERRORS{cluster_id=~"$cluster"}`)

2. **Expand to full-width** — `w=12 → 24`, `h=8 → 10`. The Health Failures table that previously sat next to it (also half-width) moves to its own row directly below at `w=24 h=6`.

3. **Shift downstream panels down by 10 grid rows** to keep the layout consistent. The GPU Health Indicators section starts at `y=31` instead of `y=21`.

Other Xid panels on this dashboard (the headline stat, the "Xid Code by Node Over Time" timeseries) still respect the `$cluster` dropdown — only this one breakdown table is intentionally unconditional.

## Verified

On the POC cluster live: dashboard reloaded, panel is at `w=24`, query no longer has `$cluster`, and the table returns the same 17 GPU rows that the dropdown-filtered version showed when "All" was selected. No data loss, just no risk of accidental hiding.

## Test plan

- [ ] Pull this branch.
- [ ] `kubectl apply -f grafana-cmk/manifests/grafana-dashboards-configmap.yaml`.
- [ ] Open Grafana → Crusoe → DCGM & Xid Errors.
- [ ] Confirm the Xid breakdown table is full-width with all rows visible.
- [ ] Change the cluster dropdown — confirm the table still shows every GPU regardless of selection.
- [ ] Confirm Health Failures table now sits below the Xid table at full-width.