### PR TITLE
grafana-cmk: include CPU-only nodes + add nodepool filter to Node tabs

### DIFF
--- a/grafana-cmk/dashboards/node-gpu-detail.json
+++ b/grafana-cmk/dashboards/node-gpu-detail.json
@@ -157,7 +157,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "DCGM_FI_DEV_GPU_UTIL{vm_name=\"$node\"}",
+          "expr": "DCGM_FI_DEV_GPU_UTIL{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
         }
@@ -252,7 +252,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "DCGM_FI_DEV_FB_USED{vm_name=\"$node\"}",
+          "expr": "DCGM_FI_DEV_FB_USED{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
         }
@@ -355,7 +355,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "DCGM_FI_DEV_GPU_TEMP{vm_name=\"$node\"}",
+          "expr": "DCGM_FI_DEV_GPU_TEMP{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
         }
@@ -450,7 +450,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "DCGM_FI_DEV_POWER_USAGE{vm_name=\"$node\"}",
+          "expr": "DCGM_FI_DEV_POWER_USAGE{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
         }
@@ -544,7 +544,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "DCGM_FI_DEV_SM_CLOCK{vm_name=\"$node\"}",
+          "expr": "DCGM_FI_DEV_SM_CLOCK{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "SM GPU {{gpu}}",
           "refId": "A"
         },
@@ -553,7 +553,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "DCGM_FI_DEV_MEM_CLOCK{vm_name=\"$node\"}",
+          "expr": "DCGM_FI_DEV_MEM_CLOCK{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "Mem GPU {{gpu}}",
           "refId": "B"
         }
@@ -635,7 +635,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "100 * (1 - avg(rate(crusoe_vm_cpu_seconds_total{vm_name=\"$node\", mode=\"idle\"}[$__rate_interval])))",
+          "expr": "100 * (1 - avg(rate(crusoe_vm_cpu_seconds_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\", mode=\"idle\"}[$__rate_interval])))",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -703,7 +703,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "100 * crusoe_vm_memory_used_bytes{vm_name=\"$node\"} / crusoe_vm_memory_total_bytes{vm_name=\"$node\"}",
+          "expr": "100 * crusoe_vm_memory_used_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"} / crusoe_vm_memory_total_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -763,7 +763,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "crusoe_vm_memory_used_bytes{vm_name=\"$node\"}",
+          "expr": "crusoe_vm_memory_used_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -823,7 +823,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "time() - crusoe_vm_boot_time{vm_name=\"$node\"}",
+          "expr": "time() - crusoe_vm_boot_time{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "",
           "refId": "A",
           "instant": true
@@ -886,7 +886,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "100 * avg by (mode) (rate(crusoe_vm_cpu_seconds_total{vm_name=\"$node\", mode!=\"idle\"}[$__rate_interval]))",
+          "expr": "100 * avg by (mode) (rate(crusoe_vm_cpu_seconds_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\", mode!=\"idle\"}[$__rate_interval]))",
           "legendFormat": "{{mode}}"
         }
       ]
@@ -947,7 +947,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "crusoe_vm_memory_used_bytes{vm_name=\"$node\"}",
+          "expr": "crusoe_vm_memory_used_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "Used"
         },
         {
@@ -955,7 +955,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "crusoe_vm_memory_total_bytes{vm_name=\"$node\"}",
+          "expr": "crusoe_vm_memory_total_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
           "legendFormat": "Total"
         }
       ]
@@ -1016,7 +1016,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_vm_disk_read_bytes_total{vm_name=\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_vm_disk_read_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
           "legendFormat": "read {{device}}"
         },
         {
@@ -1024,7 +1024,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_vm_disk_written_bytes_total{vm_name=\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_vm_disk_written_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
           "legendFormat": "write {{device}}"
         }
       ]
@@ -1085,7 +1085,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_vm_disk_reads_completed_total{vm_name=\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_vm_disk_reads_completed_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
           "legendFormat": "read {{device}}"
         },
         {
@@ -1093,7 +1093,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_vm_disk_writes_completed_total{vm_name=\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_vm_disk_writes_completed_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
           "legendFormat": "write {{device}}"
         }
       ]
@@ -1109,26 +1109,54 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "crusoe-metrics"
         },
-        "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, vm_name)",
+        "definition": "label_values(crusoe_vm_cpu_seconds_total, nodepool_name)",
         "hide": 0,
-        "includeAll": false,
-        "label": "Node",
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Nodepool",
         "multi": false,
