### PR TITLE
grafana-cmk: storage fill table + node CPU outlier chart + per-direction NW panels

### DIFF
--- a/grafana-cmk/dashboards/node-gpu-detail.json
+++ b/grafana-cmk/dashboards/node-gpu-detail.json
@@ -1097,6 +1097,72 @@
           "legendFormat": "write {{device}}"
         }
       ]
+    },
+    {
+      "id": 15,
+      "title": "Per-Node CPU Utilization Over Time",
+      "description": "One line per node in the current $nodepool / $node selection, showing CPU utilization % over time. Useful for spotting outliers and persistent high-CPU nodes within a pool.",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 49,
+        "w": 24,
+        "h": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "interval": "1m",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "100 * (1 - avg by (vm_name) (rate(crusoe_vm_cpu_seconds_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\", mode=\"idle\"}[$__rate_interval])))",
+          "legendFormat": "{{vm_name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "pluginVersion": "12.3.1"
     }
   ],
   "refresh": "1m",

--- a/grafana-cmk/dashboards/node-network-detail.json
+++ b/grafana-cmk/dashboards/node-network-detail.json
@@ -531,6 +531,130 @@
       ]
     },
     {
+      "id": 11,
+      "type": "timeseries",
+      "title": "RX Combined by Node (stacked) \u2014 inbound only",
+      "description": "Aggregate inbound traffic across all nodes in the $nodepool / $node selection, stacked per node. Top of the stack = cluster-wide RX. Answers 'how many bytes are coming in?' without TX traffic mixed in.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "TX Combined by Node (stacked) \u2014 outbound only",
+      "description": "Aggregate outbound traffic across all nodes in the $nodepool / $node selection, stacked per node. Top of the stack = cluster-wide TX. Answers 'how many bytes are going out?' (e.g., writes to remote storage) without RX traffic mixed in.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 31,
+        "w": 24,
+        "h": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "lineInterpolation": "linear",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
+          "legendFormat": "{{vm_name}}"
+        }
+      ]
+    },
+    {
       "id": 8,
       "type": "timeseries",
       "title": "RX bytes increase (last 1h)",
@@ -541,7 +665,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 22,
+        "y": 40,
         "w": 12,
         "h": 8
       },
@@ -602,7 +726,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 22,
+        "y": 40,
         "w": 12,
         "h": 8
       },
@@ -663,7 +787,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 30,
+        "y": 48,
         "w": 24,
         "h": 10
       },

--- a/grafana-cmk/dashboards/storage-cluster-overview.json
+++ b/grafana-cmk/dashboards/storage-cluster-overview.json
@@ -343,45 +343,240 @@
     },
     {
       "id": 7,
-      "type": "bargauge",
-      "title": "Per-Disk Capacity Used (all disks)",
-      "description": "Per-disk capacity used. Unfiltered \u2014 every SDisk in this project is listed regardless of dropdown selection. Legend shows `disk_id` (Crusoe Console) and `disk_name` (K8s PVC UID) so you can map between them.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "crusoe-metrics"
-      },
+      "title": "Per-Disk Capacity (used / provisioned)",
+      "description": "All Crusoe SDisks in the project. Used = crusoe_sdisk_disk_capacity_used_bytes. Provisioned + % Used are joined from kube_persistentvolume_capacity_bytes via the PV's csi.volumeHandle (CSI-mounted disks only \u2014 NFS-mounted SDisks have their disk_id in spec.nfs.path which kube-state-metrics doesn't expose as a label, so those rows show '\u2014' for Provisioned and % Used).",
+      "type": "table",
       "gridPos": {
         "x": 0,
         "y": 4,
         "w": 24,
         "h": 10
       },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "orientation": "horizontal",
