### PR TITLE
grafana-cmk: Node Network Detail — Peak RX / Peak TX (in range) stats

### DIFF
--- a/grafana-cmk/dashboards/node-network-detail.json
+++ b/grafana-cmk/dashboards/node-network-detail.json
@@ -340,6 +340,120 @@
       ]
     },
     {
+      "id": 13,
+      "type": "stat",
+      "title": "Peak RX (in range)",
+      "description": "Highest cluster-wide RX rate observed across the dashboard's time range (max over time of the per-second sum across selected nodes). Useful for spotting when data-transfer peaked.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 12,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]))",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Peak TX (in range)",
+      "description": "Highest cluster-wide TX rate observed across the dashboard's time range (max over time of the per-second sum across selected nodes). Useful for spotting when egress peaked.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crusoe-metrics"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 4,
+        "w": 12,
+        "h": 4
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]))",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
       "id": 5,
       "type": "timeseries",
       "title": "RX by Node",
@@ -350,7 +464,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 4,
+        "y": 8,
         "w": 12,
         "h": 9
       },
@@ -411,7 +525,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 4,
+        "y": 8,
         "w": 12,
         "h": 9
       },
@@ -472,7 +586,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 13,
+        "y": 17,
         "w": 24,
         "h": 9
       },
@@ -541,7 +655,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 22,
+        "y": 26,
         "w": 24,
         "h": 9
       },
@@ -603,7 +717,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 31,
+        "y": 35,
         "w": 24,
         "h": 9
       },
@@ -665,7 +779,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 40,
+        "y": 44,
         "w": 12,
         "h": 8
       },
@@ -726,7 +840,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 40,
+        "y": 44,
         "w": 12,
         "h": 8
       },
@@ -787,7 +901,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 48,
+        "y": 52,
         "w": 24,
         "h": 10
       },

--- a/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
+++ b/grafana-cmk/manifests/grafana-dashboards-configmap.yaml
@@ -8804,6 +8804,120 @@ data:
           ]
         },
         {
+          "id": 13,
+          "type": "stat",
+          "title": "Peak RX (in range)",
+          "description": "Highest cluster-wide RX rate observed across the dashboard's time range (max over time of the per-second sum across selected nodes). Useful for spotting when data-transfer peaked.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 4,
+            "w": 12,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "max"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_network_receive_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]))",
+              "legendFormat": ""
+            }
+          ]
+        },
+        {
+          "id": 14,
+          "type": "stat",
+          "title": "Peak TX (in range)",
+          "description": "Highest cluster-wide TX rate observed across the dashboard's time range (max over time of the per-second sum across selected nodes). Useful for spotting when egress peaked.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crusoe-metrics"
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 4,
+            "w": 12,
+            "h": 4
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "max"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "crusoe-metrics"
+              },
+              "expr": "sum(rate(crusoe_vm_network_transmit_bytes_total{vm_name=~\"$node\", nodepool_name=~\"$nodepool\"}[$__rate_interval]))",
+              "legendFormat": ""
+            }
+          ]
+        },
+        {
           "id": 5,
           "type": "timeseries",
           "title": "RX by Node",
@@ -8814,7 +8928,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 4,
+            "y": 8,
             "w": 12,
             "h": 9
           },
@@ -8875,7 +8989,7 @@ data:
           },
           "gridPos": {
             "x": 12,
-            "y": 4,
+            "y": 8,
             "w": 12,
             "h": 9
           },
@@ -8936,7 +9050,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 13,
+            "y": 17,
             "w": 24,
             "h": 9
           },
@@ -9005,7 +9119,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 22,
+            "y": 26,
             "w": 24,
             "h": 9
           },
@@ -9067,7 +9181,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 31,
+            "y": 35,
             "w": 24,
             "h": 9
           },
@@ -9129,7 +9243,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 40,
+            "y": 44,
             "w": 12,
             "h": 8
           },
@@ -9190,7 +9304,7 @@ data:
           },
           "gridPos": {
             "x": 12,
-            "y": 40,
+            "y": 44,
             "w": 12,
             "h": 8
           },
@@ -9251,7 +9365,7 @@ data:
           },
           "gridPos": {
             "x": 0,
-            "y": 48,
+            "y": 52,
             "w": 24,
             "h": 10
           },


### PR DESCRIPTION
## Summary

Adds two stat tiles to the **Node Network Detail** dashboard's top section, below the existing Current / Lifetime row:
- **Peak RX (in range)** — highest cluster-wide RX rate over the dashboard's selected time range
- **Peak TX (in range)** — same for TX

Same query as the existing Selected RX/TX (current) stats, but with the stat reducer set to `max` instead of `lastNotNull`, so the value reflects the peak across the displayed time range. Both respect the existing `$nodepool` / `$node` filters.

Existing panels below shift down by 4 to make room.

## Why

Answers the operator question "where are we peaking in terms of data transfer?" without having to eyeball the time-series charts. Combined with the existing Lifetime counters and the RX-only / TX-only stacked panels below, the top of the dashboard now covers: current, peak, and lifetime — at a glance.

## Test plan

- [x] Dashboard reloads via k8s-sidecar with no JSON parse errors
- [x] Peak RX / Peak TX stats display a sane Bps value reflecting the highest sustained rate in the range
- [x] Stats respect `$nodepool` and `$node` filters
- [x] Existing panels (RX/TX by Node, RX+TX Combined, RX-only / TX-only stacked, bytes-increase, Per-Node Bandwidth Table) still render and weren't shifted out of view