-        "name": "node",
+        "name": "nodepool",
         "options": [],
         "query": {
-          "query": "label_values(DCGM_FI_DEV_GPU_UTIL, vm_name)",
+          "query": "label_values(crusoe_vm_cpu_seconds_total, nodepool_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "",
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "definition": "label_values(crusoe_vm_cpu_seconds_total{nodepool_name=~\"$nodepool\"}, vm_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Node",
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(crusoe_vm_cpu_seconds_total{nodepool_name=~\"$nodepool\"}, vm_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "allValue": ".+"
       }
     ]
   },

--- a/grafana-cmk/dashboards/node-network-detail.json
+++ b/grafana-cmk/dashboards/node-network-detail.json
@@ -54,6 +54,33 @@
         "skipUrlSync": false
       },
       {
+        "current": {
+          "text": "All",
+          "value": "$__all",
+          "selected": true
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "crusoe-metrics"
+        },
+        "definition": "label_values(crusoe_vm_network_receive_bytes_total, nodepool_name)",
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Nodepool",
+        "multi": false,
+        "name": "nodepool",
+        "options": [],
+        "query": {
+          "query": "label_values(crusoe_vm_network_receive_bytes_total, nodepool_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "name": "node",
         "label": "Node",
         "type": "query",
@@ -62,10 +89,10 @@
           "uid": "crusoe-metrics"
         },
         "query": {
-          "query": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}, vm_name)",
+          "query": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\", nodepool_name=~\"$nodepool\"}, vm_name)",
           "refId": "B"
         },
-        "definition": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}, vm_name)",
+        "definition": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\", nodepool_name=~\"$nodepool\"}, vm_name)",
         "includeAll": true,
         "multi": true,
         "allValue": ".+",
@@ -136,7 +163,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval]))",
+          "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]))",
           "legendFormat": ""
         }
       ]
@@ -193,7 +220,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval]))",
+          "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]))",
           "legendFormat": ""
         }
       ]
@@ -250,7 +277,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"})",
+          "expr": "sum(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"})",
           "legendFormat": ""
         }
       ]
@@ -307,7 +334,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "sum(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"})",
+          "expr": "sum(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"})",
           "legendFormat": ""
         }
       ]
@@ -368,7 +395,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
           "legendFormat": "{{vm_name}} ({{device}})"
         }
       ]
@@ -429,7 +456,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
           "legendFormat": "{{vm_name}} ({{device}})"
         }
       ]
@@ -490,7 +517,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
           "legendFormat": "RX {{vm_name}}"
         },
         {
@@ -498,7 +525,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
           "legendFormat": "TX {{vm_name}}"
         }
       ]
@@ -559,7 +586,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "increase(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[1h])",
+          "expr": "increase(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[1h])",
           "legendFormat": "{{vm_name}}"
         }
       ]
@@ -620,7 +647,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "increase(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[1h])",
+          "expr": "increase(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[1h])",
           "legendFormat": "{{vm_name}}"
         }
       ]
@@ -677,7 +704,7 @@
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
-          "expr": "topk(50, sort_desc(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])))",
+          "expr": "topk(50, sort_desc(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])))",
           "format": "table",
           "instant": true
         }

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -6473,7 +6473,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  node-gpu-detail.json: |-
+  node-gpu-detail.json: |
     {
       "__inputs": [
         {
@@ -6633,7 +6633,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "DCGM_FI_DEV_GPU_UTIL{vm_name=\"$node\"}",
+              "expr": "DCGM_FI_DEV_GPU_UTIL{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "GPU {{gpu}}",
               "refId": "A"
             }
@@ -6728,7 +6728,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "DCGM_FI_DEV_FB_USED{vm_name=\"$node\"}",
+              "expr": "DCGM_FI_DEV_FB_USED{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "GPU {{gpu}}",
               "refId": "A"
             }
@@ -6831,7 +6831,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "DCGM_FI_DEV_GPU_TEMP{vm_name=\"$node\"}",
+              "expr": "DCGM_FI_DEV_GPU_TEMP{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "GPU {{gpu}}",
               "refId": "A"
             }
@@ -6926,7 +6926,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "DCGM_FI_DEV_POWER_USAGE{vm_name=\"$node\"}",
+              "expr": "DCGM_FI_DEV_POWER_USAGE{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "GPU {{gpu}}",
               "refId": "A"
             }