-        "displayMode": "gradient",
-        "showUnfilled": true
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes"
-        }
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
       },
       "targets": [
         {
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "crusoe-metrics"
           },
           "expr": "last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m])",
+          "format": "table",
           "instant": true,
-          "legendFormat": "{{disk_id}}  ({{disk_name}})"
+          "legendFormat": "Used"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "max by (disk_id) (label_replace(last_over_time(kube_persistentvolume_capacity_bytes[2m]) * on(persistentvolume) group_left(csi_volume_handle) last_over_time(kube_persistentvolume_info[2m]), \"disk_id\", \"$1\", \"csi_volume_handle\", \"(.*)\") and on(disk_id) last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "Provisioned"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "100 * (last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m]) / on(disk_id) group_left max by (disk_id) (label_replace(last_over_time(kube_persistentvolume_capacity_bytes[2m]) * on(persistentvolume) group_left(csi_volume_handle) last_over_time(kube_persistentvolume_info[2m]), \"disk_id\", \"$1\", \"csi_volume_handle\", \"(.*)\") and on(disk_id) last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m])))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "% Used"
         }
-      ]
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "disk_id",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "fieldName": "disk_id",
+                "config": {
+                  "id": "isNotNull",
+                  "options": {}
+                }
+              }
+            ],
+            "type": "include",
+            "match": "all"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "tenant_name": true,
+              "location": true,
+              "cluster_id": true,
+              "crusoe_resource": true,
+              "metrics_source": true,
+              "project_id": true,
+              "persistentvolume": true,
+              "csi_volume_handle": true
+            },
+            "indexByName": {
+              "disk_id": 0,
+              "disk_name": 1,
+              "Value #A": 2,
+              "Value #B": 3,
+              "Value #C": 4
+            },
+            "renameByName": {
+              "disk_id": "Disk ID",
+              "disk_name": "Disk Name",
+              "Value #A": "Used",
+              "Value #B": "Provisioned",
+              "Value #C": "% Used"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Provisioned"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "noValue",
+                "value": "\u2014"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "% Used"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "noValue",
+                "value": "\u2014"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "basic"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 80
+                    },
+                    {
+                      "color": "red",
+                      "value": 90
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        },
+        "cellHeight": "sm",
+        "sortBy": [
+          {
+            "displayName": "% Used",
+            "desc": true
+          },
+          {
+            "displayName": "Used",
+            "desc": true
+          }
+        ]
+      },
+      "pluginVersion": "12.3.1"
     },
     {
       "id": 8,

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -7573,6 +7573,72 @@ data:
               "legendFormat": "write {{device}}"
             }
           ]
+        },
+        {
+          "id": 15,
+          "title": "Per-Node CPU Utilization Over Time",
+          "description": "One line per node in the current $nodepool / $node selection, showing CPU utilization % over time. Useful for spotting outliers and persistent high-CPU nodes within a pool.",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 0,
+            "y": 49,
+            "w": 24,
+            "h": 12
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "interval": "1m",
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "100 * (1 - avg by (vm_name) (rate(crusoe_vm_cpu_seconds_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\", mode=\"idle\"}[$__rate_interval])))",
+              "legendFormat": "{{vm_name}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 0,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "none"
+                }
+              },
+              "min": 0,
+              "max": 100
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "pluginVersion": "12.3.1"
         }
       ],
       "refresh": "1m",
@@ -8929,6 +8995,130 @@ data:
           ]
         },
         {
+          "id": 11,
+          "type": "timeseries",
+          "title": "RX Combined by Node (stacked) \u2014 inbound only",
+          "description": "Aggregate inbound traffic across all nodes in the $nodepool / $node selection, stacked per node. Top of the stack = cluster-wide RX. Answers 'how many bytes are coming in?' without TX traffic mixed in.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 22,
+            "w": 24,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 30,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "normal"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
+          "id": 12,
+          "type": "timeseries",
+          "title": "TX Combined by Node (stacked) \u2014 outbound only",
+          "description": "Aggregate outbound traffic across all nodes in the $nodepool / $node selection, stacked per node. Top of the stack = cluster-wide TX. Answers 'how many bytes are going out?' (e.g., writes to remote storage) without RX traffic mixed in.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 31,
+            "w": 24,
+            "h": 9
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 30,
+                "lineInterpolation": "linear",
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "mode": "normal"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval])",
+              "legendFormat": "{{vm_name}}"
+            }
+          ]
+        },
+        {
           "id": 8,
           "type": "timeseries",
           "title": "RX bytes increase (last 1h)",
@@ -8939,7 +9129,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 22,
+            "y": 40,
             "w": 12,
             "h": 8
           },
