### PR TITLE
grafana-cmk: tighten IB dashboard windows for finer-grained scrapes

### DIFF
--- a/grafana-cmk/README.md
+++ b/grafana-cmk/README.md
@@ -365,10 +365,7 @@ All dashboards live in the `Crusoe` folder in Grafana. Most have a **Cluster** d
 >
 > On Crusoe-virtualized HCAs the IB port counters surfaced through Crusoe Metrics are not a faithful realtime view of the fabric. Three issues we have observed, all upstream of this repo:
 >
-> 1. **Slow scrape cadence.** The Watch Agent refreshes IB counters far less frequently than DCGM. Measured cadence between fresh samples on the same series:
-
-
->    Because of this, every IB panel in this repo uses **`[1h]` rate windows** and the stat panels wrap bare metric references in **`last_over_time(... [1h])`**. With the typical `$__rate_interval` (~1 min) the panels would render entirely as "No data" — there are simply fewer than 2 samples per minute. The price of the wider window is temporal smoothing: a panel reading represents the average over the trailing hour, not the current second. When the Watch Agent's IB cadence drops to ≤60 s (engineering ticket open), these windows can be tightened — likely down to `$__rate_interval`.
+> 1. **Coarser temporal resolution.** IB counters refresh on a slower push cadence than per-node DCGM telemetry. Panels here use **5-min `last_over_time` windows** for instant-value lookups and **10-min `rate`/`increase` windows** for counter-derived metrics, with panel-level `interval` set to `5m`. A reading represents activity over the trailing window, not the current second — a sub-minute traffic spike or single error event may sit between samples.
 > 2. **Magnitude is low.** Counter deltas captured during a sustained `perftest` run measured ~10× lower than the actual bandwidth `perftest` reported on the same wire. The `line_rate` label (`gig_bit_per_sec`) also reports `128` on HCAs whose `ibstat` rate is `400`, so the utilization-% panels are calibrated against the wrong denominator.
 > 3. **No in-guest fallback.** `ibv_devinfo`, `perfquery`, and the standard `/sys/class/infiniband/.../counters/` files are not exposed inside Crusoe guest VMs, so there is no in-guest path to scrape accurate per-HCA counters today.
 >

--- a/grafana-cmk/dashboards/cluster-ib-overview.json
+++ b/grafana-cmk/dashboards/cluster-ib-overview.json
@@ -1,7 +1,7 @@
 {
   "uid": "crusoe-ib-cluster",
   "title": "InfiniBand Cluster View",
-  "description": "Cluster-wide InfiniBand fabric health and activity. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
+  "description": "Cluster-wide InfiniBand fabric health and activity. Panels use 5-min display intervals with 5-min last_over_time and 10-min rate/increase windows.",
   "tags": [
     "crusoe",
     "infiniband",
@@ -84,11 +84,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])))) or vector(0)",
+          "expr": "(count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[5m])))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 2,
@@ -135,11 +136,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "expr": "(count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[5m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 3,
@@ -186,11 +188,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8) or vector(0)",
+          "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[10m])) / 8) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 4,
@@ -237,11 +240,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8) or vector(0)",
+          "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[10m])) / 8) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 5,
@@ -288,11 +292,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "expr": "(sum(rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 6,
@@ -339,11 +344,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "expr": "(sum(rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 7,
@@ -394,11 +400,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 8,
@@ -449,11 +456,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "expr": "(sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 9,
@@ -504,11 +512,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "expr": "(sum(increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 10,
@@ -559,11 +568,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(increase(crusoe_ib_port_link_error_recovery{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "expr": "(sum(increase(crusoe_ib_port_link_error_recovery{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 11,
@@ -614,11 +624,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(increase(crusoe_ib_port_rcv_remote_physical_errors{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "expr": "(sum(increase(crusoe_ib_port_rcv_remote_physical_errors{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 12,
@@ -669,11 +680,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+          "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 13,
@@ -714,10 +726,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[10m])) / 8",
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 14,
@@ -758,10 +771,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[10m])) / 8",
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 15,
@@ -802,10 +816,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[1h]))",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[10m]))",
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 16,
@@ -846,10 +861,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[1h]))",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[10m]))",
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 17,
@@ -890,10 +906,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 1e9 / sum by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])) * 100",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[10m])) / 1e9 / sum by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[5m])) * 100",
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 18,
@@ -934,10 +951,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[10m]))",
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 19,
@@ -978,10 +996,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[1h]))",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[10m]))",
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 20,
@@ -1019,16 +1038,17 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "topk(10, sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h]) + rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8)",
+          "expr": "topk(10, sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[10m]) + rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[10m])) / 8)",
           "instant": true,
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 21,
       "type": "table",
-      "title": "Link-Down Events by HCA (last 1h)",
+      "title": "Link-Down Events by HCA (last 10m)",
       "description": "Per-HCA breakdown of the Link Downed Events stat. Sort by Events; copy a vm_name into the InfiniBand Node View $node dropdown to drill in. Empty / 'No data' is the healthy state.",
       "datasource": {
         "type": "prometheus",
@@ -1111,7 +1131,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name, hca_number, nodepool_name, pod_id) (increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[1h])) > 0",
+          "expr": "sum by (vm_name, hca_number, nodepool_name, pod_id) (increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[10m])) > 0",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -1152,7 +1172,8 @@
             }
           }
         }