@@ -7020,7 +7020,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "DCGM_FI_DEV_SM_CLOCK{vm_name=\"$node\"}",
+              "expr": "DCGM_FI_DEV_SM_CLOCK{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "SM GPU {{gpu}}",
               "refId": "A"
             },
@@ -7029,7 +7029,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "DCGM_FI_DEV_MEM_CLOCK{vm_name=\"$node\"}",
+              "expr": "DCGM_FI_DEV_MEM_CLOCK{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "Mem GPU {{gpu}}",
               "refId": "B"
             }
@@ -7111,7 +7111,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "100 * (1 - avg(rate(crusoe_vm_cpu_seconds_total{vm_name=\"$node\", mode=\"idle\"}[$__rate_interval])))",
+              "expr": "100 * (1 - avg(rate(crusoe_vm_cpu_seconds_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\", mode=\"idle\"}[$__rate_interval])))",
               "legendFormat": "",
               "refId": "A",
               "instant": true
@@ -7179,7 +7179,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "100 * crusoe_vm_memory_used_bytes{vm_name=\"$node\"} / crusoe_vm_memory_total_bytes{vm_name=\"$node\"}",
+              "expr": "100 * crusoe_vm_memory_used_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"} / crusoe_vm_memory_total_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "",
               "refId": "A",
               "instant": true
@@ -7239,7 +7239,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "crusoe_vm_memory_used_bytes{vm_name=\"$node\"}",
+              "expr": "crusoe_vm_memory_used_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "",
               "refId": "A",
               "instant": true
@@ -7299,7 +7299,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "time() - crusoe_vm_boot_time{vm_name=\"$node\"}",
+              "expr": "time() - crusoe_vm_boot_time{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "",
               "refId": "A",
               "instant": true
@@ -7362,7 +7362,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "100 * avg by (mode) (rate(crusoe_vm_cpu_seconds_total{vm_name=\"$node\", mode!=\"idle\"}[$__rate_interval]))",
+              "expr": "100 * avg by (mode) (rate(crusoe_vm_cpu_seconds_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\", mode!=\"idle\"}[$__rate_interval]))",
               "legendFormat": "{{mode}}"
             }
           ]
@@ -7423,7 +7423,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "crusoe_vm_memory_used_bytes{vm_name=\"$node\"}",
+              "expr": "crusoe_vm_memory_used_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "Used"
             },
             {
@@ -7431,7 +7431,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "crusoe_vm_memory_total_bytes{vm_name=\"$node\"}",
+              "expr": "crusoe_vm_memory_total_bytes{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}",
               "legendFormat": "Total"
             }
           ]
@@ -7492,7 +7492,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_vm_disk_read_bytes_total{vm_name=\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_vm_disk_read_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
               "legendFormat": "read {{device}}"
             },
             {
@@ -7500,7 +7500,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_vm_disk_written_bytes_total{vm_name=\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_vm_disk_written_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
               "legendFormat": "write {{device}}"
             }
           ]
@@ -7561,7 +7561,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_vm_disk_reads_completed_total{vm_name=\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_vm_disk_reads_completed_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
               "legendFormat": "read {{device}}"
             },
             {
@@ -7569,7 +7569,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_vm_disk_writes_completed_total{vm_name=\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_vm_disk_writes_completed_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
               "legendFormat": "write {{device}}"
             }
           ]
@@ -7585,26 +7585,54 @@ data:
       "templating": {
         "list": [
           {
-            "current": {},
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            },
             "datasource": {
               "type": "prometheus",
               "uid": "crusoe-metrics"
             },
-            "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, vm_name)",
+            "definition": "label_values(crusoe_vm_cpu_seconds_total, nodepool_name)",
             "hide": 0,
-            "includeAll": false,
-            "label": "Node",
+            "includeAll": true,
+            "allValue": ".*",
+            "label": "Nodepool",
             "multi": false,
-            "name": "node",
+            "name": "nodepool",
             "options": [],
             "query": {
-              "query": "label_values(DCGM_FI_DEV_GPU_UTIL, vm_name)",
+              "query": "label_values(crusoe_vm_cpu_seconds_total, nodepool_name)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,
             "regex": "",
             "sort": 1,
             "type": "query"
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
+            "definition": "label_values(crusoe_vm_cpu_seconds_total{nodepool_name=~\"$nodepool\"}, vm_name)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Node",
+            "multi": true,
+            "name": "node",
+            "options": [],
+            "query": {
+              "query": "label_values(crusoe_vm_cpu_seconds_total{nodepool_name=~\"$nodepool\"}, vm_name)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query",
+            "allValue": ".+"
           }
         ]
       },
@@ -8367,7 +8395,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  node-network-detail.json: |-
+  node-network-detail.json: |
     {
       "uid": "crusoe-node-network-detail",
       "title": "Node Network Detail",
@@ -8424,6 +8452,33 @@ data:
             "skipUrlSync": false
           },
           {
+            "current": {
+              "text": "All",
+              "value": "$__all",
+              "selected": true
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "crusoe-metrics"
+            },
+            "definition": "label_values(crusoe_vm_network_receive_bytes_total, nodepool_name)",
+            "hide": 0,
+            "includeAll": true,
+            "allValue": ".*",
+            "label": "Nodepool",
+            "multi": false,
+            "name": "nodepool",
+            "options": [],
+            "query": {
+              "query": "label_values(crusoe_vm_network_receive_bytes_total, nodepool_name)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
             "name": "node",
             "label": "Node",
             "type": "query",
@@ -8432,10 +8487,10 @@ data:
               "uid": "crusoe-metrics"
             },
             "query": {
-              "query": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}, vm_name)",
+              "query": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\", nodepool_name=~\"$nodepool\"}, vm_name)",
               "refId": "B"
             },