@@ -9000,7 +9190,7 @@ data:
           },
           "gridPos": {
             "x": 12,
-            "y": 22,
+            "y": 40,
             "w": 12,
             "h": 8
           },
@@ -9061,7 +9251,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 30,
+            "y": 48,
             "w": 24,
             "h": 10
           },
@@ -10465,7 +10655,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  storage-cluster-overview.json: |-
+  storage-cluster-overview.json: |
     {
       "uid": "crusoe-storage-cluster",
       "title": "Shared Storage View",
@@ -10811,45 +11001,240 @@ data:
         },
         {
           "id": 7,
-          "type": "bargauge",
-          "title": "Per-Disk Capacity Used (all disks)",
-          "description": "Per-disk capacity used. Unfiltered \u2014 every SDisk in this project is listed regardless of dropdown selection. Legend shows `disk_id` (Crusoe Console) and `disk_name` (K8s PVC UID) so you can map between them.",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "crusoe-metrics"
-          },
+          "title": "Per-Disk Capacity (used / provisioned)",
+          "description": "All Crusoe SDisks in the project. Used = crusoe_sdisk_disk_capacity_used_bytes. Provisioned + % Used are joined from kube_persistentvolume_capacity_bytes via the PV's csi.volumeHandle (CSI-mounted disks only \u2014 NFS-mounted SDisks have their disk_id in spec.nfs.path which kube-state-metrics doesn't expose as a label, so those rows show '\u2014' for Provisioned and % Used).",
+          "type": "table",
           "gridPos": {
             "x": 0,
             "y": 4,
             "w": 24,
             "h": 10
           },
