### PR TITLE
feat: RAG pipeline with Qdrant and sentence-transformers on Crusoe Managed Inference

### DIFF
--- a/rag-crusoe/.gitignore
+++ b/rag-crusoe/.gitignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+*.pyc
+.DS_Store

--- a/rag-crusoe/README.md
+++ b/rag-crusoe/README.md
@@ -1,0 +1,77 @@
+# RAG × Crusoe AI
+
+A Retrieval-Augmented Generation (RAG) pipeline on [Crusoe Managed Inference](https://www.crusoe.ai/cloud/managed-inference) — semantic search with sentence-transformers and Qdrant, generation with Crusoe's MemoryAlloy-powered models.
+
+## What this does
+Documents → Embeddings → Qdrant (in-memory) → Retrieve top-k → Generate answer
+
+1. Embeds documents using `all-MiniLM-L6-v2` (sentence-transformers)
+2. Stores vectors in Qdrant (in-memory, no setup required)
+3. At query time, retrieves the top-3 most relevant chunks
+4. Passes retrieved context to Crusoe Managed Inference to generate a grounded answer
+
+## Prerequisites
+
+- Python 3.10+
+- A Crusoe Cloud account → [console.crusoecloud.com](https://console.crusoecloud.com)
+- Inference API key (Intelligence API Keys section under Security)
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+export CRUSOE_API_KEY="your-api-key"
+```
+
+## Run the example
+
+```bash
+python example.py
+```
+
+## Local testing (no Crusoe account needed)
+
+The pipeline automatically falls back to Groq if `CRUSOE_API_KEY` is not set:
+
+```bash
+pip install langchain-groq
+export GROQ_API_KEY="your-groq-key"  # free at console.groq.com
+python example.py
+```
+
+## Use your own documents
+
+Edit the `DOCUMENTS` and `QUERIES` lists in `example.py`:
+
+```python
+DOCUMENTS = [
+    "Your first document here.",
+    "Your second document here.",
+]
+
+QUERIES = [
+    "Your question here?",
+]
+```
+
+## Swap the vector store
+
+The pipeline uses Qdrant in-memory mode for zero-setup. To persist data, swap the client in `rag.py`:
+
+```python
+# In-memory (default, no setup)
+client = QdrantClient(":memory:")
+
+# Persistent local storage
+client = QdrantClient(path="./qdrant_data")
+
+# Remote Qdrant Cloud
+client = QdrantClient(url="https://your-cluster.qdrant.io", api_key="your-key")
+```
+
+## Related
+
+- [langchain-crusoe](../langchain-crusoe/) — LangChain integration for Crusoe Managed Inference
+- [langgraph-crusoe](../langgraph-crusoe/) — Multi-node agentic pipelines on Crusoe
+- [mlflow-on-crusoe](../mlflow-on-crusoe/) — Experiment tracking for Crusoe Managed Inference
+- [Crusoe Managed Inference Docs](https://docs.crusoecloud.com/managed-inference/overview)

--- a/rag-crusoe/example.py
+++ b/rag-crusoe/example.py
@@ -1,0 +1,36 @@
+"""
+Example: RAG pipeline on Crusoe Managed Inference.
+
+For production (Crusoe):
+    export CRUSOE_API_KEY="your-api-key"
+
+For local testing (Groq - free):
+    export GROQ_API_KEY="your-groq-key"
+
+Then run:
+    python example.py
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from rag import run_rag_pipeline
+
+DOCUMENTS = [
+    "Crusoe Cloud is an AI-focused cloud provider that builds and operates GPU clusters powered by clean energy.",
+    "Crusoe's MemoryAlloy technology enables cluster-wide KV cache sharing, dramatically reducing inference latency for large language models.",
+    "Crusoe Managed Inference supports leading open-source models including Llama 3.3, DeepSeek V3, Qwen3, and Gemma 3.",
+    "GPU clusters are well-suited for AI workloads because they can perform thousands of parallel floating-point operations simultaneously.",
+    "Retrieval-Augmented Generation (RAG) combines a retrieval step over a vector database with a generative language model to produce grounded answers.",
+    "Qdrant is an open-source vector database optimized for high-dimensional similarity search, commonly used in RAG pipelines.",
+    "Sentence transformers produce dense vector embeddings that capture semantic meaning, enabling similarity search across documents.",
+    "LangChain is a framework for building LLM-powered applications including chains, agents, and RAG pipelines.",
+]
+
+QUERIES = [
+    "What makes Crusoe different from other cloud providers?",
+    "How does MemoryAlloy technology improve inference?",
+    "What is RAG and why is it useful?",
+]
+
+if __name__ == "__main__":
+    run_rag_pipeline(DOCUMENTS, QUERIES)

--- a/rag-crusoe/rag.py
+++ b/rag-crusoe/rag.py
@@ -1,0 +1,97 @@
+"""
+RAG (Retrieval-Augmented Generation) pipeline on Crusoe Managed Inference.
+Uses sentence-transformers for embeddings and Qdrant (in-memory) for vector search.
+Tested locally with Groq as a drop-in replacement for Crusoe.
+"""
+import os
+from dotenv import load_dotenv
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams, PointStruct, QueryRequest
+
+load_dotenv()
+
+COLLECTION_NAME = "crusoe-rag"
+EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+EMBEDDING_DIM = 384
+
+
+def get_llm():
+    if os.getenv("CRUSOE_API_KEY"):
+        from langchain_crusoe import ChatCrusoe
+        return ChatCrusoe(
+            model="meta-llama/Llama-3.3-70B-Instruct",
+            temperature=0.2,
+            max_tokens=512,
+        )
+    else:
+        from langchain_groq import ChatGroq
+        return ChatGroq(
+            model="llama-3.3-70b-versatile",
+            temperature=0.2,
+            max_tokens=512,
+        )
+
+
+def build_vectorstore(documents: list[str]):
+    """Embed documents and store in an in-memory Qdrant collection."""
+    from sentence_transformers import SentenceTransformer
+    embedder = SentenceTransformer(EMBEDDING_MODEL)
+    client = QdrantClient(":memory:")
+
+    client.create_collection(
+        collection_name=COLLECTION_NAME,
+        vectors_config=VectorParams(size=EMBEDDING_DIM, distance=Distance.COSINE),
+    )
+
+    points = [
+        PointStruct(
+            id=i,
+            vector=embedder.encode(doc).tolist(),
+            payload={"text": doc},
+        )
+        for i, doc in enumerate(documents)
+    ]
+    client.upsert(collection_name=COLLECTION_NAME, points=points)
+    print(f"Indexed {len(documents)} documents into Qdrant.")
+    return client, embedder
+
+
+def retrieve(query: str, client: QdrantClient, embedder, top_k: int = 3) -> list[str]:
+    """Retrieve top-k most relevant document chunks for a query."""
+    query_vector = embedder.encode(query).tolist()
+    results = client.query_points(
+        collection_name=COLLECTION_NAME,
+        query=query_vector,
+        limit=top_k,
+    ).points
+    return [hit.payload["text"] for hit in results]
+
+
+def answer(query: str, client: QdrantClient, embedder) -> str:
+    """Retrieve relevant context then generate an answer with Crusoe."""
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    chunks = retrieve(query, client, embedder)
+    context = "\n\n".join(f"[{i+1}] {chunk}" for i, chunk in enumerate(chunks))
+
+    llm = get_llm()
+    response = llm.invoke([
+        SystemMessage(content=(
+            "You are a helpful assistant. Answer the question using only the provided context. "
+            "If the context does not contain enough information, say so."
+        )),
+        HumanMessage(content=f"Context:\n{context}\n\nQuestion: {query}"),
+    ])
+    return response.content
+
+
+def run_rag_pipeline(documents: list[str], queries: list[str]):
+    """Full pipeline: index documents then answer each query."""
+    print("Building vector store...")
+    client, embedder = build_vectorstore(documents)
+    print()
+
+    for query in queries:
+        print(f"Q: {query}")
+        print(f"A: {answer(query, client, embedder)}")
+        print("-" * 60)

--- a/rag-crusoe/requirements.txt
+++ b/rag-crusoe/requirements.txt
@@ -1,0 +1,6 @@
+langchain-crusoe>=0.1.0
+langchain-groq>=1.1.0
+langchain-core>=1.0.0
+qdrant-client>=1.9.0
+sentence-transformers>=3.0.0
+python-dotenv


### PR DESCRIPTION
## What this adds

A full RAG (Retrieval-Augmented Generation) pipeline running on Crusoe Managed Inference.

Pipeline:
Documents → Embeddings → Qdrant → Retrieve top-k → Generate grounded answer

## How it works

1. Embeds documents using `all-MiniLM-L6-v2` (sentence-transformers, 384-dim)
2. Stores vectors in Qdrant in-memory (zero infrastructure setup)
3. At query time, retrieves the top-3 most semantically relevant chunks
4. Passes retrieved context to Crusoe Managed Inference to generate a grounded answer

## Why it's useful

RAG is one of the most common patterns for building LLM applications. This gives teams a working, runnable starting point for building RAG on Crusoe no external services required out of the box.

The vector store is swappable in one line: in-memory → local persistent → Qdrant Cloud.

## Testing

Tested locally using Groq as a drop-in replacement. All 3 queries returned accurate, context-grounded answers.

To run on Crusoe:
    export CRUSOE_API_KEY="your-api-key"
    python example.py

## Related contributions
- #55 — LangGraph multi-node agent on Crusoe
- #56 — MLflow experiment tracking on Crusoe