-            "definition": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\"}, vm_name)",
+            "definition": "label_values(crusoe_vm_network_receive_bytes_total{cluster_id=~\"$cluster\", nodepool_name=~\"$nodepool\"}, vm_name)",
             "includeAll": true,
             "multi": true,
             "allValue": ".+",
@@ -8506,7 +8561,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval]))",
+              "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]))",
               "legendFormat": ""
             }
           ]
@@ -8563,7 +8618,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval]))",
+              "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]))",
               "legendFormat": ""
             }
           ]
@@ -8620,7 +8675,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"})",
+              "expr": "sum(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"})",
               "legendFormat": ""
             }
           ]
@@ -8677,7 +8732,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "sum(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"})",
+              "expr": "sum(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"})",
               "legendFormat": ""
             }
           ]
@@ -8738,7 +8793,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
               "legendFormat": "{{vm_name}} ({{device}})"
             }
           ]
@@ -8799,7 +8854,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
               "legendFormat": "{{vm_name}} ({{device}})"
             }
           ]
@@ -8860,7 +8915,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
               "legendFormat": "RX {{vm_name}}"
             },
             {
@@ -8868,7 +8923,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])",
+              "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
               "legendFormat": "TX {{vm_name}}"
             }
           ]
@@ -8929,7 +8984,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "increase(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[1h])",
+              "expr": "increase(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[1h])",
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -8990,7 +9045,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "increase(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[1h])",
+              "expr": "increase(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[1h])",
               "legendFormat": "{{vm_name}}"
             }
           ]
@@ -9047,7 +9102,7 @@ data:
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
-              "expr": "topk(50, sort_desc(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\"}[$__rate_interval])))",
+              "expr": "topk(50, sort_desc(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]) + rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])))",
               "format": "table",
               "instant": true
             }


### PR DESCRIPTION
The Node Detail and Node Network Detail dashboards sourced their $node
dropdowns from GPU-only / cluster-filtered metric queries, so CPU-only
pools (S2a, storage-pull, etc.) never appeared in the picker even though
every non-GPU panel's data was flowing.

  Node Detail:          $node query  DCGM_FI_DEV_GPU_UTIL -> crusoe_vm_cpu_seconds_total
  Node Network Detail:  $node query  unchanged metric, now also filters by $nodepool

Adds a $nodepool dropdown (default All) to both dashboards. Picking a
single pool narrows the $node list and gives a clean GPU-vs-CPU
side-by-side comparison.

Makes the Node Detail $node dropdown multi-select with an All option,
so you can chart every node in a pool at once. All 17 panel queries
flipped from `vm_name="$node"` to `vm_name=~"$node"` so the regex
interpolation works when multiple nodes (or All) are picked.

Threads `nodepool_name=~"$nodepool"` into every panel query (28 total
across both dashboards). Without this the dropdown filter only narrows
the $node list -- panels still match every VM via the `.+` allValue,
leaking data from other pools into "aggregate" views.

The $nodepool allValue is `.*` (not `.+`) so VMs without a nodepool_name
label (e.g. the data-transfer VM) remain visible when All is picked.

GPU-specific panels (Per-GPU Util / Temp / Power / Clock) render "No data"
when a CPU node is selected -- by design, no panel hiding.