-          "options": {
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ]
-            },
-            "orientation": "horizontal",
-            "displayMode": "gradient",
-            "showUnfilled": true
-          },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "bytes"
-            }
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
           },
           "targets": [
             {
+              "refId": "A",
               "datasource": {
                 "type": "prometheus",
                 "uid": "crusoe-metrics"
               },
               "expr": "last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m])",
+              "format": "table",
               "instant": true,
-              "legendFormat": "{{disk_id}}  ({{disk_name}})"
+              "legendFormat": "Used"
+            },
+            {
+              "refId": "B",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "max by (disk_id) (label_replace(last_over_time(kube_persistentvolume_capacity_bytes[2m]) * on(persistentvolume) group_left(csi_volume_handle) last_over_time(kube_persistentvolume_info[2m]), \"disk_id\", \"$1\", \"csi_volume_handle\", \"(.*)\") and on(disk_id) last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m]))",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "Provisioned"
+            },
+            {
+              "refId": "C",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "100 * (last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m]) / on(disk_id) group_left max by (disk_id) (label_replace(last_over_time(kube_persistentvolume_capacity_bytes[2m]) * on(persistentvolume) group_left(csi_volume_handle) last_over_time(kube_persistentvolume_info[2m]), \"disk_id\", \"$1\", \"csi_volume_handle\", \"(.*)\") and on(disk_id) last_over_time(crusoe_sdisk_disk_capacity_used_bytes[2m])))",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "% Used"
             }
-          ]
+          ],
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "disk_id",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "filterByValue",
+              "options": {
+                "filters": [
+                  {
+                    "fieldName": "disk_id",
+                    "config": {
+                      "id": "isNotNull",
+                      "options": {}
+                    }
+                  }
+                ],
+                "type": "include",
+                "match": "all"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time 1": true,
+                  "Time 2": true,
+                  "Time 3": true,
+                  "__name__ 1": true,
+                  "__name__ 2": true,
+                  "__name__ 3": true,
+                  "tenant_name": true,
+                  "location": true,
+                  "cluster_id": true,
+                  "crusoe_resource": true,
+                  "metrics_source": true,
+                  "project_id": true,
+                  "persistentvolume": true,
+                  "csi_volume_handle": true
+                },
+                "indexByName": {
+                  "disk_id": 0,
+                  "disk_name": 1,
+                  "Value #A": 2,
+                  "Value #B": 3,
+                  "Value #C": 4
+                },
+                "renameByName": {
+                  "disk_id": "Disk ID",
+                  "disk_name": "Disk Name",
+                  "Value #A": "Used",
+                  "Value #B": "Provisioned",
+                  "Value #C": "% Used"
+                }
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text"
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Used"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provisioned"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "\u2014"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% Used"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 1
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 100
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "\u2014"
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "gauge",
+                      "mode": "basic"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 80
+                        },
+                        {
+                          "color": "red",
+                          "value": 90
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "showHeader": true,
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "fields": ""
+            },
+            "cellHeight": "sm",
+            "sortBy": [
+              {
+                "displayName": "% Used",
+                "desc": true
+              },
+              {
+                "displayName": "Used",
+                "desc": true
+              }
+            ]
+          },
+          "pluginVersion": "12.3.1"
         },
         {
           "id": 8,


### PR DESCRIPTION
## Summary

Three dashboard improvements driven by operator-asked questions:

**Shared Storage View** — replace the existing `Per-Disk Capacity Used` bar gauge with a per-disk fill table.
- Joins `crusoe_sdisk_disk_capacity_used_bytes` (Used) to `kube_persistentvolume_capacity_bytes` (Provisioned) via `kube_persistentvolume_info.csi_volume_handle == Crusoe disk_id`.
- Columns: Disk ID, Disk Name, Used, Provisioned, % Used. The `% Used` cell renders as an embedded horizontal gauge bar with thresholds **green < 80, yellow 80-90, red ≥ 90**. Sorted by % Used desc, then Used desc.
- `and on(disk_id) crusoe_sdisk_*` keeps the table SDisk-driven (no ghost rows for k8s-only PVs).
- Limitation documented in the panel description: NFS-mounted Crusoe SDisks (`spec.nfs.path: /volumes/<disk_id>`) show `—` for Provisioned and % Used because kube-state-metrics doesn't expose the NFS path as a label. Fixing this needs a metric-pipeline change (e.g., a vmagent relabel rule), out of scope here.

**Node Details** — new `Per-Node CPU Utilization Over Time` time-series at the bottom.
- One line per node in the current `$nodepool` / `$node` selection.
- Useful for spotting persistently-busy nodes within a pool.
- Stacking explicitly disabled (otherwise per-node lines would add together and the y-axis would overflow 100%), thicker lines, no fill, per-node legend, y bounded 0-100%.

**Node Network Detail** — two new full-width stacked time-series below the existing `RX + TX Combined by Node`:
- `RX Combined by Node (stacked) — inbound only` answers *"how many bytes are coming in?"*
- `TX Combined by Node (stacked) — outbound only` answers *"how many bytes are going out?"*
- Existing panels below shift down to make room.

## Test plan

- [x] All three dashboards reload via k8s-sidecar with no JSON parse errors
- [x] Storage table: only Crusoe SDisks listed; CSI-bound disks populate Used / Provisioned / % Used; NFS-mounted disks populate Used and show `—` for the others
- [x] % Used cell renders as a colored gauge bar with the correct thresholds
- [x] Node Details CPU chart: per-node lines do not exceed 100%; line max equals legend Max (confirms stacking is off)
- [x] Node Network: RX-only and TX-only panels populate and respect `$nodepool` / `$node`
- [x] Existing panels still work and weren't shifted out of view