-      ]
+      ],
+      "interval": "5m"
     }
   ]
 }

--- a/grafana-cmk/dashboards/node-ib-detail.json
+++ b/grafana-cmk/dashboards/node-ib-detail.json
@@ -1,7 +1,7 @@
 {
   "uid": "crusoe-ib-node",
   "title": "InfiniBand Node View",
-  "description": "Per-HCA InfiniBand detail for selected nodes. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
+  "description": "Per-HCA InfiniBand detail for selected nodes. Panels use 5-min display intervals with 5-min last_over_time and 10-min rate/increase windows.",
   "tags": [
     "crusoe",
     "infiniband",
@@ -104,11 +104,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8) or vector(0)",
+          "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])) / 8) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 2,
@@ -155,11 +156,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8) or vector(0)",
+          "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])) / 8) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 3,
@@ -210,11 +212,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))) or vector(0)",
+          "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 4,
@@ -265,11 +268,12 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))) or vector(0)",
+          "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]))) or vector(0)",
           "instant": true,
           "legendFormat": "__auto"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 5,
@@ -310,10 +314,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])) / 8",
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 6,
@@ -354,10 +359,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
+          "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])) / 8",
           "legendFormat": "{{vm_name}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 7,
@@ -398,10 +404,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 8",
+          "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]) / 8",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 8,
@@ -442,10 +449,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 8",
+          "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]) / 8",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 9,
@@ -486,10 +494,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) * 100",
+          "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[5m]) * 100",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 10,
@@ -530,10 +539,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) * 100",
+          "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[5m]) * 100",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 11,
@@ -574,10 +584,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+          "expr": "rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 12,
@@ -618,10 +629,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+          "expr": "rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 13,
@@ -662,10 +674,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+          "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
-      ]
+      ],
+      "interval": "5m"
     },
     {
       "id": 14,
@@ -706,10 +719,11 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+          "expr": "rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])",
           "legendFormat": "{{vm_name}} {{hca_number}}"
         }
-      ]
+      ],
+      "interval": "5m"
     }
   ]
 }

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -1898,11 +1898,11 @@ metadata:
 ---
 apiVersion: v1
 data:
-  cluster-ib-overview.json: |-
+  cluster-ib-overview.json: |
     {
       "uid": "crusoe-ib-cluster",
       "title": "InfiniBand Cluster View",
-      "description": "Cluster-wide InfiniBand fabric health and activity. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
+      "description": "Cluster-wide InfiniBand fabric health and activity. Panels use 5-min display intervals with 5-min last_over_time and 10-min rate/increase windows.",
       "tags": [
         "crusoe",
         "infiniband",
@@ -1985,11 +1985,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])))) or vector(0)",
+              "expr": "(count(count by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[5m])))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 2,
@@ -2036,11 +2037,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "expr": "(count(last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[5m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 3,
@@ -2087,11 +2089,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8) or vector(0)",
+              "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[10m])) / 8) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 4,
@@ -2138,11 +2141,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8) or vector(0)",
+              "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[10m])) / 8) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 5,
@@ -2189,11 +2193,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "expr": "(sum(rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 6,
@@ -2240,11 +2245,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "expr": "(sum(rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 7,
@@ -2295,11 +2301,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 8,
@@ -2350,11 +2357,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "expr": "(sum(increase(crusoe_ib_port_xmit_discard{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 9,
@@ -2405,11 +2413,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "expr": "(sum(increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 10,
@@ -2460,11 +2469,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(increase(crusoe_ib_port_link_error_recovery{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "expr": "(sum(increase(crusoe_ib_port_link_error_recovery{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 11,
@@ -2515,11 +2525,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(increase(crusoe_ib_port_rcv_remote_physical_errors{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "expr": "(sum(increase(crusoe_ib_port_rcv_remote_physical_errors{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 12,
@@ -2570,11 +2581,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\"}[1h]))) or vector(0)",
+              "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 13,
@@ -2615,10 +2627,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 8",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[10m])) / 8",
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 14,
@@ -2659,10 +2672,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[10m])) / 8",
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 15,
@@ -2703,10 +2717,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[1h]))",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\"}[10m]))",
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 16,
@@ -2747,10 +2762,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[1h]))",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\"}[10m]))",
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 17,
@@ -2791,10 +2807,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h])) / 1e9 / sum by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[1h])) * 100",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[10m])) / 1e9 / sum by (vm_name) (last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\"}[5m])) * 100",
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 18,
@@ -2835,10 +2852,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[1h]))",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\"}[10m]))",
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 19,
@@ -2879,10 +2897,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[1h]))",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\"}[10m]))",
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 20,
@@ -2920,16 +2939,17 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "topk(10, sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[1h]) + rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[1h])) / 8)",
+              "expr": "topk(10, sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\"}[10m]) + rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\"}[10m])) / 8)",
               "instant": true,
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 21,
           "type": "table",
-          "title": "Link-Down Events by HCA (last 1h)",
+          "title": "Link-Down Events by HCA (last 10m)",
           "description": "Per-HCA breakdown of the Link Downed Events stat. Sort by Events; copy a vm_name into the InfiniBand Node View $node dropdown to drill in. Empty / 'No data' is the healthy state.",
           "datasource": {
             "type": "prometheus",
@@ -3012,7 +3032,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name, hca_number, nodepool_name, pod_id) (increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[1h])) > 0",
+              "expr": "sum by (vm_name, hca_number, nodepool_name, pod_id) (increase(crusoe_ib_port_link_downed{cluster_id=~\"$cluster\"}[10m])) > 0",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -3053,7 +3073,8 @@ data:
                 }
               }
             }
-          ]
+          ],
+          "interval": "5m"
         }
       ]
     }
@@ -7607,11 +7628,11 @@ metadata:
 ---
 apiVersion: v1
 data:
-  node-ib-detail.json: |-
+  node-ib-detail.json: |
     {
       "uid": "crusoe-ib-node",
       "title": "InfiniBand Node View",
-      "description": "Per-HCA InfiniBand detail for selected nodes. All panels use [1h] rate windows due to the slow IB scrape cadence; see README for details.",
+      "description": "Per-HCA InfiniBand detail for selected nodes. Panels use 5-min display intervals with 5-min last_over_time and 10-min rate/increase windows.",
       "tags": [
         "crusoe",
         "infiniband",
@@ -7714,11 +7735,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8) or vector(0)",
+              "expr": "(sum(rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])) / 8) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 2,
@@ -7765,11 +7787,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8) or vector(0)",
+              "expr": "(sum(rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])) / 8) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 3,
@@ -7820,11 +7843,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))) or vector(0)",
+              "expr": "(sum(increase(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 4,
@@ -7875,11 +7899,12 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]))) or vector(0)",
+              "expr": "(sum(increase(crusoe_ib_local_link_integrity_errors{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]))) or vector(0)",
               "instant": true,
               "legendFormat": "__auto"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 5,
@@ -7920,10 +7945,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])) / 8",
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 6,
@@ -7964,10 +7990,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])) / 8",
+              "expr": "sum by (vm_name) (rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])) / 8",
               "legendFormat": "{{vm_name}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 7,
@@ -8008,10 +8035,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 8",
+              "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]) / 8",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 8,
@@ -8052,10 +8080,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 8",
+              "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]) / 8",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 9,
@@ -8096,10 +8125,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) * 100",
+              "expr": "rate(crusoe_ib_port_throughput_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[5m]) * 100",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 10,
@@ -8140,10 +8170,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h]) * 100",
+              "expr": "rate(crusoe_ib_port_throughput_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m]) / 1e9 / ignoring(gig_bit_per_sec) last_over_time(crusoe_ib_port_line_rate{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[5m]) * 100",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 11,
@@ -8184,10 +8215,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+              "expr": "rate(crusoe_ib_port_packets_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 12,
@@ -8228,10 +8260,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+              "expr": "rate(crusoe_ib_port_packets_tx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 13,
@@ -8272,10 +8305,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+              "expr": "rate(crusoe_ib_port_error_rx{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
-          ]
+          ],
+          "interval": "5m"
         },
         {
           "id": 14,
@@ -8316,10 +8350,11 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[1h])",
+              "expr": "rate(crusoe_ib_port_tx_wait{cluster_id=~\"$cluster\", vm_name=~\"$node\"}[10m])",
               "legendFormat": "{{vm_name}} {{hca_number}}"
             }
-          ]
+          ],
+          "interval": "5m"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Tightens the IB dashboard windows so charts plot one datapoint per ~5-min step instead of smearing the trailing hour.

- `last_over_time` windows: `[1h]` → `[5m]`
- `rate` / `increase` windows: `[1h]` → `[10m]`
- Panel-level `interval`: unset → `5m`

Affects **21 panels** in `cluster-ib-overview.json` and **14 panels** in `node-ib-detail.json`. The `grafana-dashboards-configmap.yaml` is regenerated from the new JSONs.

The 10-min rate window is wide enough to capture at least two consecutive samples across normal cadence variation, so counter-derived panels stay populated even when the upstream push timing jitters.

## Test plan

- [x] All 10 dashboards load via k8s-sidecar on a freshly-installed CMK cluster
- [x] Datasource `Test` returns "Successfully queried the Prometheus API"
- [x] InfiniBand Cluster View panels render with 5-min datapoint spacing (`Active IB Nodes`, `Total HCA Ports`, `Cluster RX BW`, `Per-Node Aggregate RX/TX`, `Link Downed Events`)
- [x] InfiniBand Node View panels render per-HCA series at the new resolution
- [x] No `[1h]` references remain anywhere in IB dashboards, regenerated ConfigMap, or README