### PR TITLE
Add cmk-data-transfer: parallel S3-to-VAST shared-disk pull on CMK

### DIFF
--- a/cmk-data-transfer/.env.example
+++ b/cmk-data-transfer/.env.example
@@ -32,7 +32,11 @@ OCI_ENDPOINT=
 PVC_NAME=cmk-data-transfer-fs
 PVC_SIZE=1000Ti
 STORAGE_CLASS=crusoe-csi-driver-fs-sc
-DEST_PATH=/data/dataset          # mount-relative path workers write into
+# DEST_PATH = WHERE objects are saved on the disk. The disk mounts at /data in
+# every pod, so this is the folder under it (e.g. /data/my-dataset). For an
+# existing disk (DEST_MODE=import/nfs), point it at where on that disk you want
+# the files; rclone copy is idempotent, so an existing partial folder is fine.
+DEST_PATH=/data/dataset
 
 # --- Destination mode: dynamic | import | nfs ---
 #   dynamic : provision a new shared disk via the fs CSI driver (default).

--- a/cmk-data-transfer/.env.example
+++ b/cmk-data-transfer/.env.example
@@ -72,6 +72,12 @@ PODS_PER_NODE=8                   # workers per node (spread evenly). More pods 
 NUM_PODS=                         # absolute total override; default = NODES*PER_NODE
 INSTANCE_CLASS=s2a
 
+# Node hardware (defaults = s2a.80x). Set for other SKUs/clouds so the sizing
+# model uses the right CPU split, NIC line rate, and BDP.
+NODE_VCPU=80
+NODE_RAM_GIB=676
+NODE_NIC_GBPS=200
+
 # Path RTT (ms) source<->destination region. Drives the BDP / concurrency math.
 RTT_MS=150
 # Conservative per-stream throughput assumption (Mbps) for an untuned

--- a/cmk-data-transfer/.env.example
+++ b/cmk-data-transfer/.env.example
@@ -1,0 +1,106 @@
+# ============================================================================
+# cmk-data-transfer — configuration
+# Copy to .env and fill in.  .env is git-ignored; never commit real creds.
+#   cp .env.example .env
+# ============================================================================
+
+# --- OCI Object Storage credentials (S3-compatible "Customer Secret Key") ---
+# Create under: OCI Console > Profile > Customer Secret Keys.
+# These are the S3-compat access/secret pair, NOT your OCI API signing key.
+OCI_ACCESS_KEY_ID=
+OCI_SECRET_ACCESS_KEY=
+
+# --- OCI Object Storage location ---
+# NAMESPACE is the Object Storage namespace (Console > Tenancy details, or
+#   `oci os ns get`). REQUIRED to build the S3-compat endpoint.
+OCI_NAMESPACE=
+
+# REGION is the OCI region slug where the BUCKET lives, e.g. us-phoenix-1 /
+# us-ashburn-1. Must be a valid OCI region (not your destination/cloud region);
+# preflight warns if the slug doesn't look like OCI.
+OCI_REGION=us-phoenix-1
+
+# Source bucket and optional prefix (no leading slash on prefix).
+OCI_BUCKET=
+OCI_PREFIX=
+
+# Derived endpoint (leave blank to auto-build from NAMESPACE+REGION):
+#   https://<NAMESPACE>.compat.objectstorage.<REGION>.oraclecloud.com
+OCI_ENDPOINT=
+
+# --- Destination (VAST RWX shared disk) ---
+PVC_NAME=cmk-data-transfer-fs
+PVC_SIZE=1000Ti
+STORAGE_CLASS=crusoe-csi-driver-fs-sc
+DEST_PATH=/data/dataset          # mount-relative path workers write into
+
+# --- Destination mode: dynamic | import | nfs ---
+#   dynamic : provision a new shared disk via the fs CSI driver (default).
+#   import  : bind an EXISTING disk via a CSI static PV (id+name+serial below).
+#   nfs     : bind an EXISTING disk via an in-tree NFS PV straight to the VAST
+#             DNS endpoint, bypassing the CSI driver. Use this where CSI mounts
+#             time out on an unroutable fallback IP (disk returns no data-path
+#             connectivity fields). Needs only EXISTING_DISK_ID.
+DEST_MODE=dynamic
+
+# Existing-disk identity (find with `crusoe storage disks list -f json`):
+#   import needs all three; nfs needs only EXISTING_DISK_ID.
+# A static PV is created with reclaimPolicy=Retain (your disk is never deleted);
+# PVC_SIZE becomes the PV capacity; STORAGE_CLASS is ignored.
+EXISTING_DISK_ID=                # crusoe disk `id`  (nfs path = /volumes/<id>; CSI volumeHandle)
+EXISTING_DISK_NAME=              # crusoe disk `name`   -> csi.crusoe.ai/disk-name   (import only)
+EXISTING_DISK_SERIAL=            # crusoe disk `serial_number`                       (import only)
+EXISTING_DISK_FSTYPE=ext4
+
+# NFS-mode endpoint (the VAST data path on CMK):
+NFS_SERVER=nfs.crusoecloudcompute.com
+NFS_EXPORT_PATH=                 # blank => /volumes/<EXISTING_DISK_ID>
+NFS_MOUNT_OPTIONS=vers=3,nconnect=16,spread_reads,spread_writes,remoteports=dns
+
+# --- Fleet sizing ---
+# TARGET_GBPS is the single sizing knob — set to your target aggregate GB/s.
+TARGET_GBPS=30
+NUM_NODES=4                       # nodes to spread across
+PODS_PER_NODE=8                   # workers per node (spread evenly). More pods =
+                                  # smaller shards = shorter straggler tail. Raise
+                                  # for shorter tails; if each pod uses many
+                                  # streams, watch node memory.
+NUM_PODS=                         # absolute total override; default = NODES*PER_NODE
+INSTANCE_CLASS=s2a
+
+# Path RTT (ms) source<->destination region. Drives the BDP / concurrency math.
+RTT_MS=150
+# Conservative per-stream throughput assumption (Mbps) for an untuned
+# intercontinental TCP stream. Lower => more streams provisioned. Tune via sweep.
+PER_STREAM_MBPS=250
+# Safety multiplier on the BDP-derived stream count.
+STREAM_SAFETY=1.5
+
+# --- rclone concurrency (blank => auto-derive per-pod from the BDP sizing) ---
+# Leave TRANSFERS/STREAMS blank to size from TARGET_GBPS + RTT. To pin them, the
+# Crusoe AWS-S3 reference used transfers=40, streams=40, no --checkers (strong
+# throughput + low latency on large files):
+#   RCLONE_TRANSFERS=40 ; RCLONE_MULTI_THREAD_STREAMS=40
+RCLONE_TRANSFERS=                 # parallel files per pod (blank = auto)
+RCLONE_MULTI_THREAD_STREAMS=      # ranged-GET streams per file >cutoff (blank = auto)
+RCLONE_MULTI_THREAD_CUTOFF=256M
+RCLONE_MULTI_THREAD_CHUNK_SIZE=32M  # smaller chunk = shorter per-file straggler tail
+RCLONE_CHECKERS=                  # blank => omit --checkers (rclone default; with
+                                  # --no-traverse there's little to check + it
+                                  # avoids extra HEAD latency)
+RCLONE_BUFFER_SIZE=32M
+RCLONE_S3_CHUNK_SIZE=64M
+RCLONE_EXTRA_FLAGS=               # e.g. "--low-level-retries 20 --timeout 120s"
+
+# --- Worker pod resource requests (blank => auto-derived; the auto memory
+# estimate is conservative for high stream counts, which can over-restrict how
+# many pods schedule — set an explicit value when running 40/40). Requests
+# affect scheduling only; with no limits set, actual use can exceed the request.
+WORKER_CPU_REQUEST=
+WORKER_MEM_REQUEST=16Gi
+
+# --- K8s plumbing ---
+NAMESPACE=default
+SECRET_NAME=cmk-data-transfer-oci
+RCLONE_IMAGE=rclone/rclone:latest
+KUBECONFIG=

--- a/cmk-data-transfer/.gitignore
+++ b/cmk-data-transfer/.gitignore
@@ -1,0 +1,39 @@
+# --- Secrets / credentials (NEVER commit) ---
+.env
+*.env
+!.env.example
+rclone.conf
+*.rclone.conf
+# real secrets (the committed k8s/secret.example.yaml is intentionally kept)
+secret.yaml
+*-secret.yaml
+*.pem
+*.key
+.oci/
+
+# --- Generated runtime artifacts ---
+generated/
+run-*/
+manifests-local/
+*.shard.txt
+shard-*.txt
+listing.json
+
+# --- Benchmark output ---
+bench/results/
+*.bench.csv
+
+# --- Python ---
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+.pytest_cache/
+
+# --- Editor / OS / agent ---
+.DS_Store
+.idea/
+.vscode/
+*.swp
+.claude/

--- a/cmk-data-transfer/Makefile
+++ b/cmk-data-transfer/Makefile
@@ -1,0 +1,63 @@
+# cmk-data-transfer — operator entrypoints.
+# All targets read config from .env (see .env.example). Override on the CLI:
+#   make run TARGET_GBPS=11.6 NUM_NODES=4
+PY ?= python3
+
+.DEFAULT_GOAL := help
+
+.PHONY: help sizing dry-run preflight run run-yes sweep collect clean clean-all
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+sizing: ## Print the BDP/target sizing plan (no cluster access)
+	$(PY) -m orchestrator.sizing
+
+dry-run: ## Render manifests + run preflight checks, launch nothing
+	$(PY) -m orchestrator.run --dry-run
+
+preflight: ## VAST write-ceiling test (fio, one pod per node) — safe, no egress
+	$(PY) preflight/run_fio.py
+
+fio-bench: ## Disk read+write benchmark: fio on every s2a node -> bench/results/
+	$(PY) bench/fio/run_fio_bench.py --pvc $(FIO_PVC) --size $(FIO_SIZE) \
+		--jobs $(FIO_JOBS) --iodepth $(FIO_IODEPTH) --runtime $(FIO_RUNTIME) \
+		--direct $(FIO_DIRECT)
+
+run: ## Full pipeline; PROMPTS before launching the large transfer
+	$(PY) -m orchestrator.run
+
+run-yes: ## Full pipeline, skip the launch confirmation (CAUTION: egress)
+	$(PY) -m orchestrator.run --yes
+
+sweep: ## Parameter sweep (bounded sample); set SAMPLE_PREFIX. CAUTION: egress
+	$(PY) bench/sweep.py --yes --sample-prefix "$(SAMPLE_PREFIX)" \
+		--transfers-grid "$(TRANSFERS_GRID)" --mts-grid "$(MTS_GRID)" \
+		--pods-per-node-grid "$(PODS_PER_NODE_GRID)" --max-seconds "$(MAX_SECONDS)" --do-list
+
+collect: ## Attach the throughput collector to a running fleet
+	$(PY) bench/collect.py --namespace $(NAMESPACE)
+
+clean: ## Delete worker + master + fio pods (keep PVC/Secret/data)
+	-kubectl -n $(NAMESPACE) delete pod -l app=cmk-data-transfer-worker --ignore-not-found
+	-kubectl -n $(NAMESPACE) delete pod -l app=cmk-data-transfer-fio --ignore-not-found
+	-kubectl -n $(NAMESPACE) delete pod cmk-data-transfer-master --ignore-not-found
+
+clean-all: clean ## Also delete the Secret (keeps the PVC and downloaded data)
+	-kubectl -n $(NAMESPACE) delete secret cmk-data-transfer-oci --ignore-not-found
+	@echo "PVC and downloaded data left intact. Delete the PVC manually if desired."
+
+# --- defaults for sweep knobs (override on CLI) ---
+NAMESPACE ?= default
+FIO_PVC ?= cmk-data-transfer-fs
+FIO_SIZE ?= 4G
+FIO_JOBS ?= 16
+FIO_IODEPTH ?= 32
+FIO_RUNTIME ?= 30
+FIO_DIRECT ?= 1
+SAMPLE_PREFIX ?=
+TRANSFERS_GRID ?= 16,32,48
+MTS_GRID ?= 4,8
+PODS_PER_NODE_GRID ?= 2,4,8
+MAX_SECONDS ?= 120

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -90,7 +90,7 @@ contention). Each worker pod:
 
 
 
-## Why concurrency, not file size: the 150 ms BDP
+## Why concurrency: TCP windows and Bandwidth Delay Product (BDP)
 
 Over a >150 ms intercontinental path a single TCP stream is **window-limited**:
 
@@ -125,10 +125,10 @@ untuned stream, with a 1.5× safety factor):
 
 rclone exposes two multiplicative concurrency levers:
 
-- **`--transfers`** — number of files copied in parallel (also the *only*
+- **`--transfers`** - number of files copied in parallel (also the *only*
   parallelism for files **below** `--multi-thread-cutoff`, since each gets one
   stream).
-- **`--multi-thread-streams`** — ranged-GET streams per *single* file, for files
+- **`--multi-thread-streams`** - ranged-GET streams per *single* file, for files
   **above** the cutoff (default 256 MiB). This is what fills the per-large-file
   BDP. (Multi-thread **downloads** are supported since rclone v1.63.)
 
@@ -569,3 +569,9 @@ preflight/              fio VAST write-ceiling test (yaml + run_fio.py)
   pip install required; the orchestrator shells out to `kubectl`).
 - A `KUBECONFIG` with access to the CMK cluster and schedulable `s2a` nodes.
 - OCI Customer Secret Key with read access to the source bucket.
+
+---
+
+## Disclaimer
+
+This solution is provided **AS IS, WITHOUT WARRANTY OF ANY KIND**, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. The orchestrator, manifests, scripts, and documentation in this directory are reference implementations intended to help you get started — they are not a supported Crusoe product and may not be appropriate for every deployment without customization. Running transfers incurs object-store egress and compute cost, and throughput depends on factors outside this tooling (source-provider limits, network path, and storage backend). Use at your own risk; review the manifests and cost/egress implications against your security and operational requirements before applying them to production clusters.

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -16,11 +16,11 @@ large files.
 
 ---
 
-## TL;DR
+## Quick Start 
 
 ```bash
-cp .env.example .env          # fill in OCI creds, namespace, region, bucket
-make sizing                   # show the BDP/target concurrency plan (no cluster)
+cp .env.example .env          # fill in OCI / other object storage creds, namespace, region, bucket
+make sizing                   # (OPTIONAL) show the BDP/target concurrency plan (no cluster)
 make dry-run                  # render manifests + preflight checks (launches nothing)
 make preflight                # measure the VAST write ceiling with fio (safe, no egress)
 make run                      # full pipeline; PROMPTS before the large transfer
@@ -32,7 +32,7 @@ make run                      # full pipeline; PROMPTS before the large transfer
 
 ```
         operator workstation (this repo, python3 + kubectl)
-        │  build rclone.conf → K8s Secret (creds never touch the repo)
+        │  build rclone.conf → K8s Secret 
         │  list (via master) → bin-pack shards locally → push to shared disk
         ▼
 ┌──────────────────────────── Crusoe Managed Kubernetes ───────────────────────┐
@@ -80,34 +80,8 @@ contention). Each worker pod:
 
 ---
 
-## The AWS → OCI adaptation
 
-| Aspect | AWS reference | This repo (OCI) |
-|---|---|---|
-| Source backend | rclone `s3`, `provider = AWS`, `env_auth` | rclone `s3`, `provider = Other`, explicit `endpoint` + `force_path_style` |
-| Endpoint | AWS default | `https://<namespace>.compat.objectstorage.<region>.oraclecloud.com` |
-| Credential | AWS access/secret key | **OCI Customer Secret Key** (S3-compat access/secret pair) |
-| Credential delivery | env vars from a Secret | full `rclone.conf` in a Secret, **mounted read-only** at `/config` |
-| Listing | `boto3` on the workstation | `rclone lsf` **in-cluster** (no boto3, no WAN listing, works for OCI) |
-| Sharding | greedy LPT bin-pack (local) | same LPT bin-pack (local), pushed to the shared disk |
-| Node pinning | `nodeSelector` only, pods land unevenly | `nodeSelector` **+ topology-spread (even K/node)** + auto-sized requests |
-| `--files-from` copy | no `--no-traverse` | **`--no-traverse`** (don't list the destination tree) |
-| Concurrency | fixed `--transfers=40 --multi-thread-streams=40` | **derived from `TARGET_GBPS`, node count, NIC, and the 150 ms BDP** |
-| Instance class | `s1a` | `s2a` |
 
-A native `oracleobjectstorage` backend is also available (see
-[Alternative: native OCI backend](#alternative-native-oci-backend)), but it uses
-OCI IAM (user/instance/resource principal) rather than the access/secret key the
-customer has, so the **S3-compatible path is the default**.
-
-> **Bugs fixed from the reference script** (for anyone comparing):
-> the reference's worker `rclone.conf` heredoc was missing its `>` redirect, its
-> prefix expression had a malformed comparison, and it set no `--no-traverse`.
-> It also used `nodeSelector` alone with **no spread constraint**, so its 8 pods
-> could land unevenly across nodes; here `topologySpreadConstraints` + auto-sized
-> requests place exactly `PODS_PER_NODE` workers on every node.
-
----
 
 ## Why concurrency, not file size: the 150 ms BDP
 
@@ -459,17 +433,12 @@ file-size distribution.
   prefixes helps.
 - **VAST write ceiling** may be the real limit well before the NIC line rate —
   always run the fio preflight so a plateau is attributed correctly.
-- **CSI mount vs. NFS mount:** if the fs CSI driver falls back to an unroutable
-  IP and mounts time out, use `DEST_MODE=nfs` to mount the VAST DNS endpoint
-  directly. Verify mountability before a big run with a one-off pod that writes
-  to the PVC.
 - **`hostNetwork: true`** means workers share the node's network namespace and
   bind host ports — each worker's rclone rc listens on `localhost:5572+index`,
   so the ports are unique per pod even when several run on one node. Don't
   co-schedule other workloads that grab those ports; raise `PODS_PER_NODE`
   thoughtfully (each pod = one more rc port + CPU/mem slice).
-- **`1000Ti` PVC** is a request ceiling, not a reservation; size it to your
-  dataset.
+
 
 ---
 

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -5,14 +5,13 @@ Parallel-pull a dataset from **any S3-compatible object store** to a
 saturate worker hosts across a high-latency path. **OCI Object Storage is the
 worked example throughout** but the source
 backend is rclone's generic `provider = Other`, so AWS S3, MinIO/Ceph, GCS (S3
-interop), Cloudflare R2, Backblaze B2, etc. work too — point `OCI_ENDPOINT` at
+interop), Cloudflare R2, Backblaze B2, etc. work too -  point `OCI_ENDPOINT` at
 the store (see [Other S3-compatible sources](#other-s3-compatible-sources)).
 
 The shape follows Crusoe's AWS-S3 ["rclone parallel streams"](https://support.crusoecloud.com/hc/en-us/articles/37041258573723-How-To-Download-Data-From-AWS-S3-Using-Rclone-Parallel-Streams) reference: a master
 pod lists the source and writes balanced shard manifests to a shared disk; N
-worker pods each take one shard and `rclone copy` it in parallel — tuned for a
-**high-RTT path** where throughput comes from **massive concurrency**, not from
-large files.
+worker pods each take one shard and `rclone copy` it in parallel - tuned for a
+**high-RTT path** where throughput comes from **massive concurrency**.
 
 ---
 

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -260,6 +260,8 @@ via a diagnostic pod):
 | NIC | single 200 Gbps (Mellanox `mlx5`) |
 | 4-node fleet line rate | 800 Gbps ≈ 100 GB/s |
 
+Other SKU/cloud? Override `NODE_VCPU` / `NODE_RAM_GIB` / `NODE_NIC_GBPS`.
+
 ---
 
 ## Configuration
@@ -276,6 +278,7 @@ flags — **never hardcoded**. CLI flags > process env > `.env`.
 | `TARGET_GBPS` | **the single sizing knob** (default 30) |
 | `NUM_NODES` / `PODS_PER_NODE` | fleet size; total pods = nodes × pods/node (`NUM_PODS` forces an absolute total) |
 | `RTT_MS` / `PER_STREAM_MBPS` / `STREAM_SAFETY` | BDP model inputs |
+| `NODE_VCPU` / `NODE_RAM_GIB` / `NODE_NIC_GBPS` | per-node hardware for sizing (defaults = s2a.80x) |
 | `DEST_PATH` | **where objects are saved** — folder under the `/data` mount (default `/data/dataset`) |
 | `STORAGE_CLASS` / `PVC_NAME` / `PVC_SIZE` | VAST destination disk |
 | `DEST_MODE` | `dynamic` / `import` / `nfs` destination (see below) |

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -26,6 +26,14 @@ make preflight                # (OPTIONAL) measure the shared-disk write ceiling
 make run                      # full pipeline; PROMPTS before the large transfer
 ```
 
+> **Where does the data land?** The shared disk is mounted at **`/data`** in
+> every pod, and objects are copied to **`DEST_PATH`** (default `/data/dataset`).
+> Set `DEST_PATH` in `.env` to choose the folder — e.g.
+> `DEST_PATH=/data/fineweb-edu`.
+> **Using an existing disk?** Set `DEST_MODE=import` (or `nfs`) + the disk id,
+> then point `DEST_PATH` at where on *that* disk you want the files. See
+> [Destination modes](#destination-modes-dest_mode).
+
 ---
 
 ## Architecture
@@ -268,6 +276,7 @@ flags — **never hardcoded**. CLI flags > process env > `.env`.
 | `TARGET_GBPS` | **the single sizing knob** (default 30) |
 | `NUM_NODES` / `PODS_PER_NODE` | fleet size; total pods = nodes × pods/node (`NUM_PODS` forces an absolute total) |
 | `RTT_MS` / `PER_STREAM_MBPS` / `STREAM_SAFETY` | BDP model inputs |
+| `DEST_PATH` | **where objects are saved** — folder under the `/data` mount (default `/data/dataset`) |
 | `STORAGE_CLASS` / `PVC_NAME` / `PVC_SIZE` | VAST destination disk |
 | `DEST_MODE` | `dynamic` / `import` / `nfs` destination (see below) |
 | `EXISTING_DISK_ID` / `_NAME` / `_SERIAL` / `NFS_SERVER` | bind an existing disk (import/nfs modes) |
@@ -344,6 +353,19 @@ The tool can target the VAST shared disk three ways:
 Find the disk's identity with `crusoe storage disks list -f json` (pick the
 `shared-volume` in your region): `.id`, `.name`, `.serial_number`. All modes use
 `reclaimPolicy: Retain`, so deleting the PVC/PV never deletes the disk or data.
+
+**Where the files go (all modes):** whichever disk you bind is mounted at
+`/data`, and objects are written to **`DEST_PATH`** (default `/data/dataset`).
+Point it wherever you want them on the disk — for example, to pull a dataset
+into a folder alongside existing data on an **existing** disk:
+
+```bash
+DEST_MODE=import  EXISTING_DISK_ID=<id>  EXISTING_DISK_NAME=<name>  EXISTING_DISK_SERIAL=<serial> \
+  DEST_PATH=/data/datasets/fineweb-edu  make run
+```
+
+Because `rclone copy` is idempotent, you can safely point `DEST_PATH` at a folder
+that already holds part of the dataset — only missing/changed objects are pulled.
 
 ### `nfs` mode — when the CSI mount times out
 

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -475,6 +475,11 @@ kubectl logs -f cmk-data-transfer-worker-0                      # live rclone pr
 kubectl exec cmk-data-transfer-worker-0 -- \
   rclone rc core/stats --rc-addr localhost:5572                 # live bytes/speed for that pod
 kubectl top nodes ; kubectl top pods -l app=cmk-data-transfer-worker   # CPU/mem
+
+# overall progress in flight: sum bytes across the whole fleet (RC_PORT = 5572 + index)
+kubectl get po -l app=cmk-data-transfer-worker -o jsonpath='{range .items[*]}{.metadata.name} {range .spec.containers[0].env[?(@.name=="RC_PORT")]}{.value}{end}{"\n"}{end}' \
+  | xargs -P16 -n2 sh -c 'kubectl exec $0 -- rclone rc core/stats --rc-addr localhost:$1 2>/dev/null' \
+  | grep -o '"bytes":[0-9]*' | awk -F: '{s+=$2} END{printf "fleet transferred: %.2f TB\n", s/1e12}'
 ```
 The runner also prints a per-tick line (`elapsed`, est TB, ~rate, active/failed
 pods). **Note:** rclone's own `MiB/s` in the logs is a *cumulative average* — on

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -476,10 +476,12 @@ kubectl exec cmk-data-transfer-worker-0 -- \
   rclone rc core/stats --rc-addr localhost:5572                 # live bytes/speed for that pod
 kubectl top nodes ; kubectl top pods -l app=cmk-data-transfer-worker   # CPU/mem
 
-# overall progress in flight: sum each worker's transferred bytes (RC_PORT = 5572 + index)
-kubectl get po -l app=cmk-data-transfer-worker -o jsonpath='{range .items[*]}{.metadata.name} {range .spec.containers[0].env[?(@.name=="RC_PORT")]}{.value}{end}{"\n"}{end}' \
-  | xargs -P16 -n2 sh -c 'kubectl exec $0 -- rclone rc core/stats --rc-addr localhost:$1 2>/dev/null | python3 -c "import json,sys;print(json.load(sys.stdin).get(\"bytes\",0))"' \
-  | awk '{s+=$1} END{printf "fleet transferred: %.2f TB\n", s/1e12}'
+# overall progress in flight: sum each Running worker's bytes (RC_PORT = 5572 + index).
+# Filters to Running pods + guards non-JSON so starting/terminating pods don't error.
+kubectl get po -l app=cmk-data-transfer-worker --field-selector=status.phase=Running \
+  -o jsonpath='{range .items[*]}{.metadata.name} {range .spec.containers[0].env[?(@.name=="RC_PORT")]}{.value}{end}{"\n"}{end}' \
+  | xargs -P16 -n2 sh -c 'kubectl exec "$0" -- rclone rc core/stats --rc-addr localhost:"$1" 2>/dev/null | python3 -c "import json,sys;s=sys.stdin.read().strip();print(json.loads(s).get(\"bytes\",0) if s.startswith(\"{\") else 0)"' \
+  | awk '{s+=$1; n++} END{printf "fleet: %.2f TB across %d pods\n", s/1e12, n}'
 ```
 The runner also prints a per-tick line (`elapsed`, est TB, ~rate, active/failed
 pods). **Note:** rclone's own `MiB/s` in the logs is a *cumulative average* — on

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -182,6 +182,62 @@ set `RCLONE_TRANSFERS=40 RCLONE_MULTI_THREAD_STREAMS=40`.
 > TCP buffers or OCI gives you more per-connection throughput, fewer streams are
 > needed; the sweep harness finds the real knee empirically.
 
+### Tuning `PODS_PER_NODE` (1–2 node experiments)
+
+Most transfers run on **1–2 nodes**, where the WAN path — not the cluster — is
+the bottleneck. There you usually can't raise *steady* throughput past the path
+ceiling, so the lever that matters is **`PODS_PER_NODE`**: more pods = smaller
+shards = a **shorter straggler tail**, and the tail is what dominates total
+transfer time. Experiment like this:
+
+1. **See the plan for a baseline** (no cluster access needed):
+
+   ```bash
+   make sizing NUM_NODES=2 PODS_PER_NODE=8
+   ```
+
+2. **Right-size memory so pods pack densely.** Each rclone pod uses well under
+   1 GiB even at high concurrency (memory tracks concurrency, not file count),
+   so the default request over-reserves and limits how many can schedule. Lower
+   it so CPU — not an inflated memory request — is the packing limit:
+
+   ```ini
+   # .env
+   WORKER_MEM_REQUEST=2Gi      # actual use is small; lets many more pods schedule
+   ```
+
+   CPU per pod is `(vCPU − headroom) / PODS_PER_NODE`, so on an 80-vCPU node
+   16 pods ≈ 4 vCPU each and 32 pods ≈ 2 vCPU each — both schedule comfortably.
+
+3. **Run a time-boxed experiment** (bounds egress cost) at a few pod counts and
+   compare the rates:
+
+   ```bash
+   python3 bench/oci_experiment.py --nodes 2 --pods-per-node 8  --label ppn-8  --max-seconds 120
+   python3 bench/oci_experiment.py --nodes 2 --pods-per-node 16 --label ppn-16 --max-seconds 120
+   python3 bench/oci_experiment.py --nodes 2 --pods-per-node 24 --label ppn-24 --max-seconds 120
+   # compare avg_GBps / steady_GBps in each bench/results/oci-exp-ppn-*/summary.json
+   ```
+
+4. **Find the knee** by watching utilization while a run is live:
+
+   ```bash
+   kubectl top nodes
+   kubectl top pods -l app=cmk-data-transfer-worker
+   ```
+
+   - Rate still rising and CPU climbing toward the node total → add more pods.
+   - Rate flat while CPU/mem stay low → you're **path-capped**; more pods won't
+     raise steady throughput, but a higher count still shortens the finishing
+     tail on the full run.
+
+5. **Lock it in:** put the best value in `.env` (`PODS_PER_NODE=…`) and run the
+   full transfer with `make run`.
+
+> **Rule of thumb on `s2a`:** start around **16–24 pods/node** for 1–2 node
+> transfers. Raise it when a run shows a long finishing tail; back off if CPU
+> saturates before the path does.
+
 ---
 
 ## Discovered `s2a` hardware

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -1,36 +1,34 @@
-# CMK Cross Region Object Storage Data Transfer
+# CMK Cross-Region Object Storage Data Transfer
 
-Parallel-pull a dataset from **any S3-compatible object store** to a
-**VAST-backed PB Scale shared disk** on **Crusoe Managed Kubernetes (CMK)**, engineered to
-saturate worker hosts across a high-latency path. **OCI Object Storage is the
-worked example throughout** but the source
-backend is rclone's generic `provider = Other`, so AWS S3, MinIO/Ceph, GCS (S3
-interop), Cloudflare R2, Backblaze B2, etc. work too -  point `OCI_ENDPOINT` at
-the store (see [Other S3-compatible sources](#other-s3-compatible-sources)).
+Parallel-pull a dataset from **any S3-compatible object store** to a **VAST-backed
+RWX shared disk** on **Crusoe Managed Kubernetes (CMK)**, tuned to saturate worker
+hosts across a high-latency path. **OCI Object Storage is the worked example**, but
+the source backend is rclone's generic `provider = Other`, so AWS S3, MinIO/Ceph,
+GCS (S3 interop), Cloudflare R2, Backblaze B2, etc. work too — see
+[Other S3-compatible sources](#other-s3-compatible-sources).
 
-The shape follows Crusoe's AWS-S3 ["rclone parallel streams"](https://support.crusoecloud.com/hc/en-us/articles/37041258573723-How-To-Download-Data-From-AWS-S3-Using-Rclone-Parallel-Streams) reference: a master
-pod lists the source and writes balanced shard manifests to a shared disk; N
-worker pods each take one shard and `rclone copy` it in parallel - tuned for a
-**high-RTT path** where throughput comes from **massive concurrency**.
+A **master pod** lists the source and writes balanced shard manifests to the shared
+disk; **N worker pods** each `rclone copy` one shard in parallel. It follows Crusoe's
+AWS-S3 ["rclone parallel streams"](https://support.crusoecloud.com/hc/en-us/articles/37041258573723-How-To-Download-Data-From-AWS-S3-Using-Rclone-Parallel-Streams)
+reference, tuned for a **high-RTT path** where throughput comes from **massive
+concurrency**.
 
 ---
 
-## Quick Start 
+## Quick Start
 
 ```bash
-cp .env.example .env          # fill in OCI / other object storage creds, namespace, region, bucket
-make sizing                   # (OPTIONAL) show the BDP/target concurrency plan (no cluster)
-make dry-run                  # render manifests + preflight checks (launches nothing)
-make preflight                # (OPTIONAL) measure the shared-disk write ceiling with fio (safe, no third party egress)
-make run                      # full pipeline; PROMPTS before the large transfer
+cp .env.example .env    # fill in creds, namespace, region, bucket, destination disk
+make sizing             # (optional) print the concurrency plan — no cluster access
+make dry-run            # render manifests + preflight checks (launches nothing)
+make preflight          # (optional) fio write-ceiling test (safe, no egress)
+make run                # full pipeline; PROMPTS before the large transfer
 ```
 
-> **Where does the data land?** The shared disk is mounted at **`/data`** in
-> every pod, and objects are copied to **`DEST_PATH`** (default `/data/dataset`).
-> Set `DEST_PATH` in `.env` to choose the folder — e.g.
-> `DEST_PATH=/data/fineweb-edu`.
-> **Using an existing disk?** Set `DEST_MODE=import` (or `nfs`) + the disk id,
-> then point `DEST_PATH` at where on *that* disk you want the files. See
+> **Where does the data land?** The shared disk mounts at **`/data`** in every pod,
+> and objects copy to **`DEST_PATH`** (default `/data/dataset`) — set it in `.env`.
+> **Using an existing disk?** Set `DEST_MODE=import` (or `nfs`) + the disk id, then
+> point `DEST_PATH` at where on that disk you want the files. See
 > [Destination modes](#destination-modes-dest_mode).
 
 ---
@@ -39,13 +37,11 @@ make run                      # full pipeline; PROMPTS before the large transfer
 
 ```
         operator workstation (this repo, python3 + kubectl)
-        │  build rclone.conf → K8s Secret 
+        │  build rclone.conf → K8s Secret
         │  list (via master) → bin-pack shards locally → push to shared disk
         ▼
 ┌──────────────────────────── Crusoe Managed Kubernetes ───────────────────────┐
-│                                                                               │
-│   Secret(rclone.conf, RO)        PVC: crusoe-csi-driver-fs-sc (VAST, RWX)     │
-│        │  mounted RO into all pods         │  mounted into all pods           │
+│   Secret(rclone.conf, RO)        PVC: shared disk (VAST, RWX)                 │
 │        ▼                                   ▼                                  │
 │   ┌─────────────┐   rclone lsf      ┌─────────────────────────────────────┐  │
 │   │ master pod  │ ───────────────►  │  shared disk  /data                 │  │
@@ -53,439 +49,212 @@ make run                      # full pipeline; PROMPTS before the large transfer
 │   └─────────────┘ ◄───────────────  │   /logs/worker-*.log                │  │
 │                                     │   /dataset/...  (downloaded objects)│  │
 │                                     └─────────────────────────────────────┘  │
-│                                                  ▲  ▲  ▲  ▲                    │
-│   K workers PER s2a node (topology-spread even, hostNetwork, unique rc port):  │
+│   K workers per node (topology-spread, hostNetwork, unique rc port):          │
 │   ┌───────── node 1 ─────────┐        ┌───────── node N ─────────┐            │
-│   │ w0  w1  w2  w3 (shards)  │  ...   │ wK ... w(K+3)            │             │
-│   │ share the 200 Gbps NIC   │        │ share the 200 Gbps NIC   │            │
+│   │ w0  w1  w2  w3 (shards)  │  ...   │ wK ...                   │            │
 │   └─────┬──────────────┬─────┘        └─────┬──────────────┬─────┘            │
 └─────────┼──────────────┼────────────────────┼──────────────┼──────────────────┘
-          │              │                    │              │  hundreds of parallel
-          ▼              ▼                    ▼              ▼  ranged-GET streams
-        ┌──────────────────────────────────────────────────┐
-        │   OCI Object Storage  (S3-compatible endpoint)     │   > e.g. 150 ms RTT
-        │   https://<ns>.compat.objectstorage.<region>....   │   (intercontinental)
+          ▼              ▼                    ▼              ▼  hundreds of parallel
+        ┌──────────────────────────────────────────────────┐   ranged-GET streams
+        │   S3-compatible object store (e.g. OCI)            │   high RTT (intercontinental)
         └──────────────────────────────────────────────────┘
 ```
 
-The fleet runs **`PODS_PER_NODE` independent rclone processes on each node** —
-multiple processes saturate the shared 200 Gbps NIC better than one big rclone
-(a single process can hit internal ceilings: one `http.Transport`, GC, lock
-contention). Each worker pod:
+The fleet runs **`PODS_PER_NODE` independent rclone processes per node** — multiple
+processes saturate the node NIC better than one big rclone (a single process hits
+internal ceilings: one `http.Transport`, GC, lock contention). Each worker pod:
 
-- **`hostNetwork: true`** — bypasses the CNI datapath and uses the node's NIC
-  directly. Because hostNetwork pods share the node's network namespace, each
-  worker binds a **unique rclone rc port** (`5572 + index`) so co-located
-  workers don't collide.
-- **`topologySpreadConstraints` (maxSkew=1 on `kubernetes.io/hostname`)** —
-  spreads workers *evenly* so each node gets `PODS_PER_NODE`, not a pile-up on
-  one node. CPU/memory requests are auto-sized so exactly that many pack per
-  node (with system headroom).
-- **`nodeSelector: crusoe.ai/instance.class: s2a`** — pins to the storage SKU.
-- mounts the **RWX VAST PVC** read-write and the **rclone Secret** read-only,
-  takes one shard, writes into the shared `/data/dataset`.
+- **`hostNetwork: true`** — uses the node's NIC directly; each worker binds a unique
+  rclone rc port (`5572 + index`) so co-located workers don't collide.
+- **`topologySpreadConstraints`** — spreads workers evenly (`PODS_PER_NODE` per node),
+  with CPU/mem requests auto-sized so exactly that many pack per node.
+- **`nodeSelector: crusoe.ai/instance.class`** (`INSTANCE_CLASS`, default `s2a`) —
+  pins to the target node class.
+- mounts the RWX shared-disk PVC (read-write) and the rclone Secret (read-only),
+  takes one shard, writes into `DEST_PATH`.
 
 ---
 
+## Why concurrency (bandwidth-delay product)
 
+Over a high-RTT path a single TCP stream is **window-limited**: `throughput ≈
+tcp_window / RTT`. A ~16 MB autotuned window at 150 ms ≈ **0.85 Gbps per stream —
+regardless of file size**. Aggregate throughput therefore comes from running **many
+streams in parallel** to fill each node's bandwidth-delay product (BDP). Two
+multiplicative rclone levers:
 
+- **`--transfers`** — files copied in parallel (also the *only* parallelism for files
+  **below** `--multi-thread-cutoff`).
+- **`--multi-thread-streams`** — ranged-GET streams per *single* file **above** the
+  cutoff (rclone v1.63+ for downloads).
 
-## Why concurrency: TCP windows and Bandwidth Delay Product (BDP)
-
-Over a >150 ms intercontinental path a single TCP stream is **window-limited**:
-
-```
-per_stream_throughput  ≈  tcp_window / RTT
-```
-
-With a typical autotuned window of ~16 MB:
-
-```
-16 MB × 8 bits / 0.150 s  ≈  853 Mbps  per stream
-```
-
-At high latencies, that's the ceiling **regardless of how large the file is**. A 100 GB file
-pulled on one stream still moves at ~0.85 Gbps. So aggregate throughput has to
-come from running **many streams in parallel** to fill the bandwidth-delay
-product (BDP) of each node's NIC.
-
-**BDP of one `s2a` node's 200 Gbps NIC at 150 ms:**
-
-```
-200e9 bits/s × 0.150 s  =  30e9 bits  =  3.75 GB  must be "in flight" to fill the pipe
-```
-
-**Streams needed to fill it** (using a deliberately conservative ~250 Mbps per
-untuned stream, with a 1.5× safety factor):
-
-```
-200 Gbps ÷ 0.25 Gbps/stream  ≈  800 streams to fill the NIC
-60  Gbps ÷ 0.25 Gbps/stream × 1.5  ≈  360 streams for a 60 Gbps/node target
-```
-
-rclone exposes two multiplicative concurrency levers:
-
-- **`--transfers`** - number of files copied in parallel (also the *only*
-  parallelism for files **below** `--multi-thread-cutoff`, since each gets one
-  stream).
-- **`--multi-thread-streams`** - ranged-GET streams per *single* file, for files
-  **above** the cutoff (default 256 MiB). This is what fills the per-large-file
-  BDP. (Multi-thread **downloads** are supported since rclone v1.63.)
-
-So **in-flight streams per pod ≈ `transfers × multi-thread-streams`** for large
-files. The orchestrator derives both from `TARGET_GBPS`; see `make sizing`.
+In-flight streams per pod ≈ `transfers × multi-thread-streams`. The orchestrator
+derives both from `TARGET_GBPS`.
 
 ---
 
-## Throughput target math
+## Sizing
 
-`TARGET_GBPS` is the single sizing knob (default 30). To convert a daily volume
-into a rate:
+**`TARGET_GBPS` is the single knob** (default 30). The orchestrator splits it across
+`NUM_NODES` × `PODS_PER_NODE`, derives the rclone flags from the BDP model, and
+auto-sizes pod CPU/mem so the pods pack. Run `make sizing` to see the plan; override
+anything via env/flags, e.g.:
 
-| GB/s | PB/day | per-node (4 nodes) | % of 200 Gbps NIC |
-|---|---|---|---|
-| 11.6 | 1.0 | 2.9 GB/s = 23 Gbps | 12% |
-| 30   | 2.6 | 7.5 GB/s = 60 Gbps | 30% |
-
-Four `s2a` nodes provide `4 × 200 Gbps ≈ 100 GB/s` of NIC line rate, so a
-30 GB/s target is ~30% of the ceiling — feasible **on the network**. The real
-binding constraint is usually **object-store egress throttling / request-rate
-limits** or the **VAST write ceiling** ([Caveats](#operational-caveats)) — which
-is why this repo ships a fio write-ceiling preflight and a throughput sweep.
-
-### Fleet sizing is a function of `TARGET_GBPS`, `NUM_NODES`, and `PODS_PER_NODE`
-
-The per-node stream budget is the same (BDP-driven); it's then **divided across
-`PODS_PER_NODE` independent rclone processes**, and CPU/mem requests are sized so
-exactly that many pack per node:
-
-```
-per_node_gbps      = TARGET_GBPS / NUM_NODES            (capped at 90% of NIC)
-streams_per_node   = ceil(per_node_gbps × 1000 / PER_STREAM_MBPS × STREAM_SAFETY)
-streams_per_pod    = ceil(streams_per_node / PODS_PER_NODE)
-multi_thread_streams = clamp(streams_per_pod, 4..8)              # per pod
-transfers          = ceil(streams_per_pod / multi_thread_streams)  # per pod, ≤ 2×(vCPU/pods)
-checkers           = min(2 × transfers, 256)                    # per pod
-cpu_request/pod    = (vCPU − headroom) / PODS_PER_NODE
+```bash
+make run TARGET_GBPS=11.6 PODS_PER_NODE=16
+make run --transfers 40 --multi-thread-streams 40   # pin the AWS-S3 reference config
 ```
 
-Defaults for **30 GB/s across 4 nodes at 8 pods/node** (`make sizing`):
+Rough conversions: **1 PB/day ≈ 11.6 GB/s**, **30 GB/s ≈ 2.6 PB/day**. The binding
+constraint is usually the **network path / object-store egress limits**, not the
+cluster (see [Caveats](#operational-caveats)) — which is why this repo ships an fio
+preflight and a throughput sweep. Non-`s2a` SKU? Set `NODE_VCPU` / `NODE_RAM_GIB` /
+`NODE_NIC_GBPS` so the sizing model matches your node.
 
-```
-nodes x pods/node          4 x 8 = 32 worker pods
-streams needed / node      360   ->  45 / pod
-=> PER POD: --transfers 6  --multi-thread-streams 8  (--checkers omitted)
-   in-flight streams/pod 48 ; per-node 384 ; fleet 1536
-   pod requests cpu=9 mem=8Gi  (8 × 9 = 72 vCPU, fits 80 with headroom)
-```
-
-Override any derived value with env vars or flags (e.g.
-`make run TARGET_GBPS=11.6 PODS_PER_NODE=16`, or `--pods-per-node 6 --transfers 40`).
-`PODS_PER_NODE` is itself a throughput lever — sweep it (below) to find where
-more processes stop helping. To pin per-pod concurrency to the AWS-S3 reference,
-set `RCLONE_TRANSFERS=40 RCLONE_MULTI_THREAD_STREAMS=40`.
-
-> `PER_STREAM_MBPS` (default 250) is intentionally pessimistic. If you tune host
-> TCP buffers or OCI gives you more per-connection throughput, fewer streams are
-> needed; the sweep harness finds the real knee empirically.
-
-### Tuning `PODS_PER_NODE` (1–2 node experiments)
-
-Most transfers run on **1–2 nodes**, where the WAN path — not the cluster — is
-the bottleneck. There you usually can't raise *steady* throughput past the path
-ceiling, so the lever that matters is **`PODS_PER_NODE`**: more pods = smaller
-shards = a **shorter straggler tail**, and the tail is what dominates total
-transfer time. Experiment like this:
-
-1. **See the plan for a baseline** (no cluster access needed):
-
-   ```bash
-   make sizing NUM_NODES=2 PODS_PER_NODE=8
-   ```
-
-2. **Right-size memory so pods pack densely.** Each rclone pod uses well under
-   1 GiB even at high concurrency (memory tracks concurrency, not file count),
-   so the default request over-reserves and limits how many can schedule. Lower
-   it so CPU — not an inflated memory request — is the packing limit:
-
-   ```ini
-   # .env
-   WORKER_MEM_REQUEST=2Gi      # actual use is small; lets many more pods schedule
-   ```
-
-   CPU per pod is `(vCPU − headroom) / PODS_PER_NODE`, so on an 80-vCPU node
-   16 pods ≈ 4 vCPU each and 32 pods ≈ 2 vCPU each — both schedule comfortably.
-
-3. **Run a time-boxed experiment** (bounds egress cost) at a few pod counts and
-   compare the rates:
-
-   ```bash
-   python3 bench/oci_experiment.py --nodes 2 --pods-per-node 8  --label ppn-8  --max-seconds 120
-   python3 bench/oci_experiment.py --nodes 2 --pods-per-node 16 --label ppn-16 --max-seconds 120
-   python3 bench/oci_experiment.py --nodes 2 --pods-per-node 24 --label ppn-24 --max-seconds 120
-   # compare avg_GBps / steady_GBps in each bench/results/oci-exp-ppn-*/summary.json
-   ```
-
-4. **Find the knee** by watching utilization while a run is live:
-
-   ```bash
-   kubectl top nodes
-   kubectl top pods -l app=cmk-data-transfer-worker
-   ```
-
-   - Rate still rising and CPU climbing toward the node total → add more pods.
-   - Rate flat while CPU/mem stay low → you're **path-capped**; more pods won't
-     raise steady throughput, but a higher count still shortens the finishing
-     tail on the full run.
-
-5. **Lock it in:** put the best value in `.env` (`PODS_PER_NODE=…`) and run the
-   full transfer with `make run`.
-
-> **Rule of thumb on `s2a`:** start around **16–24 pods/node** for 1–2 node
-> transfers. Raise it when a run shows a long finishing tail; back off if CPU
-> saturates before the path does.
-
----
-
-## Discovered `s2a` hardware
-
-The sizing model is grounded in the `s2a.80x` SKU shape (product facts, observed
-via a diagnostic pod):
-
-| Resource | Per node |
-|---|---|
-| vCPU | 80 (AMD, AVX-512) |
-| RAM | ~676 GiB |
-| NIC | single 200 Gbps (Mellanox `mlx5`) |
-| 4-node fleet line rate | 800 Gbps ≈ 100 GB/s |
-
-Other SKU/cloud? Override `NODE_VCPU` / `NODE_RAM_GIB` / `NODE_NIC_GBPS`.
+> **Node count & `PODS_PER_NODE`.** On 1–2 nodes you're usually **path-capped** —
+> more pods won't raise *steady* throughput, but more pods = smaller shards = a
+> **shorter straggler tail**, which dominates total transfer time. Start around
+> **16–24 pods/node**; raise it if a run shows a long tail, back off if CPU saturates
+> before the path does. Lower `WORKER_MEM_REQUEST` (~`2Gi`; actual use is small) so
+> CPU — not an inflated memory request — is the packing limit. Find the knee with
+> `bench/oci_experiment.py` ([below](#benchmarking)).
 
 ---
 
 ## Configuration
 
-All inputs come from `.env` (copied from `.env.example`), process env, or CLI
-flags — **never hardcoded**. CLI flags > process env > `.env`.
+All inputs come from `.env` (copied from `.env.example`), process env, or CLI flags —
+**never hardcoded**. Precedence: CLI flags > process env > `.env`.
 
 | Variable | Meaning |
 |---|---|
-| `OCI_ACCESS_KEY_ID` / `OCI_SECRET_ACCESS_KEY` | OCI Customer Secret Key (S3-compat pair) |
-| `OCI_NAMESPACE` | Object Storage namespace (builds the endpoint) |
-| `OCI_REGION` | OCI region slug, e.g. `us-phoenix-1` / `us-ashburn-1` |
+| `OCI_ACCESS_KEY_ID` / `OCI_SECRET_ACCESS_KEY` | S3-compat access/secret key pair (OCI: "Customer Secret Key") |
+| `OCI_NAMESPACE` / `OCI_REGION` | OCI Object Storage namespace + region (auto-build the endpoint) |
 | `OCI_BUCKET` / `OCI_PREFIX` | source bucket and optional prefix |
+| `OCI_ENDPOINT` | explicit S3 endpoint (for non-OCI stores; blank = auto from namespace+region) |
 | `TARGET_GBPS` | **the single sizing knob** (default 30) |
-| `NUM_NODES` / `PODS_PER_NODE` | fleet size; total pods = nodes × pods/node (`NUM_PODS` forces an absolute total) |
+| `NUM_NODES` / `PODS_PER_NODE` | fleet size; total = nodes × pods/node (`NUM_PODS` forces an absolute total) |
+| `INSTANCE_CLASS` | node class for the nodeSelector (default `s2a`) |
+| `NODE_VCPU` / `NODE_RAM_GIB` / `NODE_NIC_GBPS` | per-node hardware for the sizing model (defaults = s2a.80x) |
 | `RTT_MS` / `PER_STREAM_MBPS` / `STREAM_SAFETY` | BDP model inputs |
-| `NODE_VCPU` / `NODE_RAM_GIB` / `NODE_NIC_GBPS` | per-node hardware for sizing (defaults = s2a.80x) |
 | `DEST_PATH` | **where objects are saved** — folder under the `/data` mount (default `/data/dataset`) |
-| `STORAGE_CLASS` / `PVC_NAME` / `PVC_SIZE` | VAST destination disk |
 | `DEST_MODE` | `dynamic` / `import` / `nfs` destination (see below) |
+| `STORAGE_CLASS` / `PVC_NAME` / `PVC_SIZE` | destination shared disk |
 | `EXISTING_DISK_ID` / `_NAME` / `_SERIAL` / `NFS_SERVER` | bind an existing disk (import/nfs modes) |
-| `RCLONE_*` | per-flag overrides (blank = auto-derive) |
+| `RCLONE_*` / `WORKER_MEM_REQUEST` | per-flag / resource overrides (blank = auto-derive) |
 
 > **Region note:** use the **OCI** region slug where the *bucket* lives (not your
-> destination/cloud region). Preflight warns if the slug doesn't look like OCI.
+> destination region). Preflight warns if it doesn't look like an OCI slug.
 
 ### Other S3-compatible sources
 
-The source backend is rclone `provider = Other`, so any S3-compatible store
-works. The `OCI_*` env names are just labels — for a non-OCI store, set
-`OCI_ENDPOINT` to its S3 endpoint and use its access/secret key + bucket. OCI is
-the only one that auto-builds the endpoint from `OCI_NAMESPACE` + `OCI_REGION`;
-everything else just needs `OCI_ENDPOINT`:
+The source backend is rclone `provider = Other`, so any S3-compatible store works.
+The `OCI_*` names are just labels — for a non-OCI store, set `OCI_ENDPOINT` to its S3
+endpoint and use its access/secret key + bucket:
 
-| Source | `OCI_ENDPOINT` | Notes |
-|---|---|---|
-| OCI Object Storage | *(auto from namespace+region)* | the worked example |
-| AWS S3 | `https://s3.<region>.amazonaws.com` | or leave blank with a real AWS key |
-| MinIO / Ceph RGW | `https://<host>:<port>` | self-hosted |
-| Google Cloud Storage | `https://storage.googleapis.com` | S3 interop + HMAC key |
-| Cloudflare R2 | `https://<account>.r2.cloudflarestorage.com` | |
-| Backblaze B2 | `https://s3.<region>.backblazeb2.com` | |
+| Source | `OCI_ENDPOINT` |
+|---|---|
+| OCI Object Storage | *(auto from namespace + region)* |
+| AWS S3 | `https://s3.<region>.amazonaws.com` (or blank with a real AWS key) |
+| MinIO / Ceph RGW | `https://<host>:<port>` |
+| Google Cloud Storage | `https://storage.googleapis.com` (S3 interop + HMAC key) |
+| Cloudflare R2 | `https://<account>.r2.cloudflarestorage.com` |
+| Backblaze B2 | `https://s3.<region>.backblazeb2.com` |
 
-`force_path_style` and `no_check_bucket` are set for broad compatibility. Egress
-pricing and request-rate limits vary by provider — see [Caveats](#operational-caveats).
+`force_path_style` and `no_check_bucket` are set for broad compatibility.
 
 ### Secrets handling
 
-The credential is assembled into a complete `rclone.conf` and placed **only** in
-a Kubernetes Secret, mounted **read-only** (`0400`) at `/config/rclone.conf`. It
-never lands in the repo, in pod args, or in shell history. `.gitignore` blocks
-`.env`, `rclone.conf`, and `*-secret.yaml`.
+The credential is assembled into a complete `rclone.conf` and placed **only** in a
+Kubernetes Secret, mounted **read-only** (`0400`) at `/config/rclone.conf`. It never
+lands in the repo, in pod args, or in shell history. `.gitignore` blocks `.env`,
+`rclone.conf`, and `*-secret.yaml`.
 
 ---
 
 ## What `make run` does
 
-1. **Plan + sizing** — prints the BDP-derived concurrency.
-2. **Preflight** — verifies `kubectl` reachability, that enough schedulable
-   `s2a` nodes exist, and that the `crusoe-csi-driver-fs-sc` StorageClass
-   exists (creates it if absent — this cluster ships the fs CSI driver but not
-   always the StorageClass object).
-3. **Secret** — builds `rclone.conf`, applies it in-cluster.
-4. **PVC + master pod** — applies the RWX VAST claim and the master pod.
-5. **List** — `rclone lsf --recursive --files-only --format sp` in the master
-   pod → `/data/listing.tsv`.
-6. **Shard** — pulls the listing, bin-packs (LPT) into N balanced shard files
-   locally, pushes them to `/data/shards/`.
-7. **Confirm** — *prompts before launching the large transfer* (skip with
-   `--yes`).
-8. **Launch** — one worker pod per node, each `rclone copy --files-from
-   shard-i.txt --no-traverse …`.
-9. **Monitor** — polls pod phases to completion.
-10. **Teardown** — deletes worker + master pods (keeps PVC, Secret, data) unless
-    `--keep`.
+1. **Sizing + preflight** — prints the concurrency plan; verifies `kubectl`,
+   enough schedulable nodes (`INSTANCE_CLASS`), and the StorageClass (creates it if
+   absent).
+2. **Secret** — builds `rclone.conf`, applies it in-cluster.
+3. **PVC + master pod** — applies the RWX claim and the master.
+4. **List + shard** — `rclone lsf` in the master → pull the listing → bin-pack (LPT)
+   into N balanced shard files → push to `/data/shards/`.
+5. **Confirm** — prompts before the large transfer (skip with `--yes`).
+6. **Launch** — `PODS_PER_NODE` workers per node (pinned), each `rclone copy
+   --files-from shard-i.txt --no-traverse …`.
+7. **Monitor → teardown** — polls to completion, then deletes worker + master pods
+   (keeps PVC, Secret, data) unless `--keep`.
 
-Idempotent: `rclone copy` skips objects already present (size/checksum), so a
-re-run only fetches what's missing.
+Idempotent: `rclone copy` skips objects already present (size/checksum), so a re-run
+only fetches what's missing.
 
 ---
 
 ## Destination modes (`DEST_MODE`)
 
-The tool can target the VAST shared disk three ways:
-
 | `DEST_MODE` | What it does | Needs | When |
 |---|---|---|---|
 | `dynamic` (default) | provisions a new disk via the fs CSI driver | — | greenfield |
 | `import` | binds an **existing** disk via a CSI **static PV** | disk `id` + `name` + `serial` | migrate into an existing disk, CSI healthy |
-| `nfs` | binds an **existing** disk via an **in-tree NFS PV** straight to the VAST DNS endpoint (bypasses CSI) | disk `id` (+ `NFS_SERVER`) | when the CSI mount times out on an unroutable fallback IP |
+| `nfs` | binds an **existing** disk via an **in-tree NFS PV** to the VAST DNS endpoint (bypasses CSI) | disk `id` (+ `NFS_SERVER`) | when a CSI mount times out on an unroutable fallback IP |
 
-Find the disk's identity with `crusoe storage disks list -f json` (pick the
-`shared-volume` in your region): `.id`, `.name`, `.serial_number`. All modes use
-`reclaimPolicy: Retain`, so deleting the PVC/PV never deletes the disk or data.
+Find the disk with `crusoe storage disks list -f json` (pick the `shared-volume` in
+your region): `.id`, `.name`, `.serial_number`. All modes use `reclaimPolicy: Retain`,
+so deleting the PVC/PV never deletes the disk or data.
 
-**Where the files go (all modes):** whichever disk you bind is mounted at
-`/data`, and objects are written to **`DEST_PATH`** (default `/data/dataset`).
-Point it wherever you want them on the disk — for example, to pull a dataset
-into a folder alongside existing data on an **existing** disk:
+**Where files go (all modes):** the bound disk mounts at `/data`; objects are written
+to `DEST_PATH`. Point it wherever you want them — e.g. into a folder on an existing
+disk:
 
 ```bash
-DEST_MODE=import  EXISTING_DISK_ID=<id>  EXISTING_DISK_NAME=<name>  EXISTING_DISK_SERIAL=<serial> \
+DEST_MODE=import EXISTING_DISK_ID=<id> EXISTING_DISK_NAME=<name> EXISTING_DISK_SERIAL=<serial> \
   DEST_PATH=/data/datasets/fineweb-edu  make run
 ```
 
-Because `rclone copy` is idempotent, you can safely point `DEST_PATH` at a folder
-that already holds part of the dataset — only missing/changed objects are pulled.
+Because `rclone copy` is idempotent, `DEST_PATH` can point at a folder already holding
+part of the dataset — only missing/changed objects are pulled.
 
-### `nfs` mode — when the CSI mount times out
+> **`nfs` mode** exists because the fs CSI driver can fall back to a fixed IP that may
+> be unroutable from your nodepool (mounts hang). The VAST DNS endpoint
+> (`nfs.crusoecloudcompute.com`, `remoteports=dns`) mounts cleanly; `nfs` mode creates
+> an in-tree NFS PV straight to it (see `k8s/nfs-pv.yaml`). If a CSI mount hangs,
+> prefer `nfs`. Export path defaults to `/volumes/<EXISTING_DISK_ID>`.
 
-If the fs CSI driver can't get a disk's "data path connectivity fields" it falls
-back to a fixed IP that may be **unroutable from your nodepool**, so `dynamic`
-and `import` mounts hang and time out. The **VAST DNS endpoint mounts cleanly**,
-though — `nfs.crusoecloudcompute.com` resolves to the in-VPC VAST data IPs. `nfs`
-mode creates an in-tree NFS PV that mounts it directly with `remoteports=dns`:
+---
 
-```bash
-DEST_MODE=nfs  EXISTING_DISK_ID=<disk-id>   # NFS_SERVER defaults to nfs.crusoecloudcompute.com
-make run                                     # (or --dest-mode nfs --import-disk-id <id>)
-```
+## Benchmarking
 
-The orchestrator generates the PV/PVC (see `k8s/nfs-pv.yaml` for the manual /
-`envsubst` equivalent), skips the StorageClass, and the workers write into the
-existing disk. `PVC_SIZE` is the PV capacity; the NFS path is
-`/volumes/<EXISTING_DISK_ID>` (override with `NFS_EXPORT_PATH`).
-
-> The CSI `import` PV mirrors what the provisioner emits, so it mounts
-> identically to a `dynamic` claim — and hits the same CSI fallback if that's
-> the problem. If a CSI mount hangs, prefer `nfs`.
-
-## Benchmarking & finding the binding constraint
-
-**VAST write ceiling (run first, no egress):**
-
-```bash
-make preflight                       # one fio pod per node → aggregate write GB/s
-# or: python3 preflight/run_fio.py --nodes 4 --size 20G --jobs 8 --bs 4M
-```
-
-If the download later plateaus near the fio number, the **write path** is the
-limit — not OCI or the NIC.
-
-**Disk read+write benchmark (fio on every node):** one fio pod per node, four
-stonewalled profiles (seq/rand read+write, `direct=1`). Results saved to
-git-ignored `bench/results/fio-<ts>/` (per-node JSON + `summary.csv`):
-
-```bash
-make fio-bench                       # → per-node + aggregate GB/s and IOPS
-# default 16 jobs x iodepth 32/node; push harder with FIO_JOBS=32 FIO_IODEPTH=64
-# standalone: python3 bench/fio/run_fio_bench.py --jobs 16 --iodepth 32 --runtime 30
-```
-
-Throughput scales with `FIO_JOBS × FIO_IODEPTH` (in-region disk — concurrency,
-not window, is the lever). The runner skips unschedulable nodes and lists any it
-missed. Sequential-read numbers can be inflated by server-side caching; treat
-read as an upper bound unless the working set exceeds the cache.
-
-**Throughput collector** (attach to a running fleet; polls each worker's rclone
-remote-control `core/stats`):
-
-```bash
-make collect                         # → bench/results/throughput.csv + peak/median
-```
-
-**Parameter sweep** over `(transfers, multi-thread-streams, pods-per-node)` on a
-*bounded sample* to find the saturation knee — including where adding more pods
-per node stops helping:
-
-```bash
-make sweep SAMPLE_PREFIX=smoke-set/ TRANSFERS_GRID=16,32,48 MTS_GRID=4,8 \
-           PODS_PER_NODE_GRID=2,4,8 MAX_SECONDS=120
-# → bench/results/sweep.csv, ranked by peak aggregate GB/s
-```
-
-> **Each sweep point re-downloads the sample → OCI egress is billed.** Keep the
-> sample small and the duration short. The sweep refuses to run without `--yes`.
-
-Reading the results: throughput that rises with streams then **flattens** marks
-the knee. If it flattens *below* the NIC and *at* the fio ceiling → VAST-bound.
-If OCI starts returning `503 SlowDown` / `429` in the worker logs → request-rate
-throttled (back off `transfers`/`checkers`, see below).
-
-### OCI transfer experiments + total transfer time
-
-`bench/oci_experiment.py` runs one transfer at a chosen node/pod concurrency,
-pins exactly `pods/node` workers to each of N nodes, and reports the **total
-transfer time** and average rate. Run to completion (full bucket) or time-box it:
-
-```bash
-# full bucket, 1 node, 24 pods/node (saturate the node), to completion:
-python3 bench/oci_experiment.py --nodes 1 --pods-per-node 24 --label full-1node
-# time-boxed steady-state probe (bounds egress):
-python3 bench/oci_experiment.py --nodes 4 --pods-per-node 16 --label probe --max-seconds 120
-```
-
-Each run writes `bench/results/oci-exp-<label>/`:
-- `summary.json` — `total_transfer_time_s`, `avg_GBps` (= bytes ÷ time, the
-  headline), `avg_GBps_per_node`, `steady_GBps`, `peak_GBps`, `completed`,
-  `failed_pods`, `throttle_signals`.
-- `timeseries.csv` — aggregate-bytes / rate over time.
-
-A run to completion is bounded by `--safety-seconds` (default 7200) so it can't
-hang on a straggler. `--stats-sample` caps how many pods are polled per tick so
-overhead stays small even with a 96-pod fleet.
+- **`make preflight`** — fio write-ceiling, one pod per node, no egress. If the
+  download later plateaus near this number, the write path is the limit.
+- **`make fio-bench`** — full fio matrix (seq/rand read+write, `direct=1`) per node →
+  git-ignored `bench/results/fio-<ts>/`. Tune `FIO_JOBS`/`FIO_IODEPTH`.
+- **`make collect`** — attach to a running fleet; log throughput → CSV.
+- **`make sweep …`** — sweep `(transfers, multi-thread-streams, pods-per-node)` on a
+  *bounded sample* to find the knee. **Bills egress**; requires `--yes`.
+- **`python3 bench/oci_experiment.py --nodes N --pods-per-node K [--max-seconds S]
+  --label NAME`** — one transfer at a chosen concurrency (pins exactly K/node);
+  reports total transfer time, avg/steady GB/s (from rclone stats **and** the node
+  NIC counters as ground truth), and throttle signals → `bench/results/oci-exp-<NAME>/`.
 
 ### Tracking a run in progress
 
 ```bash
 kubectl get pods -l app=cmk-data-transfer-worker -o wide        # phases + nodes
 kubectl logs -f cmk-data-transfer-worker-0                      # live rclone progress (one shard)
-kubectl exec cmk-data-transfer-worker-0 -- \
-  rclone rc core/stats --rc-addr localhost:5572                 # live bytes/speed for that pod
 kubectl top nodes ; kubectl top pods -l app=cmk-data-transfer-worker   # CPU/mem
 
-# overall progress in flight: sum each Running worker's bytes (RC_PORT = 5572 + index).
-# Filters to Running pods + guards non-JSON so starting/terminating pods don't error.
+# fleet-wide bytes transferred so far (RC_PORT = 5572 + index; skips not-ready pods):
 kubectl get po -l app=cmk-data-transfer-worker --field-selector=status.phase=Running \
   -o jsonpath='{range .items[*]}{.metadata.name} {range .spec.containers[0].env[?(@.name=="RC_PORT")]}{.value}{end}{"\n"}{end}' \
   | xargs -P16 -n2 sh -c 'kubectl exec "$0" -- rclone rc core/stats --rc-addr localhost:"$1" 2>/dev/null | python3 -c "import json,sys;s=sys.stdin.read().strip();print(json.loads(s).get(\"bytes\",0) if s.startswith(\"{\") else 0)"' \
   | awk '{s+=$1; n++} END{printf "fleet: %.2f TB across %d pods\n", s/1e12, n}'
 ```
-The runner also prints a per-tick line (`elapsed`, est TB, ~rate, active/failed
-pods). **Note:** rclone's own `MiB/s` in the logs is a *cumulative average* — on
-a high-RTT path it decays during the straggler tail and understates steady rate;
-trust `summary.json` / `timeseries.csv` for the real numbers.
+
+> rclone's own `MiB/s` in the logs is a *cumulative average* — on a high-RTT path it
+> decays during the straggler tail and understates steady rate. Trust the byte-delta /
+> NIC numbers from `oci_experiment.py` (`summary.json` / `timeseries.csv`).
 
 ---
 
@@ -493,46 +262,37 @@ trust `summary.json` / `timeseries.csv` for the real numbers.
 
 | Symptom | Likely cause | Lever |
 |---|---|---|
-| Throughput flat, NIC < 30% | not enough streams to fill BDP | ↑ `PODS_PER_NODE`, ↑ `--multi-thread-streams`, ↑ `--transfers`, ↓ `PER_STREAM_MBPS` |
-| One rclone process pegged / stalls below NIC | single-process ceiling | ↑ `PODS_PER_NODE` (more independent processes share the NIC) |
-| Throughput flat near fio number | VAST write ceiling | more nodes; larger `--buffer-size`; accept the ceiling |
-| `503 SlowDown` / `429` in logs | OCI request-rate throttling | ↓ `--checkers` and `--transfers`; spread the prefix |
-| High CPU, low throughput | checksum/verify overhead | add `--s3-disable-checksum` via `RCLONE_EXTRA_FLAGS` |
-| Many tiny files, slow | per-file overhead dominates | ↑ `--transfers` (streams don't help sub-cutoff files) |
-| One worker lags | shard imbalance / a slow node | check `/data/logs/worker-*.log`; re-shard |
-| Memory pressure | too many large in-flight chunks | ↓ `--multi-thread-streams` or `--multi-thread-chunk-size` |
+| Throughput flat, NIC underutilized | not enough streams to fill BDP | ↑ `PODS_PER_NODE`, ↑ `--multi-thread-streams`/`--transfers`, ↓ `PER_STREAM_MBPS` |
+| One rclone pegged / stalls below NIC | single-process ceiling | ↑ `PODS_PER_NODE` (more independent processes) |
+| Throughput flat near the fio number | disk write ceiling | more nodes; larger `--buffer-size`; accept the ceiling |
+| `503 SlowDown` / `429` in logs | object-store request-rate throttling | ↓ `--checkers`/`--transfers`; spread the prefix |
+| A few pods stall, throughput collapses | slow-connection lottery starves few slots | keep `--transfers` **high** (≈40); more pods/nodes for the tail |
+| Long finishing tail | last-chunk stragglers | more pods/nodes (smaller shards); smaller `--multi-thread-chunk-size` |
+| Memory pressure | too many large in-flight chunks | ↓ `--multi-thread-streams` / `--multi-thread-chunk-size` |
 
-`--transfers` scales **small-file** parallelism; `--multi-thread-streams` scales
-**large-file** (BDP-fill) parallelism. Tune them independently to your dataset's
-file-size distribution.
+`--transfers` scales small/medium-file and connection-churn parallelism;
+`--multi-thread-streams` scales large-file (BDP-fill) parallelism.
 
 ---
 
 ## Operational caveats
 
-- **OCI egress is billed.** Every byte pulled — and every byte re-pulled during
-  a sweep — incurs OCI Object Storage egress cost. Budget for the full dataset
-  size plus sweep samples.
-- **OCI request-rate throttling.** OCI Object Storage rate-limits requests per
-  bucket/prefix; very high `--checkers`/`--transfers` can trigger `429`/`503
-  SlowDown`. rclone retries with backoff, but sustained throttling caps
-  throughput. If you control the source layout, spreading objects across more
-  prefixes helps.
-- **VAST write ceiling** may be the real limit well before the NIC line rate —
-  always run the fio preflight so a plateau is attributed correctly.
-- **`hostNetwork: true`** means workers share the node's network namespace and
-  bind host ports — each worker's rclone rc listens on `localhost:5572+index`,
-  so the ports are unique per pod even when several run on one node. Don't
-  co-schedule other workloads that grab those ports; raise `PODS_PER_NODE`
-  thoughtfully (each pod = one more rc port + CPU/mem slice).
-
+- **Egress is billed per byte** — every pull, and every re-pull during a sweep,
+  incurs object-store egress. Budget for the dataset size plus sweep samples.
+- **Request-rate throttling** — very high `--checkers`/`--transfers` can trigger
+  `429`/`503`; rclone backs off, but sustained throttling caps throughput. Spreading
+  objects across more prefixes helps.
+- **Disk write/read ceiling** may bind before the NIC — run the fio preflight and
+  cross-check throughput against the node NIC counters.
+- **`hostNetwork: true`** — workers share the node's network namespace and bind host
+  ports (`localhost:5572+index`). Don't co-schedule workloads that grab those ports.
 
 ---
 
 ## Alternative: native OCI backend
 
 Instead of the S3-compat path you can use rclone's native `oracleobjectstorage`
-backend, which authenticates via OCI IAM (no access/secret key):
+backend (OCI IAM auth, no access/secret key):
 
 ```ini
 [oci-native]
@@ -542,12 +302,10 @@ region = <region>
 provider = user_principal_auth      # or instance_principal_auth / resource_principal_auth
 config_file = /root/.oci/config
 config_profile = DEFAULT
-# compartment = ocid1.compartment.oc1..<...>   # for bucket listing
 ```
 
-Mount your `~/.oci` config + key into the pods and point the remote at
-`oci-native:`. The S3-compat path remains the default because it matches the
-credential the customer already holds.
+Mount your `~/.oci` config + key into the pods and point the remote at `oci-native:`.
+The S3-compat path is the default because it matches the credential most users hold.
 
 ---
 
@@ -555,20 +313,21 @@ credential the customer already holds.
 
 ```
 .env.example            all inputs (copy to .env)
-Makefile                preflight / run / sweep / collect / clean
+Makefile                sizing / dry-run / preflight / run / fio-bench / sweep / collect / clean
 orchestrator/           config, BDP sizing, rclone.conf builder, kubectl, manifests, run
 shard/shard_manifest.py deterministic size-balanced LPT bin-packer (standalone + importable)
 k8s/                    reference YAML: storageclass, pvc, import-pv, nfs-pv, master/worker pods, secret example
-bench/                  collect.py (throughput → CSV), sweep.py (parameter sweep)
-preflight/              fio VAST write-ceiling test (yaml + run_fio.py)
+bench/                  oci_experiment.py, collect.py, sweep.py, fio/
+preflight/              fio write-ceiling test (yaml + run_fio.py)
 ```
 
 ## Requirements
 
-- `python3 >= 3.9` and `kubectl` on the operator workstation (stdlib only — no
-  pip install required; the orchestrator shells out to `kubectl`).
-- A `KUBECONFIG` with access to the CMK cluster and schedulable `s2a` nodes.
-- OCI Customer Secret Key with read access to the source bucket.
+- `python3 >= 3.9` and `kubectl` on the operator workstation (stdlib only — the
+  orchestrator shells out to `kubectl`).
+- A `KUBECONFIG` with access to the CMK cluster and schedulable worker nodes
+  (`INSTANCE_CLASS`, default `s2a`).
+- An S3-compatible access/secret key with read access to the source bucket.
 
 ---
 

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -1,14 +1,14 @@
-# cmk-data-transfer
+# CMK Cross Region Object Storage Data Transfer
 
 Parallel-pull a dataset from **any S3-compatible object store** to a
-**VAST-backed shared disk** on **Crusoe Managed Kubernetes (CMK)**, engineered to
+**VAST-backed PB Scale shared disk** on **Crusoe Managed Kubernetes (CMK)**, engineered to
 saturate worker hosts across a high-latency path. **OCI Object Storage is the
-worked example throughout** (it's the case this was built for), but the source
+worked example throughout** but the source
 backend is rclone's generic `provider = Other`, so AWS S3, MinIO/Ceph, GCS (S3
 interop), Cloudflare R2, Backblaze B2, etc. work too — point `OCI_ENDPOINT` at
 the store (see [Other S3-compatible sources](#other-s3-compatible-sources)).
 
-The shape follows Crusoe's AWS-S3 "rclone parallel streams" reference: a master
+The shape follows Crusoe's AWS-S3 ["rclone parallel streams"](https://support.crusoecloud.com/hc/en-us/articles/37041258573723-How-To-Download-Data-From-AWS-S3-Using-Rclone-Parallel-Streams) reference: a master
 pod lists the source and writes balanced shard manifests to a shared disk; N
 worker pods each take one shard and `rclone copy` it in parallel — tuned for a
 **high-RTT path** where throughput comes from **massive concurrency**, not from
@@ -22,7 +22,7 @@ large files.
 cp .env.example .env          # fill in OCI / other object storage creds, namespace, region, bucket
 make sizing                   # (OPTIONAL) show the BDP/target concurrency plan (no cluster)
 make dry-run                  # render manifests + preflight checks (launches nothing)
-make preflight                # measure the VAST write ceiling with fio (safe, no egress)
+make preflight                # (OPTIONAL) measure the shared-disk write ceiling with fio (safe, no third party egress)
 make run                      # full pipeline; PROMPTS before the large transfer
 ```
 
@@ -56,7 +56,7 @@ make run                      # full pipeline; PROMPTS before the large transfer
           │              │                    │              │  hundreds of parallel
           ▼              ▼                    ▼              ▼  ranged-GET streams
         ┌──────────────────────────────────────────────────┐
-        │   OCI Object Storage  (S3-compatible endpoint)     │   >150 ms RTT
+        │   OCI Object Storage  (S3-compatible endpoint)     │   > e.g. 150 ms RTT
         │   https://<ns>.compat.objectstorage.<region>....   │   (intercontinental)
         └──────────────────────────────────────────────────┘
 ```
@@ -97,7 +97,7 @@ With a typical autotuned window of ~16 MB:
 16 MB × 8 bits / 0.150 s  ≈  853 Mbps  per stream
 ```
 
-…and that's the ceiling **regardless of how large the file is**. A 100 GB file
+At high latencies, that's the ceiling **regardless of how large the file is**. A 100 GB file
 pulled on one stream still moves at ~0.85 Gbps. So aggregate throughput has to
 come from running **many streams in parallel** to fill the bandwidth-delay
 product (BDP) of each node's NIC.

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -1,0 +1,515 @@
+# cmk-data-transfer
+
+Parallel-pull a dataset from **any S3-compatible object store** to a
+**VAST-backed shared disk** on **Crusoe Managed Kubernetes (CMK)**, engineered to
+saturate worker hosts across a high-latency path. **OCI Object Storage is the
+worked example throughout** (it's the case this was built for), but the source
+backend is rclone's generic `provider = Other`, so AWS S3, MinIO/Ceph, GCS (S3
+interop), Cloudflare R2, Backblaze B2, etc. work too — point `OCI_ENDPOINT` at
+the store (see [Other S3-compatible sources](#other-s3-compatible-sources)).
+
+The shape follows Crusoe's AWS-S3 "rclone parallel streams" reference: a master
+pod lists the source and writes balanced shard manifests to a shared disk; N
+worker pods each take one shard and `rclone copy` it in parallel — tuned for a
+**high-RTT path** where throughput comes from **massive concurrency**, not from
+large files.
+
+---
+
+## TL;DR
+
+```bash
+cp .env.example .env          # fill in OCI creds, namespace, region, bucket
+make sizing                   # show the BDP/target concurrency plan (no cluster)
+make dry-run                  # render manifests + preflight checks (launches nothing)
+make preflight                # measure the VAST write ceiling with fio (safe, no egress)
+make run                      # full pipeline; PROMPTS before the large transfer
+```
+
+---
+
+## Architecture
+
+```
+        operator workstation (this repo, python3 + kubectl)
+        │  build rclone.conf → K8s Secret (creds never touch the repo)
+        │  list (via master) → bin-pack shards locally → push to shared disk
+        ▼
+┌──────────────────────────── Crusoe Managed Kubernetes ───────────────────────┐
+│                                                                               │
+│   Secret(rclone.conf, RO)        PVC: crusoe-csi-driver-fs-sc (VAST, RWX)     │
+│        │  mounted RO into all pods         │  mounted into all pods           │
+│        ▼                                   ▼                                  │
+│   ┌─────────────┐   rclone lsf      ┌─────────────────────────────────────┐  │
+│   │ master pod  │ ───────────────►  │  shared disk  /data                 │  │
+│   │ (rclone img)│   shards pushed   │   /shards/shard-0..N-1.txt          │  │
+│   └─────────────┘ ◄───────────────  │   /logs/worker-*.log                │  │
+│                                     │   /dataset/...  (downloaded objects)│  │
+│                                     └─────────────────────────────────────┘  │
+│                                                  ▲  ▲  ▲  ▲                    │
+│   K workers PER s2a node (topology-spread even, hostNetwork, unique rc port):  │
+│   ┌───────── node 1 ─────────┐        ┌───────── node N ─────────┐            │
+│   │ w0  w1  w2  w3 (shards)  │  ...   │ wK ... w(K+3)            │             │
+│   │ share the 200 Gbps NIC   │        │ share the 200 Gbps NIC   │            │
+│   └─────┬──────────────┬─────┘        └─────┬──────────────┬─────┘            │
+└─────────┼──────────────┼────────────────────┼──────────────┼──────────────────┘
+          │              │                    │              │  hundreds of parallel
+          ▼              ▼                    ▼              ▼  ranged-GET streams
+        ┌──────────────────────────────────────────────────┐
+        │   OCI Object Storage  (S3-compatible endpoint)     │   >150 ms RTT
+        │   https://<ns>.compat.objectstorage.<region>....   │   (intercontinental)
+        └──────────────────────────────────────────────────┘
+```
+
+The fleet runs **`PODS_PER_NODE` independent rclone processes on each node** —
+multiple processes saturate the shared 200 Gbps NIC better than one big rclone
+(a single process can hit internal ceilings: one `http.Transport`, GC, lock
+contention). Each worker pod:
+
+- **`hostNetwork: true`** — bypasses the CNI datapath and uses the node's NIC
+  directly. Because hostNetwork pods share the node's network namespace, each
+  worker binds a **unique rclone rc port** (`5572 + index`) so co-located
+  workers don't collide.
+- **`topologySpreadConstraints` (maxSkew=1 on `kubernetes.io/hostname`)** —
+  spreads workers *evenly* so each node gets `PODS_PER_NODE`, not a pile-up on
+  one node. CPU/memory requests are auto-sized so exactly that many pack per
+  node (with system headroom).
+- **`nodeSelector: crusoe.ai/instance.class: s2a`** — pins to the storage SKU.
+- mounts the **RWX VAST PVC** read-write and the **rclone Secret** read-only,
+  takes one shard, writes into the shared `/data/dataset`.
+
+---
+
+## The AWS → OCI adaptation
+
+| Aspect | AWS reference | This repo (OCI) |
+|---|---|---|
+| Source backend | rclone `s3`, `provider = AWS`, `env_auth` | rclone `s3`, `provider = Other`, explicit `endpoint` + `force_path_style` |
+| Endpoint | AWS default | `https://<namespace>.compat.objectstorage.<region>.oraclecloud.com` |
+| Credential | AWS access/secret key | **OCI Customer Secret Key** (S3-compat access/secret pair) |
+| Credential delivery | env vars from a Secret | full `rclone.conf` in a Secret, **mounted read-only** at `/config` |
+| Listing | `boto3` on the workstation | `rclone lsf` **in-cluster** (no boto3, no WAN listing, works for OCI) |
+| Sharding | greedy LPT bin-pack (local) | same LPT bin-pack (local), pushed to the shared disk |
+| Node pinning | `nodeSelector` only, pods land unevenly | `nodeSelector` **+ topology-spread (even K/node)** + auto-sized requests |
+| `--files-from` copy | no `--no-traverse` | **`--no-traverse`** (don't list the destination tree) |
+| Concurrency | fixed `--transfers=40 --multi-thread-streams=40` | **derived from `TARGET_GBPS`, node count, NIC, and the 150 ms BDP** |
+| Instance class | `s1a` | `s2a` |
+
+A native `oracleobjectstorage` backend is also available (see
+[Alternative: native OCI backend](#alternative-native-oci-backend)), but it uses
+OCI IAM (user/instance/resource principal) rather than the access/secret key the
+customer has, so the **S3-compatible path is the default**.
+
+> **Bugs fixed from the reference script** (for anyone comparing):
+> the reference's worker `rclone.conf` heredoc was missing its `>` redirect, its
+> prefix expression had a malformed comparison, and it set no `--no-traverse`.
+> It also used `nodeSelector` alone with **no spread constraint**, so its 8 pods
+> could land unevenly across nodes; here `topologySpreadConstraints` + auto-sized
+> requests place exactly `PODS_PER_NODE` workers on every node.
+
+---
+
+## Why concurrency, not file size: the 150 ms BDP
+
+Over a >150 ms intercontinental path a single TCP stream is **window-limited**:
+
+```
+per_stream_throughput  ≈  tcp_window / RTT
+```
+
+With a typical autotuned window of ~16 MB:
+
+```
+16 MB × 8 bits / 0.150 s  ≈  853 Mbps  per stream
+```
+
+…and that's the ceiling **regardless of how large the file is**. A 100 GB file
+pulled on one stream still moves at ~0.85 Gbps. So aggregate throughput has to
+come from running **many streams in parallel** to fill the bandwidth-delay
+product (BDP) of each node's NIC.
+
+**BDP of one `s2a` node's 200 Gbps NIC at 150 ms:**
+
+```
+200e9 bits/s × 0.150 s  =  30e9 bits  =  3.75 GB  must be "in flight" to fill the pipe
+```
+
+**Streams needed to fill it** (using a deliberately conservative ~250 Mbps per
+untuned stream, with a 1.5× safety factor):
+
+```
+200 Gbps ÷ 0.25 Gbps/stream  ≈  800 streams to fill the NIC
+60  Gbps ÷ 0.25 Gbps/stream × 1.5  ≈  360 streams for a 60 Gbps/node target
+```
+
+rclone exposes two multiplicative concurrency levers:
+
+- **`--transfers`** — number of files copied in parallel (also the *only*
+  parallelism for files **below** `--multi-thread-cutoff`, since each gets one
+  stream).
+- **`--multi-thread-streams`** — ranged-GET streams per *single* file, for files
+  **above** the cutoff (default 256 MiB). This is what fills the per-large-file
+  BDP. (Multi-thread **downloads** are supported since rclone v1.63.)
+
+So **in-flight streams per pod ≈ `transfers × multi-thread-streams`** for large
+files. The orchestrator derives both from `TARGET_GBPS`; see `make sizing`.
+
+---
+
+## Throughput target math
+
+`TARGET_GBPS` is the single sizing knob (default 30). To convert a daily volume
+into a rate:
+
+| GB/s | PB/day | per-node (4 nodes) | % of 200 Gbps NIC |
+|---|---|---|---|
+| 11.6 | 1.0 | 2.9 GB/s = 23 Gbps | 12% |
+| 30   | 2.6 | 7.5 GB/s = 60 Gbps | 30% |
+
+Four `s2a` nodes provide `4 × 200 Gbps ≈ 100 GB/s` of NIC line rate, so a
+30 GB/s target is ~30% of the ceiling — feasible **on the network**. The real
+binding constraint is usually **object-store egress throttling / request-rate
+limits** or the **VAST write ceiling** ([Caveats](#operational-caveats)) — which
+is why this repo ships a fio write-ceiling preflight and a throughput sweep.
+
+### Fleet sizing is a function of `TARGET_GBPS`, `NUM_NODES`, and `PODS_PER_NODE`
+
+The per-node stream budget is the same (BDP-driven); it's then **divided across
+`PODS_PER_NODE` independent rclone processes**, and CPU/mem requests are sized so
+exactly that many pack per node:
+
+```
+per_node_gbps      = TARGET_GBPS / NUM_NODES            (capped at 90% of NIC)
+streams_per_node   = ceil(per_node_gbps × 1000 / PER_STREAM_MBPS × STREAM_SAFETY)
+streams_per_pod    = ceil(streams_per_node / PODS_PER_NODE)
+multi_thread_streams = clamp(streams_per_pod, 4..8)              # per pod
+transfers          = ceil(streams_per_pod / multi_thread_streams)  # per pod, ≤ 2×(vCPU/pods)
+checkers           = min(2 × transfers, 256)                    # per pod
+cpu_request/pod    = (vCPU − headroom) / PODS_PER_NODE
+```
+
+Defaults for **30 GB/s across 4 nodes at 8 pods/node** (`make sizing`):
+
+```
+nodes x pods/node          4 x 8 = 32 worker pods
+streams needed / node      360   ->  45 / pod
+=> PER POD: --transfers 6  --multi-thread-streams 8  (--checkers omitted)
+   in-flight streams/pod 48 ; per-node 384 ; fleet 1536
+   pod requests cpu=9 mem=8Gi  (8 × 9 = 72 vCPU, fits 80 with headroom)
+```
+
+Override any derived value with env vars or flags (e.g.
+`make run TARGET_GBPS=11.6 PODS_PER_NODE=16`, or `--pods-per-node 6 --transfers 40`).
+`PODS_PER_NODE` is itself a throughput lever — sweep it (below) to find where
+more processes stop helping. To pin per-pod concurrency to the AWS-S3 reference,
+set `RCLONE_TRANSFERS=40 RCLONE_MULTI_THREAD_STREAMS=40`.
+
+> `PER_STREAM_MBPS` (default 250) is intentionally pessimistic. If you tune host
+> TCP buffers or OCI gives you more per-connection throughput, fewer streams are
+> needed; the sweep harness finds the real knee empirically.
+
+---
+
+## Discovered `s2a` hardware
+
+The sizing model is grounded in the `s2a.80x` SKU shape (product facts, observed
+via a diagnostic pod):
+
+| Resource | Per node |
+|---|---|
+| vCPU | 80 (AMD, AVX-512) |
+| RAM | ~676 GiB |
+| NIC | single 200 Gbps (Mellanox `mlx5`) |
+| 4-node fleet line rate | 800 Gbps ≈ 100 GB/s |
+
+---
+
+## Configuration
+
+All inputs come from `.env` (copied from `.env.example`), process env, or CLI
+flags — **never hardcoded**. CLI flags > process env > `.env`.
+
+| Variable | Meaning |
+|---|---|
+| `OCI_ACCESS_KEY_ID` / `OCI_SECRET_ACCESS_KEY` | OCI Customer Secret Key (S3-compat pair) |
+| `OCI_NAMESPACE` | Object Storage namespace (builds the endpoint) |
+| `OCI_REGION` | OCI region slug, e.g. `us-phoenix-1` / `us-ashburn-1` |
+| `OCI_BUCKET` / `OCI_PREFIX` | source bucket and optional prefix |
+| `TARGET_GBPS` | **the single sizing knob** (default 30) |
+| `NUM_NODES` / `PODS_PER_NODE` | fleet size; total pods = nodes × pods/node (`NUM_PODS` forces an absolute total) |
+| `RTT_MS` / `PER_STREAM_MBPS` / `STREAM_SAFETY` | BDP model inputs |
+| `STORAGE_CLASS` / `PVC_NAME` / `PVC_SIZE` | VAST destination disk |
+| `DEST_MODE` | `dynamic` / `import` / `nfs` destination (see below) |
+| `EXISTING_DISK_ID` / `_NAME` / `_SERIAL` / `NFS_SERVER` | bind an existing disk (import/nfs modes) |
+| `RCLONE_*` | per-flag overrides (blank = auto-derive) |
+
+> **Region note:** use the **OCI** region slug where the *bucket* lives (not your
+> destination/cloud region). Preflight warns if the slug doesn't look like OCI.
+
+### Other S3-compatible sources
+
+The source backend is rclone `provider = Other`, so any S3-compatible store
+works. The `OCI_*` env names are just labels — for a non-OCI store, set
+`OCI_ENDPOINT` to its S3 endpoint and use its access/secret key + bucket. OCI is
+the only one that auto-builds the endpoint from `OCI_NAMESPACE` + `OCI_REGION`;
+everything else just needs `OCI_ENDPOINT`:
+
+| Source | `OCI_ENDPOINT` | Notes |
+|---|---|---|
+| OCI Object Storage | *(auto from namespace+region)* | the worked example |
+| AWS S3 | `https://s3.<region>.amazonaws.com` | or leave blank with a real AWS key |
+| MinIO / Ceph RGW | `https://<host>:<port>` | self-hosted |
+| Google Cloud Storage | `https://storage.googleapis.com` | S3 interop + HMAC key |
+| Cloudflare R2 | `https://<account>.r2.cloudflarestorage.com` | |
+| Backblaze B2 | `https://s3.<region>.backblazeb2.com` | |
+
+`force_path_style` and `no_check_bucket` are set for broad compatibility. Egress
+pricing and request-rate limits vary by provider — see [Caveats](#operational-caveats).
+
+### Secrets handling
+
+The credential is assembled into a complete `rclone.conf` and placed **only** in
+a Kubernetes Secret, mounted **read-only** (`0400`) at `/config/rclone.conf`. It
+never lands in the repo, in pod args, or in shell history. `.gitignore` blocks
+`.env`, `rclone.conf`, and `*-secret.yaml`.
+
+---
+
+## What `make run` does
+
+1. **Plan + sizing** — prints the BDP-derived concurrency.
+2. **Preflight** — verifies `kubectl` reachability, that enough schedulable
+   `s2a` nodes exist, and that the `crusoe-csi-driver-fs-sc` StorageClass
+   exists (creates it if absent — this cluster ships the fs CSI driver but not
+   always the StorageClass object).
+3. **Secret** — builds `rclone.conf`, applies it in-cluster.
+4. **PVC + master pod** — applies the RWX VAST claim and the master pod.
+5. **List** — `rclone lsf --recursive --files-only --format sp` in the master
+   pod → `/data/listing.tsv`.
+6. **Shard** — pulls the listing, bin-packs (LPT) into N balanced shard files
+   locally, pushes them to `/data/shards/`.
+7. **Confirm** — *prompts before launching the large transfer* (skip with
+   `--yes`).
+8. **Launch** — one worker pod per node, each `rclone copy --files-from
+   shard-i.txt --no-traverse …`.
+9. **Monitor** — polls pod phases to completion.
+10. **Teardown** — deletes worker + master pods (keeps PVC, Secret, data) unless
+    `--keep`.
+
+Idempotent: `rclone copy` skips objects already present (size/checksum), so a
+re-run only fetches what's missing.
+
+---
+
+## Destination modes (`DEST_MODE`)
+
+The tool can target the VAST shared disk three ways:
+
+| `DEST_MODE` | What it does | Needs | When |
+|---|---|---|---|
+| `dynamic` (default) | provisions a new disk via the fs CSI driver | — | greenfield |
+| `import` | binds an **existing** disk via a CSI **static PV** | disk `id` + `name` + `serial` | migrate into an existing disk, CSI healthy |
+| `nfs` | binds an **existing** disk via an **in-tree NFS PV** straight to the VAST DNS endpoint (bypasses CSI) | disk `id` (+ `NFS_SERVER`) | when the CSI mount times out on an unroutable fallback IP |
+
+Find the disk's identity with `crusoe storage disks list -f json` (pick the
+`shared-volume` in your region): `.id`, `.name`, `.serial_number`. All modes use
+`reclaimPolicy: Retain`, so deleting the PVC/PV never deletes the disk or data.
+
+### `nfs` mode — when the CSI mount times out
+
+If the fs CSI driver can't get a disk's "data path connectivity fields" it falls
+back to a fixed IP that may be **unroutable from your nodepool**, so `dynamic`
+and `import` mounts hang and time out. The **VAST DNS endpoint mounts cleanly**,
+though — `nfs.crusoecloudcompute.com` resolves to the in-VPC VAST data IPs. `nfs`
+mode creates an in-tree NFS PV that mounts it directly with `remoteports=dns`:
+
+```bash
+DEST_MODE=nfs  EXISTING_DISK_ID=<disk-id>   # NFS_SERVER defaults to nfs.crusoecloudcompute.com
+make run                                     # (or --dest-mode nfs --import-disk-id <id>)
+```
+
+The orchestrator generates the PV/PVC (see `k8s/nfs-pv.yaml` for the manual /
+`envsubst` equivalent), skips the StorageClass, and the workers write into the
+existing disk. `PVC_SIZE` is the PV capacity; the NFS path is
+`/volumes/<EXISTING_DISK_ID>` (override with `NFS_EXPORT_PATH`).
+
+> The CSI `import` PV mirrors what the provisioner emits, so it mounts
+> identically to a `dynamic` claim — and hits the same CSI fallback if that's
+> the problem. If a CSI mount hangs, prefer `nfs`.
+
+## Benchmarking & finding the binding constraint
+
+**VAST write ceiling (run first, no egress):**
+
+```bash
+make preflight                       # one fio pod per node → aggregate write GB/s
+# or: python3 preflight/run_fio.py --nodes 4 --size 20G --jobs 8 --bs 4M
+```
+
+If the download later plateaus near the fio number, the **write path** is the
+limit — not OCI or the NIC.
+
+**Disk read+write benchmark (fio on every node):** one fio pod per node, four
+stonewalled profiles (seq/rand read+write, `direct=1`). Results saved to
+git-ignored `bench/results/fio-<ts>/` (per-node JSON + `summary.csv`):
+
+```bash
+make fio-bench                       # → per-node + aggregate GB/s and IOPS
+# default 16 jobs x iodepth 32/node; push harder with FIO_JOBS=32 FIO_IODEPTH=64
+# standalone: python3 bench/fio/run_fio_bench.py --jobs 16 --iodepth 32 --runtime 30
+```
+
+Throughput scales with `FIO_JOBS × FIO_IODEPTH` (in-region disk — concurrency,
+not window, is the lever). The runner skips unschedulable nodes and lists any it
+missed. Sequential-read numbers can be inflated by server-side caching; treat
+read as an upper bound unless the working set exceeds the cache.
+
+**Throughput collector** (attach to a running fleet; polls each worker's rclone
+remote-control `core/stats`):
+
+```bash
+make collect                         # → bench/results/throughput.csv + peak/median
+```
+
+**Parameter sweep** over `(transfers, multi-thread-streams, pods-per-node)` on a
+*bounded sample* to find the saturation knee — including where adding more pods
+per node stops helping:
+
+```bash
+make sweep SAMPLE_PREFIX=smoke-set/ TRANSFERS_GRID=16,32,48 MTS_GRID=4,8 \
+           PODS_PER_NODE_GRID=2,4,8 MAX_SECONDS=120
+# → bench/results/sweep.csv, ranked by peak aggregate GB/s
+```
+
+> **Each sweep point re-downloads the sample → OCI egress is billed.** Keep the
+> sample small and the duration short. The sweep refuses to run without `--yes`.
+
+Reading the results: throughput that rises with streams then **flattens** marks
+the knee. If it flattens *below* the NIC and *at* the fio ceiling → VAST-bound.
+If OCI starts returning `503 SlowDown` / `429` in the worker logs → request-rate
+throttled (back off `transfers`/`checkers`, see below).
+
+### OCI transfer experiments + total transfer time
+
+`bench/oci_experiment.py` runs one transfer at a chosen node/pod concurrency,
+pins exactly `pods/node` workers to each of N nodes, and reports the **total
+transfer time** and average rate. Run to completion (full bucket) or time-box it:
+
+```bash
+# full bucket, 1 node, 24 pods/node (saturate the node), to completion:
+python3 bench/oci_experiment.py --nodes 1 --pods-per-node 24 --label full-1node
+# time-boxed steady-state probe (bounds egress):
+python3 bench/oci_experiment.py --nodes 4 --pods-per-node 16 --label probe --max-seconds 120
+```
+
+Each run writes `bench/results/oci-exp-<label>/`:
+- `summary.json` — `total_transfer_time_s`, `avg_GBps` (= bytes ÷ time, the
+  headline), `avg_GBps_per_node`, `steady_GBps`, `peak_GBps`, `completed`,
+  `failed_pods`, `throttle_signals`.
+- `timeseries.csv` — aggregate-bytes / rate over time.
+
+A run to completion is bounded by `--safety-seconds` (default 7200) so it can't
+hang on a straggler. `--stats-sample` caps how many pods are polled per tick so
+overhead stays small even with a 96-pod fleet.
+
+### Tracking a run in progress
+
+```bash
+kubectl get pods -l app=cmk-data-transfer-worker -o wide        # phases + nodes
+kubectl logs -f cmk-data-transfer-worker-0                      # live rclone progress (one shard)
+kubectl exec cmk-data-transfer-worker-0 -- \
+  rclone rc core/stats --rc-addr localhost:5572                 # live bytes/speed for that pod
+kubectl top nodes ; kubectl top pods -l app=cmk-data-transfer-worker   # CPU/mem
+```
+The runner also prints a per-tick line (`elapsed`, est TB, ~rate, active/failed
+pods). **Note:** rclone's own `MiB/s` in the logs is a *cumulative average* — on
+a high-RTT path it decays during the straggler tail and understates steady rate;
+trust `summary.json` / `timeseries.csv` for the real numbers.
+
+---
+
+## Tuning guide
+
+| Symptom | Likely cause | Lever |
+|---|---|---|
+| Throughput flat, NIC < 30% | not enough streams to fill BDP | ↑ `PODS_PER_NODE`, ↑ `--multi-thread-streams`, ↑ `--transfers`, ↓ `PER_STREAM_MBPS` |
+| One rclone process pegged / stalls below NIC | single-process ceiling | ↑ `PODS_PER_NODE` (more independent processes share the NIC) |
+| Throughput flat near fio number | VAST write ceiling | more nodes; larger `--buffer-size`; accept the ceiling |
+| `503 SlowDown` / `429` in logs | OCI request-rate throttling | ↓ `--checkers` and `--transfers`; spread the prefix |
+| High CPU, low throughput | checksum/verify overhead | add `--s3-disable-checksum` via `RCLONE_EXTRA_FLAGS` |
+| Many tiny files, slow | per-file overhead dominates | ↑ `--transfers` (streams don't help sub-cutoff files) |
+| One worker lags | shard imbalance / a slow node | check `/data/logs/worker-*.log`; re-shard |
+| Memory pressure | too many large in-flight chunks | ↓ `--multi-thread-streams` or `--multi-thread-chunk-size` |
+
+`--transfers` scales **small-file** parallelism; `--multi-thread-streams` scales
+**large-file** (BDP-fill) parallelism. Tune them independently to your dataset's
+file-size distribution.
+
+---
+
+## Operational caveats
+
+- **OCI egress is billed.** Every byte pulled — and every byte re-pulled during
+  a sweep — incurs OCI Object Storage egress cost. Budget for the full dataset
+  size plus sweep samples.
+- **OCI request-rate throttling.** OCI Object Storage rate-limits requests per
+  bucket/prefix; very high `--checkers`/`--transfers` can trigger `429`/`503
+  SlowDown`. rclone retries with backoff, but sustained throttling caps
+  throughput. If you control the source layout, spreading objects across more
+  prefixes helps.
+- **VAST write ceiling** may be the real limit well before the NIC line rate —
+  always run the fio preflight so a plateau is attributed correctly.
+- **CSI mount vs. NFS mount:** if the fs CSI driver falls back to an unroutable
+  IP and mounts time out, use `DEST_MODE=nfs` to mount the VAST DNS endpoint
+  directly. Verify mountability before a big run with a one-off pod that writes
+  to the PVC.
+- **`hostNetwork: true`** means workers share the node's network namespace and
+  bind host ports — each worker's rclone rc listens on `localhost:5572+index`,
+  so the ports are unique per pod even when several run on one node. Don't
+  co-schedule other workloads that grab those ports; raise `PODS_PER_NODE`
+  thoughtfully (each pod = one more rc port + CPU/mem slice).
+- **`1000Ti` PVC** is a request ceiling, not a reservation; size it to your
+  dataset.
+
+---
+
+## Alternative: native OCI backend
+
+Instead of the S3-compat path you can use rclone's native `oracleobjectstorage`
+backend, which authenticates via OCI IAM (no access/secret key):
+
+```ini
+[oci-native]
+type = oracleobjectstorage
+namespace = <namespace>
+region = <region>
+provider = user_principal_auth      # or instance_principal_auth / resource_principal_auth
+config_file = /root/.oci/config
+config_profile = DEFAULT
+# compartment = ocid1.compartment.oc1..<...>   # for bucket listing
+```
+
+Mount your `~/.oci` config + key into the pods and point the remote at
+`oci-native:`. The S3-compat path remains the default because it matches the
+credential the customer already holds.
+
+---
+
+## Repo layout
+
+```
+.env.example            all inputs (copy to .env)
+Makefile                preflight / run / sweep / collect / clean
+orchestrator/           config, BDP sizing, rclone.conf builder, kubectl, manifests, run
+shard/shard_manifest.py deterministic size-balanced LPT bin-packer (standalone + importable)
+k8s/                    reference YAML: storageclass, pvc, import-pv, nfs-pv, master/worker pods, secret example
+bench/                  collect.py (throughput → CSV), sweep.py (parameter sweep)
+preflight/              fio VAST write-ceiling test (yaml + run_fio.py)
+```
+
+## Requirements
+
+- `python3 >= 3.9` and `kubectl` on the operator workstation (stdlib only — no
+  pip install required; the orchestrator shells out to `kubectl`).
+- A `KUBECONFIG` with access to the CMK cluster and schedulable `s2a` nodes.
+- OCI Customer Secret Key with read access to the source bucket.

--- a/cmk-data-transfer/README.md
+++ b/cmk-data-transfer/README.md
@@ -476,10 +476,10 @@ kubectl exec cmk-data-transfer-worker-0 -- \
   rclone rc core/stats --rc-addr localhost:5572                 # live bytes/speed for that pod
 kubectl top nodes ; kubectl top pods -l app=cmk-data-transfer-worker   # CPU/mem
 
-# overall progress in flight: sum bytes across the whole fleet (RC_PORT = 5572 + index)
+# overall progress in flight: sum each worker's transferred bytes (RC_PORT = 5572 + index)
 kubectl get po -l app=cmk-data-transfer-worker -o jsonpath='{range .items[*]}{.metadata.name} {range .spec.containers[0].env[?(@.name=="RC_PORT")]}{.value}{end}{"\n"}{end}' \
-  | xargs -P16 -n2 sh -c 'kubectl exec $0 -- rclone rc core/stats --rc-addr localhost:$1 2>/dev/null' \
-  | grep -o '"bytes":[0-9]*' | awk -F: '{s+=$2} END{printf "fleet transferred: %.2f TB\n", s/1e12}'
+  | xargs -P16 -n2 sh -c 'kubectl exec $0 -- rclone rc core/stats --rc-addr localhost:$1 2>/dev/null | python3 -c "import json,sys;print(json.load(sys.stdin).get(\"bytes\",0))"' \
+  | awk '{s+=$1} END{printf "fleet transferred: %.2f TB\n", s/1e12}'
 ```
 The runner also prints a per-tick line (`elapsed`, est TB, ~rate, active/failed
 pods). **Note:** rclone's own `MiB/s` in the logs is a *cumulative average* — on

--- a/cmk-data-transfer/bench/__init__.py
+++ b/cmk-data-transfer/bench/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark harness: throughput collection + parameter sweep."""

--- a/cmk-data-transfer/bench/collect.py
+++ b/cmk-data-transfer/bench/collect.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Throughput collector.
+
+Polls each worker pod's rclone remote-control endpoint (core/stats) and records
+cumulative bytes + instantaneous speed per pod and in aggregate to a CSV, so we
+can plot the throughput-over-time curve and find the saturation knee.
+
+Each worker runs rclone with `--rc --rc-addr localhost:5572 --rc-no-auth`, so we
+query it from inside the pod:
+    kubectl exec <pod> -- rclone rc core/stats --rc-addr localhost:5572
+
+Usage:
+    python3 bench/collect.py --namespace default --interval 10 \
+        --out bench/results/run.csv [--max-seconds 600]
+Stops when all worker pods have completed, or --max-seconds elapses.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import time
+
+WORKER_LABEL = "cmk-data-transfer-worker"
+
+
+def _kubectl(ns, *args, check=True):
+    return subprocess.run(["kubectl", "-n", ns, *args],
+                          capture_output=True, text=True, check=check)
+
+
+def list_workers(ns: str) -> list[dict]:
+    out = _kubectl(ns, "get", "pods", "-l", f"app={WORKER_LABEL}",
+                   "-o", "json").stdout
+    return json.loads(out).get("items", [])
+
+
+def rc_port(pod: dict) -> str:
+    """Each worker binds a unique rc port (RC_PORT env); default 5572."""
+    for c in pod.get("spec", {}).get("containers", []):
+        for e in c.get("env", []):
+            if e.get("name") == "RC_PORT" and e.get("value"):
+                return e["value"]
+    return "5572"
+
+
+def pod_stats(ns: str, pod: str, port: str) -> dict | None:
+    """Return rclone core/stats dict, or None if rc not reachable yet."""
+    r = _kubectl(ns, "exec", pod, "--", "rclone", "rc", "core/stats",
+                 "--rc-addr", f"localhost:{port}", check=False)
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--namespace", default="default")
+    p.add_argument("--interval", type=int, default=10)
+    p.add_argument("--out", default="bench/results/throughput.csv")
+    p.add_argument("--max-seconds", type=int, default=0,
+                   help="0 = run until all workers complete")
+    args = p.parse_args(argv)
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    t0 = time.time()
+    rows = []
+    peak_aggr = 0.0
+
+    with open(args.out, "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["elapsed_s", "pod", "bytes", "speed_Bps",
+                    "transfers", "errors", "aggregate_GBps"])
+
+        while True:
+            elapsed = time.time() - t0
+            pods = list_workers(args.namespace)
+            if not pods:
+                print("no worker pods found; exiting")
+                break
+
+            active = 0
+            aggr_speed = 0.0
+            sample = []
+            for pod in pods:
+                name = pod["metadata"]["name"]
+                phase = pod["status"]["phase"]
+                if phase not in ("Succeeded", "Failed"):
+                    active += 1
+                st = pod_stats(args.namespace, name, rc_port(pod))
+                if st is None:
+                    continue
+                speed = float(st.get("speed", 0.0))
+                aggr_speed += speed
+                sample.append((name, int(st.get("bytes", 0)), speed,
+                               int(st.get("transfers", 0)),
+                               int(st.get("errors", 0))))
+
+            aggr_gbps = aggr_speed / 1e9
+            peak_aggr = max(peak_aggr, aggr_gbps)
+            for name, b, speed, tr, errs in sample:
+                w.writerow([f"{elapsed:.1f}", name, b, f"{speed:.0f}",
+                            tr, errs, f"{aggr_gbps:.3f}"])
+                rows.append(aggr_gbps)
+            fh.flush()
+
+            print(f"[{elapsed:6.0f}s] active={active} "
+                  f"aggregate={aggr_gbps:6.3f} GB/s  peak={peak_aggr:6.3f} GB/s")
+
+            if active == 0:
+                print("all workers complete")
+                break
+            if args.max_seconds and elapsed >= args.max_seconds:
+                print("max-seconds reached")
+                break
+            time.sleep(args.interval)
+
+    # summary
+    sustained = sorted(rows)[len(rows) // 2] if rows else 0.0
+    print("\n--- summary ---")
+    print(f"  peak aggregate     : {peak_aggr:.3f} GB/s")
+    print(f"  median aggregate   : {sustained:.3f} GB/s")
+    print(f"  csv                : {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmk-data-transfer/bench/fio/fio-bench-job.yaml
+++ b/cmk-data-transfer/bench/fio/fio-bench-job.yaml
@@ -1,0 +1,87 @@
+# Disk benchmark: one fio pod per s2a node, against the shared VAST PVC.
+#
+# Runs four stonewalled (sequential) fio profiles against a single per-node file
+# so reads measure data actually on VAST (direct=1 bypasses the page cache):
+#   seqwrite  (1M)  -> sequential write bandwidth
+#   seqread   (1M)  -> sequential read bandwidth (re-reads the written file)
+#   randwrite (4k)  -> random write IOPS
+#   randread  (4k)  -> random read IOPS
+#
+# Reproducible standalone:
+#   export INSTANCE_CLASS=s2a PVC_NAME=cmk-data-transfer-nfs IMAGE=alpine:3.20 \
+#          COMPLETIONS=4 PARALLELISM=4 FIO_SIZE=4G FIO_JOBS=16 FIO_IODEPTH=32 \
+#          FIO_RUNTIME=30 FIO_DIRECT=1
+#   envsubst < bench/fio/fio-bench-job.yaml | kubectl apply -f -
+#   kubectl wait --for=condition=complete job/cmk-fio-bench --timeout=900s
+#   kubectl logs -l app=cmk-fio-bench --tail=-1     # fio JSON per pod
+#
+# Or drive it (auto node count + results capture) with:
+#   python3 bench/fio/run_fio_bench.py
+#
+# completions == parallelism == node count, with hostname anti-affinity => exactly
+# one pod per node. backoffLimit 0 so a failure surfaces instead of retrying.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cmk-fio-bench
+  labels:
+    app: cmk-fio-bench
+spec:
+  completions: ${COMPLETIONS}
+  parallelism: ${PARALLELISM}
+  completionMode: Indexed
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app: cmk-fio-bench
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        crusoe.ai/instance.class: ${INSTANCE_CLASS}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: cmk-fio-bench
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: fio
+          image: ${IMAGE}
+          env:
+            - { name: FIO_SIZE,    value: "${FIO_SIZE}" }      # per-job file size
+            - { name: FIO_JOBS,    value: "${FIO_JOBS}" }      # parallel jobs/node
+            - { name: FIO_IODEPTH, value: "${FIO_IODEPTH}" }   # async queue depth/job
+            - { name: FIO_RUNTIME, value: "${FIO_RUNTIME}" }   # seconds per phase
+            - { name: FIO_DIRECT,  value: "${FIO_DIRECT}" }
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              DIR=/data/_fiobench/$(hostname)
+              mkdir -p "$DIR"
+              command -v fio >/dev/null 2>&1 || apk add --no-cache fio >/dev/null 2>&1
+              # Many parallel jobs, each its own file (filename_format=f.$jobnum so
+              # all phases share the same files => seqread re-reads what seqwrite
+              # wrote). time_based gives sustained-throughput numbers. Tune
+              # FIO_JOBS x FIO_IODEPTH up to saturate the node NIC (~25 GB/s on s2a).
+              fio --directory="$DIR" --filename_format='f.$jobnum' \
+                  --size="$FIO_SIZE" --numjobs="$FIO_JOBS" \
+                  --ioengine=libaio --direct="$FIO_DIRECT" --iodepth="$FIO_IODEPTH" \
+                  --ramp_time=5 --time_based --runtime="$FIO_RUNTIME" \
+                  --group_reporting --output-format=json \
+                  --name=seqwrite  --rw=write     --bs=1M \
+                  --name=seqread   --rw=read      --bs=1M --stonewall \
+                  --name=randwrite --rw=randwrite --bs=4k --iodepth=128 --stonewall \
+                  --name=randread  --rw=randread  --bs=4k --iodepth=128 --stonewall
+              rm -rf "$DIR" 2>/dev/null || true
+          volumeMounts:
+            - name: shared
+              mountPath: /data
+      volumes:
+        - name: shared
+          persistentVolumeClaim:
+            claimName: ${PVC_NAME}

--- a/cmk-data-transfer/bench/fio/run_fio_bench.py
+++ b/cmk-data-transfer/bench/fio/run_fio_bench.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Drive the fio disk benchmark across every s2a node and save results.
+
+Renders bench/fio/fio-bench-job.yaml (one fio pod per node via hostname
+anti-affinity), applies it, waits for completion, then pulls each pod's fio JSON
+and a parsed summary into bench/results/fio-<timestamp>/ (git-ignored).
+
+Usage:
+    python3 bench/fio/run_fio_bench.py [--pvc cmk-data-transfer-nfs]
+        [--size 10G] [--jobs 4] [--direct 1] [--instance-class s2a]
+        [--namespace default] [--image alpine:3.20] [--timeout 1200]
+
+Safe: writes only under /data/_fiobench/<node>/ on the PVC and cleans up. No OCI
+egress (VAST I/O is in-region).
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+
+LABEL = "cmk-fio-bench"
+JOB = "cmk-fio-bench"
+HERE = os.path.dirname(os.path.abspath(__file__))
+MANIFEST = os.path.join(HERE, "fio-bench-job.yaml")
+RESULTS_ROOT = os.path.join(HERE, "..", "results")
+
+
+def kubectl(ns, *args, check=True, input_str=None):
+    return subprocess.run(["kubectl", "-n", ns, *args], capture_output=True,
+                          text=True, check=check, input=input_str)
+
+
+def schedulable_nodes(instance_class: str) -> list[str]:
+    out = subprocess.run(
+        ["kubectl", "get", "nodes", "-l",
+         f"crusoe.ai/instance.class={instance_class}", "-o", "json"],
+        capture_output=True, text=True, check=True).stdout
+    names = []
+    for n in json.loads(out).get("items", []):
+        conds = {c["type"]: c["status"] for c in
+                 n.get("status", {}).get("conditions", [])}
+        if conds.get("Ready") == "True" and not n["spec"].get("unschedulable"):
+            names.append(n["metadata"]["name"])
+    return names
+
+
+def render(values: dict) -> str:
+    text = open(MANIFEST).read()
+    for k, v in values.items():
+        text = text.replace("${%s}" % k, str(v))  # braced placeholders only
+    return text
+
+
+def parse_fio(blob: str) -> list[dict]:
+    """Return per-profile rows from one pod's fio JSON."""
+    start = blob.find("{")
+    if start < 0:
+        return []
+    try:
+        data = json.loads(blob[start:])
+    except json.JSONDecodeError:
+        return []
+    rows = []
+    for job in data.get("jobs", []):
+        name = job.get("jobname", "?")
+        side = job.get("write" if "write" in name else "read", {})
+        bw_bytes = side.get("bw_bytes") or (side.get("bw", 0) * 1024)
+        rows.append({
+            "profile": name,
+            "bw_MBps": round(bw_bytes / 1e6, 1),
+            "iops": round(side.get("iops", 0.0)),
+            "lat_ms": round(side.get("lat_ns", {}).get("mean", 0) / 1e6, 3),
+        })
+    return rows
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--pvc", default="cmk-data-transfer-nfs")
+    p.add_argument("--size", default="4G", help="fio file size PER JOB")
+    p.add_argument("--jobs", default="16", help="fio parallel jobs per node "
+                   "(raise to saturate the NIC)")
+    p.add_argument("--iodepth", default="32", help="async queue depth per job")
+    p.add_argument("--runtime", default="30", help="seconds per phase (time_based)")
+    p.add_argument("--direct", default="1", choices=("0", "1"))
+    p.add_argument("--instance-class", default="s2a")
+    p.add_argument("--namespace", default="default")
+    p.add_argument("--image", default="alpine:3.20")
+    p.add_argument("--timeout", type=int, default=1200)
+    p.add_argument("--stuck-grace", type=int, default=240,
+                   help="once running pods finish, wait this long for stuck "
+                        "(Pending/FailedMount) pods before collecting anyway")
+    p.add_argument("--collect-only", action="store_true",
+                   help="skip apply/wait; just collect from the existing job")
+    args = p.parse_args(argv)
+    ns = args.namespace
+
+    nodes = schedulable_nodes(args.instance_class)
+    if not nodes:
+        print(f"no schedulable {args.instance_class} nodes", file=sys.stderr)
+        return 2
+    n = len(nodes)
+    print(f"Benchmarking {n} {args.instance_class} nodes against PVC "
+          f"{args.pvc} (jobs={args.jobs} iodepth={args.iodepth} "
+          f"size/job={args.size} runtime={args.runtime}s direct={args.direct})")
+    for nd in nodes:
+        print(f"  - {nd}")
+
+    manifest = render({
+        "INSTANCE_CLASS": args.instance_class, "PVC_NAME": args.pvc,
+        "COMPLETIONS": n, "PARALLELISM": n, "IMAGE": args.image,
+        "FIO_SIZE": args.size, "FIO_JOBS": args.jobs,
+        "FIO_IODEPTH": args.iodepth, "FIO_RUNTIME": args.runtime,
+        "FIO_DIRECT": args.direct,
+    })
+
+    final = "collect-only"
+    if not args.collect_only:
+        kubectl(ns, "delete", "job", JOB, "--ignore-not-found", "--now",
+                check=False)
+        kubectl(ns, "apply", "-f", "-", input_str=manifest)
+        print("job applied; waiting for completion (fio runs 4 profiles/node)...")
+        # Poll pod phases. Break when all pods are terminal, or when the only
+        # non-terminal pods are stuck (Pending, e.g. FailedMount) and nothing is
+        # still running — so one bad node can't hang the whole benchmark.
+        t0 = time.time()
+        final = None
+        while time.time() - t0 < args.timeout:
+            pods = json.loads(kubectl(ns, "get", "pods", "-l",
+                              f"app={LABEL}", "-o", "json").stdout)["items"]
+            ph = [p["status"]["phase"] for p in pods]
+            succ = ph.count("Succeeded")
+            fail = ph.count("Failed")
+            running = ph.count("Running")
+            pending = ph.count("Pending")
+            el = int(time.time() - t0)
+            print(f"  [{el:4d}s] succeeded={succ}/{n} running={running} "
+                  f"pending={pending} failed={fail}")
+            if succ + fail >= n and len(pods) >= n:
+                final = "complete" if succ >= n else "partial"
+                break
+            if (running == 0 and pending > 0 and succ + fail > 0
+                    and el > args.stuck_grace):
+                final = "partial"
+                print(f"  {pending} pod(s) stuck (likely FailedMount); "
+                      "collecting the rest")
+                break
+            time.sleep(15)
+        if final is None:
+            final = "timeout"
+            print("timed out waiting for job", file=sys.stderr)
+
+    # collect results
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    outdir = os.path.abspath(os.path.join(RESULTS_ROOT, f"fio-{ts}"))
+    os.makedirs(outdir, exist_ok=True)
+    pods = json.loads(kubectl(ns, "get", "pods", "-l", f"app={LABEL}",
+                              "-o", "json").stdout)["items"]
+    summary = []
+    for pod in pods:
+        name = pod["metadata"]["name"]
+        node = pod["spec"].get("nodeName", "?")
+        blob = kubectl(ns, "logs", name, check=False).stdout or ""
+        with open(os.path.join(outdir, f"{node}.json"), "w") as fh:
+            fh.write(blob)
+        for row in parse_fio(blob):
+            row["node"] = node
+            summary.append(row)
+
+    # write summary CSV
+    csv_path = os.path.join(outdir, "summary.csv")
+    with open(csv_path, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["node", "profile", "bw_MBps",
+                                           "iops", "lat_ms"])
+        w.writeheader()
+        for r in sorted(summary, key=lambda x: (x["profile"], x["node"])):
+            w.writerow({k: r[k] for k in w.fieldnames})
+
+    # aggregate + print
+    print(f"\n=== results -> {outdir} ===")
+    if not summary:
+        print("  no fio output parsed (check the per-node .json files)")
+        return 1
+    profiles = ["seqwrite", "seqread", "randwrite", "randread"]
+    print(f"  {'profile':10}  {'aggregate':>14}  {'per-node avg':>14}  nodes")
+    for prof in profiles:
+        rows = [r for r in summary if r["profile"] == prof]
+        if not rows:
+            continue
+        if prof.startswith("seq"):
+            agg = sum(r["bw_MBps"] for r in rows) / 1000.0  # GB/s
+            avg = agg / len(rows)
+            print(f"  {prof:10}  {agg:9.2f} GB/s  {avg:9.2f} GB/s  {len(rows)}")
+        else:
+            agg = sum(r["iops"] for r in rows)
+            avg = agg / len(rows)
+            print(f"  {prof:10}  {agg:11.0f} IOPS  {avg:11.0f} IOPS  {len(rows)}")
+    covered = {r["node"] for r in summary}
+    missing = [nd for nd in nodes if nd not in covered]
+    print(f"\n  nodes with results: {len(covered)}/{n}")
+    if missing:
+        print("  MISSING (mount/run failed — see describe/CSI logs):")
+        for nd in missing:
+            print(f"    - {nd}")
+    print(f"  per-node detail + raw fio JSON in {outdir}")
+    print(f"  summary CSV: {csv_path}")
+
+    if not args.collect_only:
+        kubectl(ns, "delete", "job", JOB, "--ignore-not-found", "--now",
+                check=False)
+    return 0 if final == "complete" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmk-data-transfer/bench/oci_experiment.py
+++ b/cmk-data-transfer/bench/oci_experiment.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""OCI -> VAST transfer experiment: measure sustained pull rate at a given
+node/pod concurrency, writing to a DISTINCT destination subfolder per run.
+
+Drives the orchestrator (secret -> PVC/master -> list -> shard -> workers) for a
+chosen NUM_NODES with FIXED per-node concurrency, then polls each worker's
+rclone rc core/stats to compute the aggregate transfer rate over time. Reports:
+  - bytes transferred + wall-clock elapsed
+  - average GB/s   (= bytes / elapsed)  <- the headline "how fast did we pull"
+  - peak windowed GB/s (steady-state)
+  - per-node GB/s, and any OCI throttling (429/503 SlowDown) seen in logs
+Time-series + summary saved to bench/results/oci-exp-<label>-<ts>/ (git-ignored).
+
+Each run writes to DEST_PATH=/data/dataset/<label> so it re-pulls the full data
+(rclone copy would otherwise skip an already-populated dir).
+
+Usage:
+  python3 bench/oci_experiment.py --nodes 1 --label exp-1node
+  python3 bench/oci_experiment.py --nodes 1 --label smoke --prefix-override <small/subdir>
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from orchestrator import manifests, run as orun          # noqa: E402
+from orchestrator.config import load_config               # noqa: E402
+from orchestrator.k8s import Kubectl                       # noqa: E402
+from orchestrator.rclone_conf import build_s3_compat_conf  # noqa: E402
+from orchestrator.sizing import compute_sizing             # noqa: E402
+from bench import collect                                  # noqa: E402
+
+WL = manifests.WORKER_LABEL
+GB = 1_000_000_000
+
+
+def human_gbps(bps: float) -> str:
+    return f"{bps / GB:.2f} GB/s"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--nodes", type=int, required=True)
+    p.add_argument("--pods-per-node", type=int, default=4)
+    p.add_argument("--transfers", type=int, default=12, help="per pod (fixed)")
+    p.add_argument("--mts", type=int, default=8, help="multi-thread-streams/pod")
+    p.add_argument("--label", required=True, help="dest subfolder + result name")
+    p.add_argument("--prefix-override", default=None,
+                   help="smaller source prefix for smoke validation")
+    p.add_argument("--poll", type=int, default=10)
+    p.add_argument("--max-seconds", type=int, default=0,
+                   help="time-box: stop after N s (0 = run to completion). "
+                        "Bounds egress + skips the straggler tail.")
+    p.add_argument("--ramp-seconds", type=int, default=30,
+                   help="exclude the first N s from the steady-state average")
+    p.add_argument("--stats-sample", type=int, default=6,
+                   help="poll rclone rc on at most this many pods per tick "
+                        "(bounds overhead at large fleets; 0 = phase-only)")
+    p.add_argument("--safety-seconds", type=int, default=7200,
+                   help="hard stop for a to-completion run so it can't hang")
+    p.add_argument("--keep", action="store_true", help="don't tear down workers")
+    args = p.parse_args(argv)
+
+    cfg, _ = load_config([])
+    # fixed per-node concurrency; vary only node count
+    cfg.num_nodes = args.nodes
+    cfg.pods_per_node = args.pods_per_node
+    cfg.num_pods = None
+    cfg.rclone_transfers = args.transfers
+    cfg.rclone_multi_thread_streams = args.mts
+    cfg.dest_path = f"{cfg.mount_root}/dataset/{args.label}"   # DISTINCT per run
+    if args.prefix_override is not None:
+        cfg.prefix = args.prefix_override
+    errs = cfg.validate()
+    if errs:
+        for e in errs:
+            print("ERROR:", e, file=sys.stderr)
+        return 2
+
+    sizing = compute_sizing(cfg)
+    ns = cfg.k8s_namespace
+    kc = Kubectl(namespace=ns)
+    run_dir = tempfile.mkdtemp(prefix=f"oci-exp-{args.label}-")
+
+    print(f"=== OCI experiment: {args.label} ===")
+    print(f"  source : {cfg.remote_root()}")
+    print(f"  dest   : {cfg.dest_path}  (PVC {cfg.pvc_name}, nfs)")
+    print(f"  fleet  : {cfg.num_nodes} nodes x {sizing.pods_per_node} pods "
+          f"= {sizing.total_pods} workers; per-pod T={sizing.transfers} "
+          f"MTS={sizing.multi_thread_streams}; {sizing.in_flight_per_node} "
+          f"streams/node, {sizing.in_flight_per_node * cfg.num_nodes} fleet")
+
+    # --- setup (reuse orchestrator steps) ---
+    orun.preflight(cfg, kc)
+    kc.create_secret_from_files(cfg.secret_name,
+                                {"rclone.conf": build_s3_compat_conf(cfg)})
+    if cfg.is_nfs():
+        kc.apply(manifests.nfs_pv(cfg))
+    elif cfg.is_import():
+        kc.apply(manifests.import_pv(cfg))
+    kc.apply(manifests.pvc(cfg))
+    # clean slate so a still-terminating master/worker from a prior run can't
+    # collide on name when sweeping multiple runs back-to-back
+    kc.delete("pod", selector=f"app={WL}", wait=True)
+    kc.delete("pod", name=cfg.master_pod_name, wait=True)
+    kc.apply(manifests.master_pod(cfg))
+    kc.wait_ready(cfg.master_pod_name)
+    orun.list_source(cfg, kc)
+    expected_bytes = orun.shard_locally(cfg, kc, run_dir)
+
+    # Pin workers to EXACTLY num_nodes specific nodes (nodeName), pods_per_node
+    # each — so "node count" is controlled, not left to topology-spread across
+    # all available s2a nodes.
+    avail = kc.list_ready_nodes(cfg.instance_class)
+    if len(avail) < cfg.num_nodes:
+        print(f"ERROR: need {cfg.num_nodes} {cfg.instance_class} nodes, "
+              f"have {len(avail)}", file=sys.stderr)
+        return 2
+    chosen = sorted(avail)[:cfg.num_nodes]
+    print(f"  pinned nodes ({cfg.num_nodes}): " + ", ".join(
+        n.split(".")[0] for n in chosen))
+    orun.banner("Launching worker pods (pinned)")
+    for i in range(sizing.total_pods):
+        pod = manifests.worker_pod(cfg, sizing, i)
+        pod["spec"]["nodeName"] = chosen[i % len(chosen)]      # hard pin
+        pod["spec"].pop("topologySpreadConstraints", None)     # not needed
+        kc.apply(pod)
+    print(f"  launched {sizing.total_pods} workers "
+          f"({sizing.pods_per_node}/node x {cfg.num_nodes})")
+
+    # --- monitor + collect (byte-delta rate) ---
+    out = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), "results", f"oci-exp-{args.label}"))
+    os.makedirs(out, exist_ok=True)
+    ts_csv = os.path.join(out, "timeseries.csv")
+    fh = open(ts_csv, "w", newline="")
+    w = csv.writer(fh)
+    w.writerow(["elapsed_s", "agg_bytes", "interval_GBps", "running_avg_GBps",
+                "active_pods"])
+
+    t0 = time.time()
+    prev_bytes, prev_t = 0, t0
+    peak = 0.0
+    est_agg = 0
+    steady_rates = []      # post-ramp interval rates, for steady-state
+    completed = False
+    failed_pods = 0
+    print(f"  --- transferring (phase-poll + rc-stats sample of "
+          f"{args.stats_sample} pods/tick) ---")
+    while True:
+        time.sleep(args.poll)
+        now = time.time()
+        elapsed = now - t0
+        pods = kc.get_json("get", "pods", "-l", f"app={WL}").get("items", [])
+        active = sum(1 for p in pods
+                     if p["status"]["phase"] not in ("Succeeded", "Failed"))
+        failed_pods = sum(1 for p in pods if p["status"]["phase"] == "Failed")
+        # bounded rc-stats sample -> extrapolate to the fleet (live estimate
+        # only; the authoritative total uses expected_bytes on completion)
+        sbytes, scount = 0, 0
+        for pod in pods[:args.stats_sample]:
+            st = collect.pod_stats(ns, pod["metadata"]["name"],
+                                   collect.rc_port(pod))
+            if st:
+                sbytes += int(st.get("bytes", 0))
+                scount += 1
+        if scount:
+            est_agg = sbytes / scount * len(pods)
+        interval_rate = (est_agg - prev_bytes) / max(0.1, now - prev_t)
+        avg_rate = est_agg / max(0.1, elapsed)
+        peak = max(peak, interval_rate)
+        if elapsed >= args.ramp_seconds and scount:
+            steady_rates.append(interval_rate)
+        w.writerow([f"{elapsed:.0f}", int(est_agg), f"{interval_rate/GB:.3f}",
+                    f"{avg_rate/GB:.3f}", active])
+        fh.flush()
+        print(f"  [{elapsed:6.0f}s] est {est_agg/1e12:5.2f} TB  "
+              f"~now={human_gbps(interval_rate)}  "
+              f"active={active}/{sizing.total_pods} failed={failed_pods}")
+        prev_bytes, prev_t = est_agg, now
+        if active == 0 and pods:
+            completed = (failed_pods == 0)
+            break
+        if args.max_seconds and elapsed >= args.max_seconds:
+            print(f"  time-box {args.max_seconds}s reached; stopping")
+            break
+        if elapsed >= args.safety_seconds:
+            print(f"  SAFETY cap {args.safety_seconds}s reached; stopping")
+            break
+    fh.close()
+    elapsed = time.time() - t0
+    # Accurate transferred bytes = what actually landed on the destination disk
+    # (straggler-proof, unlike the per-tick sampled estimate). Measured via
+    # `rclone size` on the local dest path from the still-running master pod.
+    disk_bytes = None
+    try:
+        r = kc.exec(cfg.master_pod_name,
+                    ["rclone", "size", "--json", cfg.dest_path])
+        disk_bytes = int(json.loads((r.stdout or b"{}").decode())["bytes"])
+    except Exception as e:  # noqa: BLE001
+        print(f"  (could not measure dest size: {e})")
+    total_bytes = (disk_bytes if disk_bytes is not None
+                   else (expected_bytes if completed else int(est_agg)))
+    total_time = elapsed
+    pct = 100.0 * total_bytes / max(1, expected_bytes)
+    avg = total_bytes / max(0.1, total_time)
+    steady = (sorted(steady_rates)[len(steady_rates) // 2]
+              if steady_rates else avg)   # median post-ramp interval rate
+
+    # throttling / errors from worker logs
+    throttle = 0
+    for pod in kc.get_json("get", "pods", "-l", f"app={WL}").get("items", []):
+        log = kc.logs(pod["metadata"]["name"], tail=2000)
+        for sig in ("SlowDown", " 429 ", " 503 ", "RequestThrottled"):
+            throttle += log.count(sig)
+
+    summary = {
+        "label": args.label, "nodes": cfg.num_nodes,
+        "pods_per_node": sizing.pods_per_node, "total_pods": sizing.total_pods,
+        "per_pod_transfers": sizing.transfers,
+        "per_pod_mts": sizing.multi_thread_streams,
+        "streams_per_node": sizing.in_flight_per_node,
+        "completed": completed, "failed_pods": failed_pods,
+        "expected_bytes": expected_bytes, "transferred_bytes": total_bytes,
+        "pct_complete": round(pct, 1),
+        "total_transfer_time_s": round(total_time, 1),
+        "avg_GBps": round(avg / GB, 3),
+        "avg_GBps_per_node": round(avg / GB / cfg.num_nodes, 3),
+        "steady_GBps": round(steady / GB, 3),
+        "peak_GBps": round(peak / GB, 3),
+        "throttle_signals": throttle,
+    }
+    with open(os.path.join(out, "summary.json"), "w") as sfh:
+        json.dump(summary, sfh, indent=2)
+
+    print("\n=== RESULT ===")
+    status = "COMPLETE" if completed else f"capped/partial (failed={failed_pods})"
+    mins = total_time / 60
+    print(f"  status            : {status}  ({pct:.1f}% of bucket on disk)")
+    print(f"  TOTAL TRANSFER TIME: {total_time:.0f}s ({mins:.1f} min) for "
+          f"{total_bytes/1e12:.3f} TB")
+    print(f"  AVERAGE rate      : {human_gbps(avg)}  "
+          f"({avg/GB/cfg.num_nodes:.2f} GB/s/node)")
+    print(f"  steady (sampled)  : {human_gbps(steady)}   peak: {human_gbps(peak)}")
+    print(f"  OCI throttle signals: {throttle}")
+    print(f"  -> {out}/summary.json , timeseries.csv")
+
+    if not args.keep:
+        kc.delete("pod", selector=f"app={WL}", wait=True)
+        kc.delete("pod", name=cfg.master_pod_name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmk-data-transfer/bench/oci_experiment.py
+++ b/cmk-data-transfer/bench/oci_experiment.py
@@ -27,6 +27,7 @@ import os
 import sys
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -142,18 +143,71 @@ def main(argv=None) -> int:
     ts_csv = os.path.join(out, "timeseries.csv")
     fh = open(ts_csv, "w", newline="")
     w = csv.writer(fh)
-    w.writerow(["elapsed_s", "agg_bytes", "interval_GBps", "running_avg_GBps",
-                "active_pods"])
+    w.writerow(["elapsed_s", "rclone_agg_bytes", "rclone_interval_GBps",
+                "nic_interval_GBps", "active_pods"])
+
+    # --- measurement helpers ---
+    # (1) rclone-reported bytes: sum core/stats across ALL pods, in parallel.
+    #     No sampling/extrapolation (the old 6-pod x len(pods) estimate biased
+    #     high because pods[:6] are the fast starters).
+    def fleet_bytes(pods):
+        names = [(p["metadata"]["name"], collect.rc_port(p)) for p in pods
+                 if p["status"]["phase"] == "Running"]
+        if not names:
+            return 0, 0
+
+        def one(np):
+            st = collect.pod_stats(ns, np[0], np[1])
+            return int(st.get("bytes", 0)) if st else None
+        with ThreadPoolExecutor(max_workers=min(32, len(names))) as ex:
+            vals = [v for v in ex.map(one, names) if v is not None]
+        return sum(vals), len(vals)
+
+    # (2) GROUND TRUTH: node NIC receive counters. Workers are hostNetwork, so
+    #     /proc/net/dev inside a worker reports the NODE's interfaces. One worker
+    #     per node; take the busiest non-virtual iface (the physical data NIC).
+    _VIRT = ("lo", "veth", "cni", "flannel", "docker", "cali", "lxc", "kube",
+             "dummy", "nodelocal", "ovn", "genev", "br-", "tunl", "ip6tnl")
+
+    def node_rx(pod_name):
+        try:
+            r = kc.exec(pod_name, ["cat", "/proc/net/dev"])
+            best = 0
+            for line in (r.stdout or b"").decode().splitlines():
+                if ":" not in line:
+                    continue
+                iface, _, rest = line.partition(":")
+                if iface.strip().startswith(_VIRT):
+                    continue
+                cols = rest.split()
+                if cols:
+                    best = max(best, int(cols[0]))   # cumulative rx_bytes
+            return best
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def fleet_nic_rx(pods):
+        reps = {}
+        for p in pods:
+            n = p["spec"].get("nodeName")
+            if n and n not in reps and p["status"]["phase"] == "Running":
+                reps[n] = p["metadata"]["name"]
+        if not reps:
+            return 0
+        with ThreadPoolExecutor(max_workers=min(16, len(reps))) as ex:
+            return sum(ex.map(node_rx, reps.values()))
 
     t0 = time.time()
     prev_bytes, prev_t = 0, t0
-    peak = 0.0
-    est_agg = 0
-    steady_rates = []      # post-ramp interval rates, for steady-state
+    prev_nic = None            # cumulative NIC counter baseline (set on tick 1)
+    peak = 0.0                 # rclone-reported peak interval
+    peak_nic = 0.0             # NIC ground-truth peak interval
+    agg_bytes = 0
+    nic_delta_total = 0        # bytes seen on the wire since baseline
+    steady_rates, nic_steady = [], []
     completed = False
     failed_pods = 0
-    print(f"  --- transferring (phase-poll + rc-stats sample of "
-          f"{args.stats_sample} pods/tick) ---")
+    print("  --- transferring (rclone rc-stats ALL pods + node NIC counters) ---")
     while True:
         time.sleep(args.poll)
         now = time.time()
@@ -162,29 +216,28 @@ def main(argv=None) -> int:
         active = sum(1 for p in pods
                      if p["status"]["phase"] not in ("Succeeded", "Failed"))
         failed_pods = sum(1 for p in pods if p["status"]["phase"] == "Failed")
-        # bounded rc-stats sample -> extrapolate to the fleet (live estimate
-        # only; the authoritative total uses expected_bytes on completion)
-        sbytes, scount = 0, 0
-        for pod in pods[:args.stats_sample]:
-            st = collect.pod_stats(ns, pod["metadata"]["name"],
-                                   collect.rc_port(pod))
-            if st:
-                sbytes += int(st.get("bytes", 0))
-                scount += 1
-        if scount:
-            est_agg = sbytes / scount * len(pods)
-        interval_rate = (est_agg - prev_bytes) / max(0.1, now - prev_t)
-        avg_rate = est_agg / max(0.1, elapsed)
+
+        agg_bytes, responded = fleet_bytes(pods)
+        nic_now = fleet_nic_rx(pods)
+        if prev_nic is None:
+            prev_nic = nic_now                       # baseline (cumulative)
+
+        dt = max(0.1, now - prev_t)
+        interval_rate = (agg_bytes - prev_bytes) / dt
+        nic_rate = (nic_now - prev_nic) / dt if nic_now >= prev_nic else 0.0
         peak = max(peak, interval_rate)
-        if elapsed >= args.ramp_seconds and scount:
+        peak_nic = max(peak_nic, nic_rate)
+        nic_delta_total += max(0, nic_now - prev_nic)
+        if elapsed >= args.ramp_seconds:
             steady_rates.append(interval_rate)
-        w.writerow([f"{elapsed:.0f}", int(est_agg), f"{interval_rate/GB:.3f}",
-                    f"{avg_rate/GB:.3f}", active])
+            nic_steady.append(nic_rate)
+        w.writerow([f"{elapsed:.0f}", int(agg_bytes),
+                    f"{interval_rate/GB:.3f}", f"{nic_rate/GB:.3f}", active])
         fh.flush()
-        print(f"  [{elapsed:6.0f}s] est {est_agg/1e12:5.2f} TB  "
-              f"~now={human_gbps(interval_rate)}  "
-              f"active={active}/{sizing.total_pods} failed={failed_pods}")
-        prev_bytes, prev_t = est_agg, now
+        print(f"  [{elapsed:6.0f}s] rclone {agg_bytes/1e12:5.2f} TB  "
+              f"rclone~{human_gbps(interval_rate)}  NIC~{human_gbps(nic_rate)}  "
+              f"act={active}/{sizing.total_pods} resp={responded} fail={failed_pods}")
+        prev_bytes, prev_nic, prev_t = agg_bytes, nic_now, now
         if active == 0 and pods:
             completed = (failed_pods == 0)
             break
@@ -196,23 +249,20 @@ def main(argv=None) -> int:
             break
     fh.close()
     elapsed = time.time() - t0
-    # Accurate transferred bytes = what actually landed on the destination disk
-    # (straggler-proof, unlike the per-tick sampled estimate). Measured via
-    # `rclone size` on the local dest path from the still-running master pod.
-    disk_bytes = None
-    try:
-        r = kc.exec(cfg.master_pod_name,
-                    ["rclone", "size", "--json", cfg.dest_path])
-        disk_bytes = int(json.loads((r.stdout or b"{}").decode())["bytes"])
-    except Exception as e:  # noqa: BLE001
-        print(f"  (could not measure dest size: {e})")
-    total_bytes = (disk_bytes if disk_bytes is not None
-                   else (expected_bytes if completed else int(est_agg)))
+
+    # transferred bytes = rclone rc-stats sum across ALL pods (actual downloaded
+    # bytes). NOT `rclone size`, which counts in-flight sparse multi-thread files
+    # at full allocated size and overstates the total.
+    total_bytes = int(agg_bytes)
     total_time = elapsed
     pct = 100.0 * total_bytes / max(1, expected_bytes)
     avg = total_bytes / max(0.1, total_time)
     steady = (sorted(steady_rates)[len(steady_rates) // 2]
-              if steady_rates else avg)   # median post-ramp interval rate
+              if steady_rates else avg)
+    # NIC ground truth (independent of rclone's self-report)
+    nic_avg = nic_delta_total / max(0.1, total_time)
+    nic_steady_med = (sorted(nic_steady)[len(nic_steady) // 2]
+                      if nic_steady else nic_avg)
 
     # throttling / errors from worker logs
     throttle = 0
@@ -231,10 +281,14 @@ def main(argv=None) -> int:
         "expected_bytes": expected_bytes, "transferred_bytes": total_bytes,
         "pct_complete": round(pct, 1),
         "total_transfer_time_s": round(total_time, 1),
-        "avg_GBps": round(avg / GB, 3),
+        "avg_GBps": round(avg / GB, 3),                 # rclone-reported
         "avg_GBps_per_node": round(avg / GB / cfg.num_nodes, 3),
         "steady_GBps": round(steady / GB, 3),
         "peak_GBps": round(peak / GB, 3),
+        "nic_avg_GBps": round(nic_avg / GB, 3),         # GROUND TRUTH: node NIC rx
+        "nic_avg_GBps_per_node": round(nic_avg / GB / cfg.num_nodes, 3),
+        "nic_steady_GBps": round(nic_steady_med / GB, 3),
+        "nic_peak_GBps": round(peak_nic / GB, 3),
         "throttle_signals": throttle,
     }
     with open(os.path.join(out, "summary.json"), "w") as sfh:
@@ -246,9 +300,11 @@ def main(argv=None) -> int:
     print(f"  status            : {status}  ({pct:.1f}% of bucket on disk)")
     print(f"  TOTAL TRANSFER TIME: {total_time:.0f}s ({mins:.1f} min) for "
           f"{total_bytes/1e12:.3f} TB")
-    print(f"  AVERAGE rate      : {human_gbps(avg)}  "
-          f"({avg/GB/cfg.num_nodes:.2f} GB/s/node)")
-    print(f"  steady (sampled)  : {human_gbps(steady)}   peak: {human_gbps(peak)}")
+    print(f"  rclone  avg/steady/peak: {avg/GB:.2f} / {steady/GB:.2f} / "
+          f"{peak/GB:.2f} GB/s")
+    print(f"  NIC     avg/steady/peak: {nic_avg/GB:.2f} / {nic_steady_med/GB:.2f} / "
+          f"{peak_nic/GB:.2f} GB/s  <- GROUND TRUTH "
+          f"({nic_avg/GB/cfg.num_nodes:.2f} GB/s/node)")
     print(f"  OCI throttle signals: {throttle}")
     print(f"  -> {out}/summary.json , timeseries.csv")
 

--- a/cmk-data-transfer/bench/sweep.py
+++ b/cmk-data-transfer/bench/sweep.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Parameter sweep over (transfers, multi-thread-streams, pods).
+
+For each grid point it launches the worker fleet with those rclone settings
+against a BOUNDED sample of the source, records the throughput curve via
+collect.py, tears the fleet down, and appends peak/median aggregate GB/s to a
+results CSV. The goal is to find the saturation knee and identify the binding
+constraint (network vs VAST write ceiling vs OCI request throttling).
+
+COST WARNING: each grid point re-downloads the sample (OCI egress is billed).
+Keep --sample-prefix small and --max-seconds short. Requires --yes.
+
+Prereqs: run the main orchestrator once (or this with --do-list) so the Secret,
+PVC, and master pod exist and the sample is listed+sharded.
+
+Usage:
+    python3 bench/sweep.py --yes \
+        --sample-prefix smoke-set/ \
+        --transfers-grid 16,32,48 \
+        --mts-grid 4,8 \
+        --pods-grid 4 \
+        --max-seconds 120 \
+        --out bench/results/sweep.csv
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shard import shard_manifest                       # noqa: E402
+from orchestrator import manifests                      # noqa: E402
+from orchestrator.config import load_config             # noqa: E402
+from orchestrator.k8s import Kubectl                     # noqa: E402
+from orchestrator.rclone_conf import build_s3_compat_conf  # noqa: E402
+from orchestrator.sizing import compute_sizing           # noqa: E402
+
+from bench import collect  # noqa: E402
+
+
+def _grid(s: str) -> list[int]:
+    return [int(x) for x in s.split(",") if x.strip()]
+
+
+def ensure_base(cfg, kc: Kubectl, do_list: bool) -> None:
+    """Make sure Secret / PVC / master pod exist; optionally (re)list+shard."""
+    kc.create_secret_from_files(
+        cfg.secret_name, {"rclone.conf": build_s3_compat_conf(cfg)})
+    kc.apply(manifests.pvc(cfg))
+    if not kc.exists("pod", cfg.master_pod_name):
+        kc.apply(manifests.master_pod(cfg))
+        kc.wait_ready(cfg.master_pod_name)
+    if do_list:
+        listing = f"{cfg.mount_root}/listing.tsv"
+        lsf = ("SEP=$(printf '\\t'); rclone lsf --recursive --files-only "
+               "--format sp --separator \"$SEP\" --config /config/rclone.conf "
+               f"{cfg.remote_root()} > {listing}")
+        kc.exec(cfg.master_pod_name, ["/bin/sh", "-c", lsf])
+
+
+def reshard(cfg, kc: Kubectl, num_pods: int, run_dir: str) -> None:
+    """Re-bin-pack the existing listing into num_pods shards and push them."""
+    listing = f"{cfg.mount_root}/listing.tsv"
+    local = os.path.join(run_dir, "listing.tsv")
+    with open(local, "wb") as fh:
+        fh.write(kc.exec(cfg.master_pod_name, ["cat", listing]).stdout or b"")
+    with open(local) as fh:
+        objects = list(shard_manifest.parse_tsv(fh))
+    bins, _ = shard_manifest.bin_pack(objects, num_pods)
+    files = shard_manifest.write_shards(bins, os.path.join(run_dir, "shards"))
+    # clear old shards then push new
+    kc.exec(cfg.master_pod_name,
+            ["/bin/sh", "-c", f"rm -f {manifests.shard_dir(cfg)}/shard-*.txt"])
+    for fp in files:
+        kc.cp_to(cfg.master_pod_name, fp,
+                 f"{manifests.shard_dir(cfg)}/{os.path.basename(fp)}")
+
+
+def run_point(cfg, kc, transfers, mts, ppn, dest, max_seconds, csv_path):
+    c = copy.deepcopy(cfg)
+    c.rclone_transfers = transfers
+    c.rclone_multi_thread_streams = mts
+    c.pods_per_node = ppn
+    c.num_pods = None
+    c.dest_path = dest
+    sizing = compute_sizing(c)
+    total = sizing.total_pods
+
+    print(f"\n>>> point T={transfers} MTS={mts} pods/node={ppn} "
+          f"({total} pods) dest={dest}")
+    for i in range(total):
+        kc.apply(manifests.worker_pod(c, sizing, i))
+
+    # collect throughput for this point
+    pt_csv = csv_path.replace(".csv", f".T{transfers}_s{mts}_ppn{ppn}.csv")
+    collect.main([
+        "--namespace", c.k8s_namespace,
+        "--interval", "10",
+        "--out", pt_csv,
+        "--max-seconds", str(max_seconds),
+    ])
+
+    # parse peak/median from the per-point csv
+    peak, vals = 0.0, []
+    with open(pt_csv) as fh:
+        for row in csv.DictReader(fh):
+            g = float(row["aggregate_GBps"])
+            peak = max(peak, g)
+            vals.append(g)
+    median = sorted(vals)[len(vals) // 2] if vals else 0.0
+
+    kc.delete("pod", selector=f"app={manifests.WORKER_LABEL}", wait=True)
+    return peak, median, sizing.in_flight_per_node * c.num_nodes
+
+
+def main(argv=None) -> int:
+    # Config comes from env/.env; this tool owns its own CLI grid flags, so we
+    # do NOT route argv through the orchestrator's strict parser.
+    cfg, _ = load_config([])
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--transfers-grid", default="16,32,48")
+    p.add_argument("--mts-grid", default="4,8")
+    p.add_argument("--pods-per-node-grid", default="2,4,8",
+                   help="sweep workers-per-node (the new throughput lever)")
+    p.add_argument("--sample-prefix", default=None,
+                   help="override OCI_PREFIX with a small sample subdir")
+    p.add_argument("--max-seconds", type=int, default=120)
+    p.add_argument("--out", default="bench/results/sweep.csv")
+    p.add_argument("--do-list", action="store_true",
+                   help="(re)list the source before sweeping")
+    p.add_argument("--yes", action="store_true")
+    # parse only our flags; cfg already built from env/.env
+    args, _unknown = p.parse_known_args(argv)
+
+    if not args.yes:
+        print("Refusing to run without --yes (each point bills OCI egress).")
+        return 2
+    if args.sample_prefix is not None:
+        cfg.prefix = args.sample_prefix
+
+    import tempfile
+    run_dir = tempfile.mkdtemp(prefix="cmk-sweep-")
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    kc = Kubectl(namespace=cfg.k8s_namespace, dry_run=False)
+
+    ensure_base(cfg, kc, do_list=args.do_list)
+
+    results = []
+    with open(args.out, "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["transfers", "mts", "pods_per_node", "total_pods",
+                    "fleet_streams", "peak_GBps", "median_GBps"])
+        for ppn in _grid(args.pods_per_node_grid):
+            total = cfg.num_nodes * ppn
+            reshard(cfg, kc, total, run_dir)
+            for mts in _grid(args.mts_grid):
+                for t in _grid(args.transfers_grid):
+                    dest = f"{cfg.mount_root}/sweep/T{t}_s{mts}_ppn{ppn}"
+                    peak, med, streams = run_point(
+                        cfg, kc, t, mts, ppn, dest, args.max_seconds, args.out)
+                    w.writerow([t, mts, ppn, total, streams,
+                                f"{peak:.3f}", f"{med:.3f}"])
+                    fh.flush()
+                    results.append((t, mts, ppn, peak))
+                    print(f"    => peak {peak:.3f} GB/s, median {med:.3f} GB/s")
+                    time.sleep(5)
+
+    results.sort(key=lambda r: r[3], reverse=True)
+    print("\n--- sweep summary (top by peak) ---")
+    for t, mts, ppn, peak in results[:5]:
+        print(f"  T={t:>3} MTS={mts:>2} pods/node={ppn:>2}  peak {peak:.3f} GB/s")
+    print(f"  full results: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmk-data-transfer/k8s/import-pv.yaml
+++ b/cmk-data-transfer/k8s/import-pv.yaml
@@ -1,0 +1,57 @@
+# Import an EXISTING Crusoe shared disk as a static PV + PVC.
+#
+# Use this when you already have a shared disk (e.g. created in the Crusoe
+# console or `crusoe storage disks create`) and wants to migrate data INTO it,
+# rather than provisioning a fresh disk. The orchestrator generates the
+# authoritative versions when EXISTING_DISK_* are set; this is the manual
+# equivalent.
+#
+# 1) Find the disk:
+#      crusoe storage disks list -f json
+#    Pick the `shared-volume` entry in your region and note three fields:
+#      .id             -> volumeHandle            (a UUID)
+#      .name           -> csi.crusoe.ai/disk-name (a UUID)
+#      .serial_number  -> csi.crusoe.ai/serial-number
+#
+# 2) Substitute ${...} and apply (PV first, then PVC):
+#      envsubst < k8s/import-pv.yaml | kubectl apply -f -
+#
+# reclaimPolicy: Retain is deliberate — deleting the PVC/PV must NOT delete the
+# customer's disk or its data. claimRef pre-binds the PV to our PVC so nothing
+# else can claim it.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ${PVC_NAME}-pv
+spec:
+  capacity:
+    storage: ${PVC_SIZE}                 # PV capacity (match/exceed the disk)
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""                   # static binding; no dynamic provisioning
+  volumeMode: Filesystem
+  csi:
+    driver: fs.csi.crusoe.ai
+    volumeHandle: ${EXISTING_DISK_ID}
+    fsType: ${EXISTING_DISK_FSTYPE}      # ext4
+    volumeAttributes:
+      csi.crusoe.ai/disk-name: ${EXISTING_DISK_NAME}
+      csi.crusoe.ai/serial-number: ${EXISTING_DISK_SERIAL}
+  claimRef:
+    namespace: ${NAMESPACE}
+    name: ${PVC_NAME}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""                   # bind to the static PV above
+  volumeName: ${PVC_NAME}-pv
+  resources:
+    requests:
+      storage: ${PVC_SIZE}

--- a/cmk-data-transfer/k8s/master-pod.yaml
+++ b/cmk-data-transfer/k8s/master-pod.yaml
@@ -1,0 +1,41 @@
+# Master / distribution pod: mounts the shared disk and the rclone Secret.
+# The orchestrator execs `rclone lsf` here to list the source, then pushes the
+# computed shard files into ${MOUNT_ROOT}/shards. Pinned to the same instance
+# class as the workers so its egress path to OCI matches theirs.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cmk-data-transfer-master
+  labels:
+    app: cmk-data-transfer-master
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    crusoe.ai/instance.class: ${INSTANCE_CLASS}   # s2a
+  containers:
+    - name: master
+      image: ${RCLONE_IMAGE}                       # rclone/rclone:latest
+      command:
+        - /bin/sh
+        - -c
+        - "mkdir -p /data/shards /data/logs /data/dataset; while true; do sleep 3600; done"
+      env:
+        - name: RCLONE_CONFIG
+          value: /config/rclone.conf
+      volumeMounts:
+        - name: shared
+          mountPath: /data                          # ${MOUNT_ROOT}
+        - name: rclone-conf
+          mountPath: /config
+          readOnly: true
+  volumes:
+    - name: shared
+      persistentVolumeClaim:
+        claimName: ${PVC_NAME}
+    - name: rclone-conf
+      secret:
+        secretName: ${SECRET_NAME}                  # cmk-data-transfer-oci
+        defaultMode: 0400
+        items:
+          - key: rclone.conf
+            path: rclone.conf

--- a/cmk-data-transfer/k8s/nfs-pv.yaml
+++ b/cmk-data-transfer/k8s/nfs-pv.yaml
@@ -1,0 +1,51 @@
+# Bind an existing VAST shared disk via an in-tree NFS PV (bypasses the CSI
+# driver). Use this where the fs CSI driver's mount times out on an unroutable
+# fallback IP (the disk returns no "data path connectivity fields"): the VAST
+# DNS endpoint resolves to the in-VPC data IPs and mounts cleanly with
+# remoteports=dns.
+#
+# The orchestrator generates the authoritative versions when DEST_MODE=nfs; this
+# is the manual / envsubst equivalent.
+#
+# 1) Find the disk id:  crusoe storage disks list -f json   (the `id` field)
+# 2) envsubst < k8s/nfs-pv.yaml | kubectl apply -f -   (PV first, then PVC)
+#
+# reclaimPolicy: Retain — deleting the PVC/PV never deletes the disk or its data.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ${PVC_NAME}-pv
+spec:
+  capacity:
+    storage: ${PVC_SIZE}                 # e.g. 1000Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  volumeMode: Filesystem
+  mountOptions:                          # VAST multipath NFS over DNS
+    - vers=3
+    - nconnect=16
+    - spread_reads
+    - spread_writes
+    - remoteports=dns
+  nfs:
+    server: ${NFS_SERVER}                # nfs.crusoecloudcompute.com
+    path: /volumes/${EXISTING_DISK_ID}   # the crusoe disk `id`
+  claimRef:
+    namespace: ${NAMESPACE}
+    name: ${PVC_NAME}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: ${PVC_NAME}-pv
+  resources:
+    requests:
+      storage: ${PVC_SIZE}

--- a/cmk-data-transfer/k8s/pvc.yaml
+++ b/cmk-data-transfer/k8s/pvc.yaml
@@ -1,0 +1,15 @@
+# Destination shared disk: ReadWriteMany so every worker mounts it.
+# Substitute ${...} (e.g. `envsubst < k8s/pvc.yaml | kubectl apply -f -`)
+# or just let the orchestrator apply the authoritative version.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}            # default: cmk-data-transfer-fs
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ${STORAGE_CLASS}   # crusoe-csi-driver-fs-sc (VAST)
+  resources:
+    requests:
+      storage: ${PVC_SIZE}    # e.g. 1000Ti
+  volumeMode: Filesystem

--- a/cmk-data-transfer/k8s/secret.example.yaml
+++ b/cmk-data-transfer/k8s/secret.example.yaml
@@ -1,0 +1,37 @@
+# EXAMPLE ONLY — do NOT commit a real Secret. The orchestrator builds this
+# in-cluster from your .env (the credential never touches the repo or your
+# shell history). This shows the shape if you want to create it by hand.
+#
+# The single key `rclone.conf` is mounted read-only at /config/rclone.conf.
+#
+# Build it safely from a local rclone.conf without echoing creds into argv:
+#   kubectl create secret generic cmk-data-transfer-oci \
+#       --from-file=rclone.conf=./rclone.conf \
+#       --dry-run=client -o yaml | kubectl apply -f -
+#
+# ...where ./rclone.conf (git-ignored) contains:
+#   [oci]
+#   type = s3
+#   provider = Other
+#   access_key_id = <OCI_ACCESS_KEY_ID>
+#   secret_access_key = <OCI_SECRET_ACCESS_KEY>
+#   endpoint = https://<NAMESPACE>.compat.objectstorage.<REGION>.oraclecloud.com
+#   region = <REGION>
+#   force_path_style = true
+#   no_check_bucket = true
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cmk-data-transfer-oci
+type: Opaque
+stringData:
+  rclone.conf: |
+    [oci]
+    type = s3
+    provider = Other
+    access_key_id = REDACTED
+    secret_access_key = REDACTED
+    endpoint = https://NAMESPACE.compat.objectstorage.REGION.oraclecloud.com
+    region = REGION
+    force_path_style = true
+    no_check_bucket = true

--- a/cmk-data-transfer/k8s/storageclass.yaml
+++ b/cmk-data-transfer/k8s/storageclass.yaml
@@ -1,0 +1,14 @@
+# Crusoe VAST shared-filesystem (ReadWriteMany) StorageClass.
+#
+# This cluster ships the fs CSI driver (fs.csi.crusoe.ai) but does not always
+# create the StorageClass object. The orchestrator creates this automatically
+# in preflight if it is absent; this file is the manual equivalent:
+#   kubectl apply -f k8s/storageclass.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: crusoe-csi-driver-fs-sc
+provisioner: fs.csi.crusoe.ai
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/cmk-data-transfer/k8s/worker-pod.yaml
+++ b/cmk-data-transfer/k8s/worker-pod.yaml
@@ -1,0 +1,76 @@
+# Worker pod (one shard each, PODS_PER_NODE per node). REFERENCE template — the
+# orchestrator generates the authoritative spec per shard with the sizing-derived
+# rclone flags filled in. Shown here for review / manual use.
+#
+# Design:
+#   hostNetwork: true            -> use the node NIC directly (bypass the CNI).
+#   topologySpreadConstraints    -> spread workers EVENLY (maxSkew=1 on hostname)
+#                                   so each node gets PODS_PER_NODE, not a pile-up.
+#   unique rc port 5572+index    -> hostNetwork pods share the node netns, so each
+#                                   worker's rclone rc must bind a distinct port.
+#   resources.requests           -> sized so exactly PODS_PER_NODE pack per node.
+#   --no-traverse                -> with --files-from, never list the dest tree.
+#   --checkers                   -> omitted by default (set RCLONE_CHECKERS to add).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cmk-data-transfer-worker-0          # -<shard index>
+  labels:
+    app: cmk-data-transfer-worker
+    shard: "0"
+spec:
+  restartPolicy: Never
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  nodeSelector:
+    crusoe.ai/instance.class: ${INSTANCE_CLASS}     # s2a
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: cmk-data-transfer-worker
+  containers:
+    - name: worker
+      image: ${RCLONE_IMAGE}                        # rclone/rclone:latest
+      env:
+        - { name: SHARD_INDEX, value: "0" }
+        - { name: RC_PORT, value: "5572" }          # 5572 + pod index (unique/node)
+      command:
+        - /bin/sh
+        - -c
+        - >
+          set -eu;
+          mkdir -p /data/dataset /data/logs;
+          rclone copy
+          --files-from /data/shards/shard-${SHARD_INDEX}.txt
+          oci:${OCI_BUCKET}/${OCI_PREFIX} /data/dataset
+          --config /config/rclone.conf
+          --transfers ${RCLONE_TRANSFERS}
+          --multi-thread-streams ${RCLONE_MULTI_THREAD_STREAMS}
+          --multi-thread-cutoff ${RCLONE_MULTI_THREAD_CUTOFF}
+          --multi-thread-chunk-size ${RCLONE_MULTI_THREAD_CHUNK_SIZE}
+          --no-traverse
+          --s3-chunk-size ${RCLONE_S3_CHUNK_SIZE}
+          --buffer-size ${RCLONE_BUFFER_SIZE}
+          --rc --rc-addr localhost:$RC_PORT --rc-no-auth
+          --stats 10s --stats-one-line -v
+          2>&1 | tee /data/logs/worker-${SHARD_INDEX}.log
+      resources:
+        requests:
+          cpu: "${WORKER_CPU_REQUEST}"              # auto: (vCPU - headroom) / PODS_PER_NODE
+          memory: ${WORKER_MEM_REQUEST}
+      volumeMounts:
+        - { name: shared, mountPath: /data }
+        - { name: rclone-conf, mountPath: /config, readOnly: true }
+  volumes:
+    - name: shared
+      persistentVolumeClaim:
+        claimName: ${PVC_NAME}
+    - name: rclone-conf
+      secret:
+        secretName: ${SECRET_NAME}
+        defaultMode: 0400
+        items:
+          - { key: rclone.conf, path: rclone.conf }

--- a/cmk-data-transfer/orchestrator/__init__.py
+++ b/cmk-data-transfer/orchestrator/__init__.py
@@ -1,0 +1,8 @@
+"""cmk-data-transfer orchestrator.
+
+Parallel-pulls a dataset from OCI Object Storage (S3-compatible endpoint) to a
+VAST-backed ReadWriteMany shared disk on Crusoe Managed Kubernetes, engineered
+to saturate s2a worker hosts over a high-RTT intercontinental path.
+"""
+
+__version__ = "0.1.0"

--- a/cmk-data-transfer/orchestrator/config.py
+++ b/cmk-data-transfer/orchestrator/config.py
@@ -1,0 +1,374 @@
+"""Configuration: env / .env / CLI flags -> a single Config object.
+
+Precedence (low -> high): .env file < process env < CLI flags.
+Secrets are read but never logged or written to disk in cleartext outside the
+in-cluster Kubernetes Secret.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+from typing import Optional
+
+
+# --- s2a.80x SKU baseline (drives the sizing model) ---
+# 80 vCPU, ~676 GiB RAM, single 200 Gbps NIC. Adjust for other SKUs.
+S2A_VCPU = 80
+S2A_RAM_GIB = 676
+S2A_NIC_GBPS = 200
+
+
+KNOWN_OCI_REGION_RE = re.compile(r"^[a-z]{2,3}-[a-z]+-\d+$")  # e.g. us-phoenix-1
+
+
+def _load_dotenv(path: Path) -> dict[str, str]:
+    """Minimal .env parser (no dependency on python-dotenv)."""
+    out: dict[str, str] = {}
+    if not path.is_file():
+        return out
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip()
+        # strip inline comment, but not inside quotes and not a '#' that's part
+        # of the value (only treat ' #' / leading '#' / '\t#' as a comment start)
+        if val and val[0] not in ("'", '"'):
+            if val.startswith("#"):
+                val = ""
+            else:
+                for sep in (" #", "\t#"):
+                    idx = val.find(sep)
+                    if idx != -1:
+                        val = val[:idx]
+        val = val.strip().strip('"').strip("'")
+        if key:
+            out[key] = val
+    return out
+
+
+@dataclass
+class Config:
+    # --- OCI source ---
+    access_key_id: str = ""
+    secret_access_key: str = ""
+    namespace: str = ""
+    region: str = "us-phoenix-1"
+    bucket: str = ""
+    prefix: str = ""
+    endpoint: str = ""
+
+    # --- Destination ---
+    pvc_name: str = "cmk-data-transfer-fs"
+    pvc_size: str = "1000Ti"
+    storage_class: str = "crusoe-csi-driver-fs-sc"
+    dest_path: str = "/data/dataset"
+
+    # --- Import an EXISTING Crusoe shared disk (instead of dynamic provisioning).
+    # Find the values with `crusoe storage disks list -f json`: use the disk's
+    # `id` (volumeHandle), `name` (disk-name attribute) and `serial_number`.
+    # When all three are set, the orchestrator creates a static PV (reclaim
+    # policy Retain — the customer's disk is never deleted) and binds the PVC to
+    # it instead of provisioning a new disk. Migrate data into an existing disk.
+    existing_disk_id: str = ""       # crusoe disk `id`  -> CSI volumeHandle
+    existing_disk_name: str = ""     # crusoe disk `name`-> csi.crusoe.ai/disk-name
+    existing_disk_serial: str = ""   # crusoe disk `serial_number`
+    existing_disk_fstype: str = "ext4"
+
+    # --- Destination mode ---
+    #   dynamic : provision a new disk via the fs CSI driver (default)
+    #   import  : bind an existing disk via a CSI static PV (disk id/name/serial)
+    #   nfs     : bind an existing disk via an in-tree NFS PV straight to the VAST
+    #             DNS endpoint, bypassing the CSI driver. Use this where CSI mounts
+    #             time out on an unroutable fallback IP (disk returns no data-path
+    #             connectivity fields).
+    dest_mode: str = "dynamic"
+    nfs_server: str = "nfs.crusoecloudcompute.com"
+    nfs_export_path: str = ""        # default: /volumes/<existing_disk_id>
+    nfs_mount_options: str = (
+        "vers=3,nconnect=16,spread_reads,spread_writes,remoteports=dns")
+
+    # --- Sizing ---
+    target_gbps: float = 30.0
+    num_nodes: int = 4
+    pods_per_node: int = 8          # multiple workers per node (more = shorter tail)
+    num_pods: Optional[int] = None  # absolute override; default = nodes*per_node
+    instance_class: str = "s2a"
+    rtt_ms: float = 150.0
+    per_stream_mbps: float = 250.0
+    stream_safety: float = 1.5
+
+    # --- rclone (blank/None => auto-derive in sizing) ---
+    rclone_transfers: Optional[int] = None
+    rclone_multi_thread_streams: Optional[int] = None
+    rclone_multi_thread_cutoff: str = "256M"
+    rclone_multi_thread_chunk_size: str = "32M"   # smaller = shorter per-file tail
+    rclone_checkers: Optional[int] = None
+    rclone_buffer_size: str = "32M"
+    rclone_s3_chunk_size: str = "64M"
+    rclone_extra_flags: str = ""
+
+    # --- Worker pod resources (blank => auto-derive from pods_per_node) ---
+    worker_cpu_request: str = ""
+    worker_mem_request: str = ""
+
+    # --- K8s plumbing ---
+    k8s_namespace: str = "default"
+    secret_name: str = "cmk-data-transfer-oci"
+    rclone_image: str = "rclone/rclone:latest"
+    master_pod_name: str = "cmk-data-transfer-master"
+    mount_root: str = "/data"  # shared-disk (PVC) mount path in all pods
+    kubeconfig: str = ""
+
+    def effective_num_pods(self) -> int:
+        """Total worker pods across the fleet."""
+        if self.num_pods:
+            return self.num_pods
+        return self.num_nodes * max(1, self.pods_per_node)
+
+    def effective_pods_per_node(self) -> int:
+        """Workers per node. If NUM_PODS is forced, spread it across nodes."""
+        if self.num_pods:
+            return max(1, -(-self.num_pods // self.num_nodes))  # ceil div
+        return max(1, self.pods_per_node)
+
+    def effective_endpoint(self) -> str:
+        if self.endpoint:
+            return self.endpoint
+        return (
+            f"https://{self.namespace}.compat.objectstorage."
+            f"{self.region}.oraclecloud.com"
+        )
+
+    def remote_root(self) -> str:
+        """`oci:bucket[/prefix]` for rclone."""
+        root = f"oci:{self.bucket}"
+        if self.prefix:
+            root += "/" + self.prefix.strip("/")
+        return root
+
+    def is_import(self) -> bool:
+        """Bind an existing disk via a CSI static PV."""
+        return self.dest_mode == "import"
+
+    def is_nfs(self) -> bool:
+        """Bind an existing disk via an in-tree NFS PV (DNS endpoint)."""
+        return self.dest_mode == "nfs"
+
+    def static_pv_name(self) -> str:
+        """Name of the static PV created for import/nfs modes."""
+        return f"{self.pvc_name}-pv"
+
+    def nfs_path(self) -> str:
+        return self.nfs_export_path or f"/volumes/{self.existing_disk_id}"
+
+    # ----------------------------------------------------------------- validate
+    def validate(self, require_secrets: bool = True) -> list[str]:
+        errs: list[str] = []
+        if require_secrets:
+            if not self.access_key_id:
+                errs.append("OCI_ACCESS_KEY_ID is required")
+            if not self.secret_access_key:
+                errs.append("OCI_SECRET_ACCESS_KEY is required")
+        if not self.namespace and not self.endpoint:
+            errs.append("OCI_NAMESPACE (or explicit OCI_ENDPOINT) is required")
+        if not self.bucket:
+            errs.append("OCI_BUCKET is required")
+        if self.num_nodes < 1:
+            errs.append("NUM_NODES must be >= 1")
+        if self.target_gbps <= 0:
+            errs.append("TARGET_GBPS must be > 0")
+        if self.pods_per_node < 1:
+            errs.append("PODS_PER_NODE must be >= 1")
+        if self.dest_mode not in ("dynamic", "import", "nfs"):
+            errs.append(f"DEST_MODE must be dynamic|import|nfs (got "
+                        f"'{self.dest_mode}')")
+        if self.is_import() and not (self.existing_disk_id
+                                     and self.existing_disk_name
+                                     and self.existing_disk_serial):
+            errs.append(
+                "import mode needs EXISTING_DISK_ID, EXISTING_DISK_NAME, and "
+                "EXISTING_DISK_SERIAL together (from `crusoe storage disks "
+                "list -f json`: the disk's id, name, and serial_number)."
+            )
+        if self.is_nfs():
+            if not self.existing_disk_id and not self.nfs_export_path:
+                errs.append("nfs mode needs EXISTING_DISK_ID (export path "
+                            "/volumes/<id>) or an explicit NFS_EXPORT_PATH")
+            if not self.nfs_server:
+                errs.append("nfs mode needs NFS_SERVER")
+        return errs
+
+    def warnings(self) -> list[str]:
+        warns: list[str] = []
+        if not self.endpoint and not KNOWN_OCI_REGION_RE.match(self.region):
+            warns.append(
+                f"OCI_REGION='{self.region}' does not look like an OCI region "
+                "slug (expected e.g. us-phoenix-1 / us-ashburn-1). Use the OCI "
+                "region where the bucket lives, not the destination/cloud region."
+            )
+        return warns
+
+
+def _coerce(name: str, raw: str):
+    """Coerce a string env value to the dataclass field type."""
+    types = {f.name: f.type for f in fields(Config)}
+    t = types.get(name, "str")
+    if raw == "":
+        return None if "Optional" in str(t) else raw
+    if "int" in str(t):
+        return int(raw)
+    if "float" in str(t):
+        return float(raw)
+    return raw
+
+
+# env var name -> Config field name
+_ENV_MAP = {
+    "OCI_ACCESS_KEY_ID": "access_key_id",
+    "OCI_SECRET_ACCESS_KEY": "secret_access_key",
+    "OCI_NAMESPACE": "namespace",
+    "OCI_REGION": "region",
+    "OCI_BUCKET": "bucket",
+    "OCI_PREFIX": "prefix",
+    "OCI_ENDPOINT": "endpoint",
+    "PVC_NAME": "pvc_name",
+    "PVC_SIZE": "pvc_size",
+    "STORAGE_CLASS": "storage_class",
+    "DEST_PATH": "dest_path",
+    "EXISTING_DISK_ID": "existing_disk_id",
+    "EXISTING_DISK_NAME": "existing_disk_name",
+    "EXISTING_DISK_SERIAL": "existing_disk_serial",
+    "EXISTING_DISK_FSTYPE": "existing_disk_fstype",
+    "DEST_MODE": "dest_mode",
+    "NFS_SERVER": "nfs_server",
+    "NFS_EXPORT_PATH": "nfs_export_path",
+    "NFS_MOUNT_OPTIONS": "nfs_mount_options",
+    "TARGET_GBPS": "target_gbps",
+    "NUM_NODES": "num_nodes",
+    "PODS_PER_NODE": "pods_per_node",
+    "NUM_PODS": "num_pods",
+    "INSTANCE_CLASS": "instance_class",
+    "RTT_MS": "rtt_ms",
+    "PER_STREAM_MBPS": "per_stream_mbps",
+    "STREAM_SAFETY": "stream_safety",
+    "RCLONE_TRANSFERS": "rclone_transfers",
+    "RCLONE_MULTI_THREAD_STREAMS": "rclone_multi_thread_streams",
+    "RCLONE_MULTI_THREAD_CUTOFF": "rclone_multi_thread_cutoff",
+    "RCLONE_MULTI_THREAD_CHUNK_SIZE": "rclone_multi_thread_chunk_size",
+    "RCLONE_CHECKERS": "rclone_checkers",
+    "RCLONE_BUFFER_SIZE": "rclone_buffer_size",
+    "RCLONE_S3_CHUNK_SIZE": "rclone_s3_chunk_size",
+    "RCLONE_EXTRA_FLAGS": "rclone_extra_flags",
+    "WORKER_CPU_REQUEST": "worker_cpu_request",
+    "WORKER_MEM_REQUEST": "worker_mem_request",
+    "NAMESPACE": "k8s_namespace",
+    "SECRET_NAME": "secret_name",
+    "RCLONE_IMAGE": "rclone_image",
+    "KUBECONFIG": "kubeconfig",
+}
+
+
+def load_config(argv: Optional[list[str]] = None):
+    """Build Config from .env, process env, then CLI flags (highest).
+
+    Returns (Config, argparse.Namespace) so callers can read run-control flags
+    like --dry-run / --keep / --yes.
+    """
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    env_file = Path(args.env_file or ".env")
+    merged: dict[str, str] = {}
+    merged.update(_load_dotenv(env_file))
+    # process env overrides .env
+    for env_key in _ENV_MAP:
+        if env_key in os.environ:
+            merged[env_key] = os.environ[env_key]
+
+    cfg = Config()
+    for env_key, field_name in _ENV_MAP.items():
+        if env_key in merged:
+            coerced = _coerce(field_name, merged[env_key])
+            if coerced is not None:
+                setattr(cfg, field_name, coerced)
+
+    # CLI flags (highest precedence) — only those explicitly provided.
+    cli_map = {
+        "target_gbps": args.target_gbps,
+        "num_nodes": args.num_nodes,
+        "pods_per_node": args.pods_per_node,
+        "num_pods": args.num_pods,
+        "bucket": args.bucket,
+        "prefix": args.prefix,
+        "namespace": args.namespace,
+        "region": args.region,
+        "rtt_ms": args.rtt_ms,
+        "per_stream_mbps": args.per_stream_mbps,
+        "rclone_transfers": args.transfers,
+        "rclone_multi_thread_streams": args.multi_thread_streams,
+        "rclone_checkers": args.checkers,
+        "pvc_name": args.pvc_name,
+        "storage_class": args.storage_class,
+        "existing_disk_id": args.import_disk_id,
+        "existing_disk_name": args.import_disk_name,
+        "existing_disk_serial": args.import_disk_serial,
+        "dest_mode": args.dest_mode,
+        "nfs_server": args.nfs_server,
+    }
+    for field_name, val in cli_map.items():
+        if val is not None:
+            setattr(cfg, field_name, val)
+
+    if cfg.kubeconfig:
+        os.environ["KUBECONFIG"] = cfg.kubeconfig
+
+    return cfg, args
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Parallel OCI->VAST pull on Crusoe CMK, tuned for s2a.",
+    )
+    p.add_argument("--env-file", help="Path to .env (default: ./.env)")
+    p.add_argument("--target-gbps", type=float, help="Single sizing knob")
+    p.add_argument("--num-nodes", type=int)
+    p.add_argument("--pods-per-node", type=int,
+                   help="worker pods per node (spread evenly)")
+    p.add_argument("--num-pods", type=int,
+                   help="absolute total pods override (spread across nodes)")
+    p.add_argument("--bucket")
+    p.add_argument("--prefix")
+    p.add_argument("--namespace", help="OCI Object Storage namespace")
+    p.add_argument("--region", help="OCI region slug")
+    p.add_argument("--rtt-ms", type=float)
+    p.add_argument("--per-stream-mbps", type=float)
+    p.add_argument("--transfers", type=int, help="Override rclone --transfers")
+    p.add_argument("--multi-thread-streams", type=int,
+                   help="Override rclone --multi-thread-streams")
+    p.add_argument("--checkers", type=int, help="Override rclone --checkers")
+    p.add_argument("--pvc-name")
+    p.add_argument("--storage-class")
+    p.add_argument("--import-disk-id",
+                   help="Bind an EXISTING shared disk: its `id` (volumeHandle) "
+                        "from `crusoe storage disks list`")
+    p.add_argument("--import-disk-name",
+                   help="Existing disk `name` (csi.crusoe.ai/disk-name)")
+    p.add_argument("--import-disk-serial",
+                   help="Existing disk `serial_number`")
+    p.add_argument("--dest-mode", choices=("dynamic", "import", "nfs"),
+                   help="destination: provision / CSI import / in-tree NFS PV")
+    p.add_argument("--nfs-server", help="VAST NFS DNS endpoint (nfs mode)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Render plan + manifests, do not apply to the cluster")
+    p.add_argument("--keep", action="store_true",
+                   help="Do not tear down pods after completion")
+    p.add_argument("--yes", action="store_true",
+                   help="Skip the interactive confirmation before launching "
+                        "worker pods (the large transfer).")
+    return p

--- a/cmk-data-transfer/orchestrator/config.py
+++ b/cmk-data-transfer/orchestrator/config.py
@@ -14,8 +14,8 @@ from pathlib import Path
 from typing import Optional
 
 
-# --- s2a.80x SKU baseline (drives the sizing model) ---
-# 80 vCPU, ~676 GiB RAM, single 200 Gbps NIC. Adjust for other SKUs.
+# --- Default node hardware baseline (s2a.80x): drives the sizing model. ---
+# Override per-SKU via NODE_VCPU / NODE_RAM_GIB / NODE_NIC_GBPS.
 S2A_VCPU = 80
 S2A_RAM_GIB = 676
 S2A_NIC_GBPS = 200
@@ -99,6 +99,10 @@ class Config:
     pods_per_node: int = 8          # multiple workers per node (more = shorter tail)
     num_pods: Optional[int] = None  # absolute override; default = nodes*per_node
     instance_class: str = "s2a"
+    # Node hardware (defaults = s2a.80x); set for other SKUs/clouds.
+    node_vcpu: int = S2A_VCPU
+    node_ram_gib: int = S2A_RAM_GIB
+    node_nic_gbps: int = S2A_NIC_GBPS
     rtt_ms: float = 150.0
     per_stream_mbps: float = 250.0
     stream_safety: float = 1.5
@@ -254,6 +258,9 @@ _ENV_MAP = {
     "PODS_PER_NODE": "pods_per_node",
     "NUM_PODS": "num_pods",
     "INSTANCE_CLASS": "instance_class",
+    "NODE_VCPU": "node_vcpu",
+    "NODE_RAM_GIB": "node_ram_gib",
+    "NODE_NIC_GBPS": "node_nic_gbps",
     "RTT_MS": "rtt_ms",
     "PER_STREAM_MBPS": "per_stream_mbps",
     "STREAM_SAFETY": "stream_safety",

--- a/cmk-data-transfer/orchestrator/k8s.py
+++ b/cmk-data-transfer/orchestrator/k8s.py
@@ -1,0 +1,163 @@
+"""Thin kubectl wrappers (shell out, stdlib only — mirrors the reference impl).
+
+All cluster mutations funnel through here so they are easy to audit and so
+--dry-run can intercept apply/run calls.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from typing import Optional
+
+
+class Kubectl:
+    def __init__(self, namespace: str = "default", dry_run: bool = False):
+        self.namespace = namespace
+        self.dry_run = dry_run
+
+    # ------------------------------------------------------------------ helpers
+    def _base(self) -> list[str]:
+        return ["kubectl", "-n", self.namespace]
+
+    def _run(self, args: list[str], *, input_bytes: Optional[bytes] = None,
+             check: bool = True, capture: bool = False) -> subprocess.CompletedProcess:
+        cmd = self._base() + args
+        return subprocess.run(
+            cmd, input=input_bytes, check=check,
+            capture_output=capture, text=False,
+        )
+
+    # ------------------------------------------------------------------ queries
+    def get_json(self, *args: str) -> dict:
+        proc = subprocess.run(
+            self._base() + list(args) + ["-o", "json"],
+            check=True, capture_output=True, text=True,
+        )
+        return json.loads(proc.stdout)
+
+    def exists(self, kind: str, name: str) -> bool:
+        proc = subprocess.run(
+            self._base() + ["get", kind, name],
+            capture_output=True, text=True,
+        )
+        return proc.returncode == 0
+
+    def cluster_exists(self, kind: str, name: str) -> bool:
+        """Cluster-scoped resources (e.g. storageclass, nodes)."""
+        proc = subprocess.run(
+            ["kubectl", "get", kind, name],
+            capture_output=True, text=True,
+        )
+        return proc.returncode == 0
+
+    def list_ready_nodes(self, instance_class: str) -> list[str]:
+        data = self.get_json_cluster(
+            "get", "nodes", "-l", f"crusoe.ai/instance.class={instance_class}",
+        )
+        names = []
+        for n in data.get("items", []):
+            conds = {c["type"]: c["status"] for c in
+                     n.get("status", {}).get("conditions", [])}
+            unschedulable = n.get("spec", {}).get("unschedulable", False)
+            if conds.get("Ready") == "True" and not unschedulable:
+                names.append(n["metadata"]["name"])
+        return names
+
+    def get_json_cluster(self, *args: str) -> dict:
+        proc = subprocess.run(
+            ["kubectl"] + list(args) + ["-o", "json"],
+            check=True, capture_output=True, text=True,
+        )
+        return json.loads(proc.stdout)
+
+    # ----------------------------------------------------------------- mutators
+    def apply(self, manifest: dict) -> None:
+        body = json.dumps(manifest).encode()
+        if self.dry_run:
+            kind = manifest.get("kind", "?")
+            name = manifest.get("metadata", {}).get("name", "?")
+            print(f"  [dry-run] would apply {kind}/{name}")
+            return
+        self._run(["apply", "-f", "-"], input_bytes=body)
+
+    def apply_cluster(self, manifest: dict) -> None:
+        """Apply a cluster-scoped resource (no namespace)."""
+        body = json.dumps(manifest).encode()
+        if self.dry_run:
+            print(f"  [dry-run] would apply (cluster) "
+                  f"{manifest.get('kind')}/{manifest['metadata']['name']}")
+            return
+        subprocess.run(["kubectl", "apply", "-f", "-"],
+                       input=body, check=True)
+
+    def create_secret_from_files(self, name: str,
+                                 files: dict[str, str]) -> None:
+        """Idempotent generic secret from in-memory file contents.
+
+        Renders the secret as YAML via --dry-run=client then applies it, so the
+        secret value never appears in a process arg list (avoids leaking creds
+        into shell history / psaux). `files` maps filename -> contents.
+        """
+        if self.dry_run:
+            print(f"  [dry-run] would create/replace secret/{name} "
+                  f"with keys {list(files)}")
+            return
+        import base64
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {"name": name, "namespace": self.namespace},
+            "type": "Opaque",
+            "data": {
+                k: base64.b64encode(v.encode()).decode()
+                for k, v in files.items()
+            },
+        }
+        self._run(["apply", "-f", "-"], input_bytes=json.dumps(manifest).encode())
+
+    def wait_ready(self, pod: str, timeout: str = "600s") -> None:
+        if self.dry_run:
+            print(f"  [dry-run] would wait for pod/{pod} Ready")
+            return
+        self._run(["wait", "--for=condition=Ready", f"pod/{pod}",
+                   f"--timeout={timeout}"])
+
+    def exec(self, pod: str, argv: list[str], check: bool = True
+             ) -> subprocess.CompletedProcess:
+        if self.dry_run:
+            print(f"  [dry-run] would exec in {pod}: {' '.join(argv)}")
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+        return self._run(["exec", pod, "--"] + argv, check=check,
+                         capture=True)
+
+    def cp_to(self, pod: str, local_path: str, remote_path: str) -> None:
+        if self.dry_run:
+            print(f"  [dry-run] would cp {local_path} -> {pod}:{remote_path}")
+            return
+        self._run(["cp", local_path, f"{pod}:{remote_path}"])
+
+    def logs(self, pod: str, tail: int = 5) -> str:
+        proc = self._run(["logs", "--tail", str(tail), pod],
+                         check=False, capture=True)
+        return proc.stdout.decode(errors="replace") if proc.stdout else ""
+
+    def delete(self, kind: str, name: str = "", selector: str = "",
+               wait: bool = False) -> None:
+        if self.dry_run:
+            tgt = name or f"-l {selector}"
+            print(f"  [dry-run] would delete {kind} {tgt}")
+            return
+        args = ["delete", kind]
+        if name:
+            args.append(name)
+        if selector:
+            args += ["-l", selector]
+        args += [f"--wait={'true' if wait else 'false'}", "--ignore-not-found"]
+        self._run(args, check=False)
+
+
+def die(msg: str) -> None:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)

--- a/cmk-data-transfer/orchestrator/manifests.py
+++ b/cmk-data-transfer/orchestrator/manifests.py
@@ -1,0 +1,273 @@
+"""Kubernetes manifest (dict) builders.
+
+These dicts are the authoritative, runtime-applied manifests. Human-readable
+YAML equivalents live under k8s/ for reference and manual use.
+
+Layout on the shared RWX volume (mounted at cfg.mount_root, default /data):
+    /data/shards/shard-<i>.txt     # one manifest per worker
+    /data/logs/worker-<i>.log      # per-worker rclone output
+    /data/dataset/...              # downloaded objects (DEST_PATH)
+"""
+from __future__ import annotations
+
+from .config import Config
+from .sizing import Sizing
+
+WORKER_LABEL = "cmk-data-transfer-worker"
+SHARD_SUBDIR = "shards"
+LOG_SUBDIR = "logs"
+BASE_RC_PORT = 5572   # worker i binds rc on BASE_RC_PORT + i (unique per pod)
+
+
+def shard_dir(cfg: Config) -> str:
+    return f"{cfg.mount_root}/{SHARD_SUBDIR}"
+
+
+def log_dir(cfg: Config) -> str:
+    return f"{cfg.mount_root}/{LOG_SUBDIR}"
+
+
+def storage_class(name: str) -> dict:
+    """Crusoe VAST RWX storage class (created only if absent)."""
+    return {
+        "apiVersion": "storage.k8s.io/v1",
+        "kind": "StorageClass",
+        "metadata": {"name": name},
+        "provisioner": "fs.csi.crusoe.ai",
+        "reclaimPolicy": "Delete",
+        "volumeBindingMode": "Immediate",
+        "allowVolumeExpansion": True,
+    }
+
+
+def import_pv(cfg: Config) -> dict:
+    """Static PV that binds to an EXISTING Crusoe shared disk.
+
+    Mirrors the PV shape the fs CSI provisioner emits for a dynamic claim, but
+    points volumeHandle at the customer's existing disk and uses reclaimPolicy
+    Retain so the disk (and its data) is never deleted when the PVC/PV go away.
+    Pre-bound to our PVC via claimRef so nothing else can claim it.
+    """
+    return {
+        "apiVersion": "v1",
+        "kind": "PersistentVolume",
+        "metadata": {"name": cfg.static_pv_name()},
+        "spec": {
+            "capacity": {"storage": cfg.pvc_size},
+            "accessModes": ["ReadWriteMany"],
+            "persistentVolumeReclaimPolicy": "Retain",
+            "storageClassName": "",            # static; no dynamic provisioning
+            "volumeMode": "Filesystem",
+            "csi": {
+                "driver": "fs.csi.crusoe.ai",
+                "volumeHandle": cfg.existing_disk_id,
+                "fsType": cfg.existing_disk_fstype,
+                "volumeAttributes": {
+                    "csi.crusoe.ai/disk-name": cfg.existing_disk_name,
+                    "csi.crusoe.ai/serial-number": cfg.existing_disk_serial,
+                },
+            },
+            "claimRef": {"namespace": cfg.k8s_namespace, "name": cfg.pvc_name},
+        },
+    }
+
+
+def nfs_pv(cfg: Config) -> dict:
+    """Static IN-TREE NFS PV bound to an existing VAST volume via the DNS
+    endpoint — bypasses the CSI driver.
+
+    Why this exists: where the fs CSI driver falls back to an unroutable IP
+    (the disk returns no data-path connectivity fields) and mounts time out, the
+    VAST DNS endpoint resolves to the in-VPC data IPs and mounts cleanly with
+    remoteports=dns. reclaimPolicy Retain so the disk/data is never deleted.
+    """
+    return {
+        "apiVersion": "v1",
+        "kind": "PersistentVolume",
+        "metadata": {"name": cfg.static_pv_name()},
+        "spec": {
+            "capacity": {"storage": cfg.pvc_size},
+            "accessModes": ["ReadWriteMany"],
+            "persistentVolumeReclaimPolicy": "Retain",
+            "storageClassName": "",
+            "volumeMode": "Filesystem",
+            "mountOptions": cfg.nfs_mount_options.split(","),
+            "nfs": {"server": cfg.nfs_server, "path": cfg.nfs_path()},
+            "claimRef": {"namespace": cfg.k8s_namespace, "name": cfg.pvc_name},
+        },
+    }
+
+
+def pvc(cfg: Config) -> dict:
+    spec = {
+        "accessModes": ["ReadWriteMany"],
+        "resources": {"requests": {"storage": cfg.pvc_size}},
+        "volumeMode": "Filesystem",
+    }
+    if cfg.is_import() or cfg.is_nfs():
+        # bind to the static PV; empty class disables dynamic provisioning
+        spec["storageClassName"] = ""
+        spec["volumeName"] = cfg.static_pv_name()
+    else:
+        spec["storageClassName"] = cfg.storage_class
+    return {
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {"name": cfg.pvc_name, "namespace": cfg.k8s_namespace},
+        "spec": spec,
+    }
+
+
+def _shared_volume(cfg: Config) -> dict:
+    return {"name": "shared",
+            "persistentVolumeClaim": {"claimName": cfg.pvc_name}}
+
+
+def _rclone_conf_volume(cfg: Config) -> dict:
+    return {"name": "rclone-conf",
+            "secret": {"secretName": cfg.secret_name,
+                       "defaultMode": 0o400,
+                       "items": [{"key": "rclone.conf",
+                                  "path": "rclone.conf"}]}}
+
+
+def master_pod(cfg: Config) -> dict:
+    """Lightweight pod that mounts the shared disk; lists + shards run here.
+
+    Pinned to the worker instance class so its in-cluster egress path to OCI
+    matches the workers' (relevant for the listing pass).
+    """
+    init = (f"mkdir -p {shard_dir(cfg)} {log_dir(cfg)} {cfg.dest_path}; "
+            "while true; do sleep 3600; done")
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": cfg.master_pod_name,
+            "namespace": cfg.k8s_namespace,
+            "labels": {"app": "cmk-data-transfer-master"},
+        },
+        "spec": {
+            "restartPolicy": "Never",
+            "nodeSelector": {"crusoe.ai/instance.class": cfg.instance_class},
+            "containers": [
+                {
+                    "name": "master",
+                    "image": cfg.rclone_image,
+                    "command": ["/bin/sh", "-c", init],
+                    "env": [{"name": "RCLONE_CONFIG",
+                             "value": "/config/rclone.conf"}],
+                    "volumeMounts": [
+                        {"name": "shared", "mountPath": cfg.mount_root},
+                        {"name": "rclone-conf", "mountPath": "/config",
+                         "readOnly": True},
+                    ],
+                }
+            ],
+            "volumes": [
+                _shared_volume(cfg),
+                _rclone_conf_volume(cfg),
+            ],
+        },
+    }
+
+
+def _worker_command(cfg: Config, sizing: Sizing) -> list[str]:
+    shard_file = f"{shard_dir(cfg)}/shard-${{SHARD_INDEX}}.txt"
+    log_file = f"{log_dir(cfg)}/worker-${{SHARD_INDEX}}.log"
+
+    rclone = [
+        "rclone", "copy",
+        "--files-from", shard_file,
+        cfg.remote_root(), cfg.dest_path,
+        "--config", "/config/rclone.conf",
+        "--transfers", str(sizing.transfers),
+        "--multi-thread-streams", str(sizing.multi_thread_streams),
+        "--multi-thread-cutoff", cfg.rclone_multi_thread_cutoff,
+        "--multi-thread-chunk-size", cfg.rclone_multi_thread_chunk_size,
+    ]
+    # --checkers only when explicitly set (RCLONE_CHECKERS). With --files-from
+    # + --no-traverse there's little to check, and the AWS reference omits it;
+    # leaving it off uses rclone's default and avoids extra HEAD latency.
+    if cfg.rclone_checkers is not None:
+        rclone += ["--checkers", str(sizing.checkers)]
+    rclone += [
+        "--no-traverse",
+        "--s3-chunk-size", cfg.rclone_s3_chunk_size,
+        "--buffer-size", cfg.rclone_buffer_size,
+        # remote-control endpoint so the benchmark collector can poll
+        # core/stats per pod. Each pod binds a UNIQUE port ($RC_PORT) because
+        # hostNetwork pods share the node's netns — fixed 5572 would collide
+        # when multiple workers run on the same node.
+        "--rc", "--rc-addr", "localhost:$RC_PORT", "--rc-no-auth",
+        "--stats", "10s", "--stats-one-line", "-v",
+    ]
+    if cfg.rclone_extra_flags:
+        rclone += cfg.rclone_extra_flags.split()
+
+    rclone_str = " ".join(rclone)
+    script = (
+        "set -eu; "
+        f"mkdir -p {cfg.dest_path} {log_dir(cfg)}; "
+        'echo "[worker ${SHARD_INDEX}] $(date -u) starting"; '
+        f"{rclone_str} 2>&1 | tee {log_file}"
+    )
+    return ["/bin/sh", "-c", script]
+
+
+def worker_pod(cfg: Config, sizing: Sizing, index: int) -> dict:
+    name = f"cmk-data-transfer-worker-{index}"
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": name,
+            "namespace": cfg.k8s_namespace,
+            "labels": {"app": WORKER_LABEL, "shard": str(index)},
+        },
+        "spec": {
+            "restartPolicy": "Never",
+            "hostNetwork": True,            # bypass CNI, use node NIC directly
+            "dnsPolicy": "ClusterFirstWithHostNet",
+            "nodeSelector": {"crusoe.ai/instance.class": cfg.instance_class},
+            # Spread workers EVENLY across nodes (maxSkew=1) so we get
+            # pods_per_node on each node rather than all piling onto one. With
+            # total_pods = nodes * pods_per_node, even spread => exactly
+            # pods_per_node per node. Resource requests (below) enforce density.
+            "topologySpreadConstraints": [
+                {
+                    "maxSkew": 1,
+                    "topologyKey": "kubernetes.io/hostname",
+                    "whenUnsatisfiable": "DoNotSchedule",
+                    "labelSelector": {"matchLabels": {"app": WORKER_LABEL}},
+                }
+            ],
+            "containers": [
+                {
+                    "name": "worker",
+                    "image": cfg.rclone_image,
+                    "command": _worker_command(cfg, sizing),
+                    "env": [
+                        {"name": "SHARD_INDEX", "value": str(index)},
+                        # globally-unique rc port (hostNetwork shares node netns)
+                        {"name": "RC_PORT", "value": str(BASE_RC_PORT + index)},
+                    ],
+                    "resources": {
+                        "requests": {
+                            "cpu": sizing.worker_cpu_request,
+                            "memory": sizing.worker_mem_request,
+                        }
+                    },
+                    "volumeMounts": [
+                        {"name": "shared", "mountPath": cfg.mount_root},
+                        {"name": "rclone-conf", "mountPath": "/config",
+                         "readOnly": True},
+                    ],
+                }
+            ],
+            "volumes": [
+                _shared_volume(cfg),
+                _rclone_conf_volume(cfg),
+            ],
+        },
+    }

--- a/cmk-data-transfer/orchestrator/rclone_conf.py
+++ b/cmk-data-transfer/orchestrator/rclone_conf.py
@@ -1,0 +1,58 @@
+"""Build the rclone.conf body for the OCI remote.
+
+Primary path: S3-compatible backend pointed at OCI's S3-compat endpoint, using
+the customer's Access Key / Secret Key (OCI "Customer Secret Key"). 
+
+The generated config is placed ONLY into a Kubernetes Secret (see k8s.py) and
+mounted read-only into pods. It is never written to the repo or committed.
+"""
+from __future__ import annotations
+
+from .config import Config
+
+
+def build_s3_compat_conf(cfg: Config) -> str:
+    """rclone remote named `oci` using the s3 backend against OCI S3-compat.
+
+    provider=Other + force_path_style is the generic S3-compatible profile;
+    OCI's S3-compat endpoint is path-style and validates region in the v4
+    signature, so we set region explicitly.
+    """
+    endpoint = cfg.effective_endpoint()
+    return "\n".join(
+        [
+            "[oci]",
+            "type = s3",
+            "provider = Other",
+            f"access_key_id = {cfg.access_key_id}",
+            f"secret_access_key = {cfg.secret_access_key}",
+            f"endpoint = {endpoint}",
+            f"region = {cfg.region}",
+            "force_path_style = true",
+            # OCI S3-compat does not implement bucket-create/HEAD-bucket the way
+            # AWS does; skip it so copy doesn't error on a read-only key.
+            "no_check_bucket = true",
+            "",
+        ]
+    )
+
+
+def native_oracle_conf_example(cfg: Config) -> str:
+    """Documented ALTERNATIVE: native oracleobjectstorage backend.
+
+    Uses OCI IAM (user/instance/resource principal), NOT the S3 access/secret
+    key. Shown for completeness; not the default path.
+    """
+    return "\n".join(
+        [
+            "[oci-native]",
+            "type = oracleobjectstorage",
+            f"namespace = {cfg.namespace or '<namespace>'}",
+            f"region = {cfg.region}",
+            "provider = user_principal_auth",
+            "config_file = /root/.oci/config",
+            "config_profile = DEFAULT",
+            "# compartment = ocid1.compartment.oc1..<...>   # for bucket listing",
+            "",
+        ]
+    )

--- a/cmk-data-transfer/orchestrator/run.py
+++ b/cmk-data-transfer/orchestrator/run.py
@@ -138,12 +138,24 @@ def shard_locally(cfg, kc: Kubectl, run_dir: str) -> int:
 
 def launch_workers(cfg, kc: Kubectl, sizing) -> list[str]:
     banner("Launching worker pods")
+    # Honor NUM_NODES for PLACEMENT: pin workers to exactly num_nodes nodes
+    # (round-robin via nodeName) so "N nodes x K pods/node" lands as N x K,
+    # instead of topology-spreading across every schedulable s2a node. nodeName
+    # bypasses the scheduler, so the manifest's spread constraint is inert here.
+    chosen = sorted(kc.list_ready_nodes(cfg.instance_class))[:cfg.num_nodes]
+    if len(chosen) < cfg.num_nodes:
+        die(f"only {len(chosen)} schedulable {cfg.instance_class} nodes; "
+            f"need NUM_NODES={cfg.num_nodes}.")
+    print(f"  pinning {cfg.effective_num_pods()} workers to {len(chosen)} "
+          f"node(s): " + ", ".join(n.split('.')[0] for n in chosen))
     names = []
     for i in range(cfg.effective_num_pods()):
         pod = manifests.worker_pod(cfg, sizing, i)
+        pod["spec"]["nodeName"] = chosen[i % len(chosen)]   # hard pin
         kc.apply(pod)
         names.append(pod["metadata"]["name"])
-        print(f"  launched {pod['metadata']['name']} (shard {i})")
+    print(f"  launched {len(names)} workers "
+          f"({cfg.effective_pods_per_node()}/node x {len(chosen)})")
     return names
 
 

--- a/cmk-data-transfer/orchestrator/run.py
+++ b/cmk-data-transfer/orchestrator/run.py
@@ -1,0 +1,297 @@
+"""Orchestrator entrypoint.
+
+Pipeline:
+  1. load config + compute sizing (BDP-grounded)               [always]
+  2. preflight: kubectl reachable, enough s2a nodes, StorageClass present
+  3. create K8s Secret (rclone.conf) — creds only live in-cluster
+  4. apply PVC (RWX VAST) + master pod
+  5. list source via `rclone lsf` (in master pod) -> /data/listing.tsv
+  6. pull listing, shard locally (LPT bin-pack), push shard files back
+  7. CONFIRM, then launch N pinned worker pods (the large transfer)
+  8. monitor to completion
+  9. teardown (unless --keep)
+
+Run:  python -m orchestrator.run   [flags]
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+
+# allow `from shard import shard_manifest` when run from repo root
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shard import shard_manifest  # noqa: E402
+
+from . import manifests  # noqa: E402
+from .config import load_config  # noqa: E402
+from .k8s import Kubectl, die  # noqa: E402
+from .rclone_conf import build_s3_compat_conf  # noqa: E402
+from .sizing import compute_sizing  # noqa: E402
+
+
+LISTING_REMOTE = "{root}/listing.tsv"
+
+
+def banner(msg: str) -> None:
+    print(f"\n=== {msg} ===")
+
+
+def confirm(prompt: str) -> bool:
+    try:
+        return input(f"{prompt} [y/N] ").strip().lower() in ("y", "yes")
+    except EOFError:
+        return False
+
+
+def preflight(cfg, kc: Kubectl) -> None:
+    banner("Preflight")
+    # kubectl reachable (queries the API server; non-zero if unreachable)
+    try:
+        kc.get_json_cluster("version")
+    except Exception as e:  # noqa: BLE001
+        die(f"kubectl cannot reach the cluster: {e}")
+
+    # enough schedulable s2a nodes?
+    nodes = kc.list_ready_nodes(cfg.instance_class)
+    print(f"  schedulable {cfg.instance_class} nodes: {len(nodes)} "
+          f"(need {cfg.num_nodes})")
+    for n in nodes:
+        print(f"    - {n}")
+    if len(nodes) < cfg.num_nodes:
+        die(f"only {len(nodes)} schedulable {cfg.instance_class} nodes; "
+            f"NUM_NODES={cfg.num_nodes}. Lower NUM_NODES or add nodes.")
+
+    if cfg.is_nfs():
+        print(f"  destination: NFS in-tree PV -> {cfg.nfs_server}:"
+              f"{cfg.nfs_path()} (bypasses CSI; reclaimPolicy=Retain)")
+        return
+    if cfg.is_import():
+        # Import mode binds a static PV; no StorageClass needed.
+        print(f"  destination: IMPORT existing disk id={cfg.existing_disk_id} "
+              f"serial={cfg.existing_disk_serial} (reclaimPolicy=Retain)")
+        return
+
+    # StorageClass present? (this cluster ships fs CSI but not the SC object)
+    if kc.cluster_exists("storageclass", cfg.storage_class):
+        print(f"  StorageClass {cfg.storage_class}: present")
+    else:
+        print(f"  StorageClass {cfg.storage_class}: ABSENT — creating "
+              "(fs.csi.crusoe.ai)")
+        kc.apply_cluster(manifests.storage_class(cfg.storage_class))
+
+
+def list_source(cfg, kc: Kubectl) -> None:
+    banner("Listing source (rclone lsf in master pod)")
+    listing = LISTING_REMOTE.format(root=cfg.mount_root)
+    # SEP is a real TAB byte (printf), so rclone and the local TSV parser agree.
+    # --format sp puts size first; the parser splits on the first TAB, so a TAB
+    # inside an object key (rare) stays part of the path.
+    lsf = (
+        "SEP=$(printf '\\t'); "
+        "rclone lsf --recursive --files-only --format sp --separator \"$SEP\" "
+        f"--config /config/rclone.conf {cfg.remote_root()} > {listing} && "
+        f"wc -l {listing}"
+    )
+    print(f"  {cfg.remote_root()}  ->  {listing}")
+    res = kc.exec(cfg.master_pod_name, ["/bin/sh", "-c", lsf])
+    if res.stdout:
+        print("  " + res.stdout.decode(errors="replace").strip())
+
+
+def shard_locally(cfg, kc: Kubectl, run_dir: str) -> int:
+    banner("Sharding (local LPT bin-pack)")
+    listing = LISTING_REMOTE.format(root=cfg.mount_root)
+    local_listing = os.path.join(run_dir, "listing.tsv")
+
+    if not kc.dry_run:
+        with open(local_listing, "wb") as fh:
+            res = kc.exec(cfg.master_pod_name, ["cat", listing])
+            fh.write(res.stdout or b"")
+        with open(local_listing) as fh:
+            objects = list(shard_manifest.parse_tsv(fh))
+        if not objects:
+            die("listing is empty — check bucket/prefix/credentials")
+        n = cfg.effective_num_pods()
+        bins, sizes = shard_manifest.bin_pack(objects, n)
+        local_shard_dir = os.path.join(run_dir, "shards")
+        shard_files = shard_manifest.write_shards(bins, local_shard_dir)
+        total = sum(sizes)
+        print(f"  {len(objects)} objects, {shard_manifest.human(total)} "
+              f"-> {n} shards")
+        for i, s in enumerate(sizes):
+            print(f"    shard-{i}.txt: {len(bins[i])} files "
+                  f"{shard_manifest.human(s)}")
+        # push shards back to the shared disk
+        for fp in shard_files:
+            dest = f"{manifests.shard_dir(cfg)}/{os.path.basename(fp)}"
+            kc.cp_to(cfg.master_pod_name, fp, dest)
+        print(f"  pushed {len(shard_files)} shard files to "
+              f"{manifests.shard_dir(cfg)}/")
+        return total
+    else:
+        print("  [dry-run] would list, bin-pack, and push shard files")
+        return 0
+
+
+def launch_workers(cfg, kc: Kubectl, sizing) -> list[str]:
+    banner("Launching worker pods")
+    names = []
+    for i in range(cfg.effective_num_pods()):
+        pod = manifests.worker_pod(cfg, sizing, i)
+        kc.apply(pod)
+        names.append(pod["metadata"]["name"])
+        print(f"  launched {pod['metadata']['name']} (shard {i})")
+    return names
+
+
+def monitor(cfg, kc: Kubectl, poll: int = 15) -> None:
+    banner("Monitoring workers")
+    if kc.dry_run:
+        print("  [dry-run] skipping monitor")
+        return
+    sel = f"app={manifests.WORKER_LABEL}"
+    while True:
+        data = kc.get_json("get", "pods", "-l", sel)
+        items = data.get("items", [])
+        phases = {}
+        running = []
+        for p in items:
+            ph = p["status"]["phase"]
+            phases[ph] = phases.get(ph, 0) + 1
+            if ph not in ("Succeeded", "Failed"):
+                running.append(p["metadata"]["name"])
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(phases.items()))
+        print(f"  [{time.strftime('%H:%M:%S')}] {summary}")
+        if not running:
+            break
+        time.sleep(poll)
+    # report failures
+    for p in items:
+        if p["status"]["phase"] == "Failed":
+            name = p["metadata"]["name"]
+            print(f"  !! {name} FAILED; last log lines:")
+            print("    " + kc.logs(name, tail=10).replace("\n", "\n    "))
+
+
+def teardown(cfg, kc: Kubectl) -> None:
+    banner("Teardown")
+    kc.delete("pod", selector=f"app={manifests.WORKER_LABEL}")
+    kc.delete("pod", name=cfg.master_pod_name)
+    print("  worker + master pods deleted (PVC, Secret, StorageClass kept)")
+
+
+def main(argv: list[str] | None = None) -> int:
+    cfg, args = load_config(argv)
+
+    errs = cfg.validate(require_secrets=not args.dry_run)
+    for w in cfg.warnings():
+        print(f"WARNING: {w}", file=sys.stderr)
+    if errs:
+        for e in errs:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    sizing = compute_sizing(cfg)
+    banner("Plan")
+    print(f"  source : {cfg.remote_root()}")
+    print(f"  via    : {cfg.effective_endpoint()}")
+    if cfg.is_nfs():
+        print(f"  dest   : PVC {cfg.pvc_name} -> NFS {cfg.nfs_server}:"
+              f"{cfg.nfs_path()} (in-tree PV, Retain) -> {cfg.dest_path}")
+    elif cfg.is_import():
+        print(f"  dest   : PVC {cfg.pvc_name} -> IMPORTED disk "
+              f"{cfg.existing_disk_id} (CSI static PV, Retain) -> {cfg.dest_path}")
+    else:
+        print(f"  dest   : PVC {cfg.pvc_name} ({cfg.storage_class}, dynamic) "
+              f"-> {cfg.dest_path}")
+    print()
+    print(sizing.explain())
+
+    kc = Kubectl(namespace=cfg.k8s_namespace, dry_run=args.dry_run)
+
+    if args.dry_run:
+        banner("Dry-run: rendering manifests to ./generated")
+        _render_generated(cfg, sizing)
+        preflight(cfg, kc)
+        print("\nDry-run complete. No transfer launched.")
+        return 0
+
+    run_dir = tempfile.mkdtemp(prefix="cmk-data-transfer-")
+    print(f"\n  run dir: {run_dir}")
+
+    preflight(cfg, kc)
+
+    banner("Creating Secret (rclone.conf) — creds stay in-cluster")
+    kc.create_secret_from_files(
+        cfg.secret_name, {"rclone.conf": build_s3_compat_conf(cfg)})
+    print(f"  secret/{cfg.secret_name} applied")
+
+    banner("Applying PVC + master pod")
+    if cfg.is_nfs():
+        kc.apply(manifests.nfs_pv(cfg))
+        print(f"  static NFS PV {cfg.static_pv_name()} -> {cfg.nfs_server}:"
+              f"{cfg.nfs_path()}")
+    elif cfg.is_import():
+        kc.apply(manifests.import_pv(cfg))
+        print(f"  static PV {cfg.static_pv_name()} -> disk {cfg.existing_disk_id}")
+    kc.apply(manifests.pvc(cfg))
+    kc.apply(manifests.master_pod(cfg))
+    kc.wait_ready(cfg.master_pod_name)
+    print(f"  pod/{cfg.master_pod_name} ready")
+
+    list_source(cfg, kc)
+    total_bytes = shard_locally(cfg, kc, run_dir)
+
+    banner("Ready to launch the transfer")
+    print(f"  {sizing.total_pods} worker pods "
+          f"({sizing.pods_per_node}/node x {cfg.num_nodes} {cfg.instance_class} "
+          f"nodes), {sizing.in_flight_per_node} in-flight streams/node.")
+    if total_bytes:
+        print(f"  dataset size: {shard_manifest.human(total_bytes)}")
+    if not args.yes and not confirm(
+            "Launch the worker pods now (starts the large download)?"):
+        print("Aborted before launch. Master pod + shards left in place "
+              "(re-run with --yes to launch).")
+        return 0
+
+    launch_workers(cfg, kc, sizing)
+    monitor(cfg, kc)
+
+    if args.keep:
+        print("\n--keep set: leaving pods running for inspection.")
+    else:
+        teardown(cfg, kc)
+
+    banner("Done")
+    print(f"  dataset on PVC {cfg.pvc_name} at {cfg.dest_path}")
+    print(f"  per-worker logs: {manifests.log_dir(cfg)}/worker-<i>.log")
+    return 0
+
+
+def _render_generated(cfg, sizing) -> None:
+    import json
+    out = os.path.join(os.getcwd(), "generated")
+    os.makedirs(out, exist_ok=True)
+    docs = {
+        "pvc.json": manifests.pvc(cfg),
+        "master-pod.json": manifests.master_pod(cfg),
+        "worker-pod-0.json": manifests.worker_pod(cfg, sizing, 0),
+    }
+    if cfg.is_nfs():
+        docs["nfs-pv.json"] = manifests.nfs_pv(cfg)
+    elif cfg.is_import():
+        docs["import-pv.json"] = manifests.import_pv(cfg)
+    else:
+        docs["storageclass.json"] = manifests.storage_class(cfg.storage_class)
+    for fname, doc in docs.items():
+        with open(os.path.join(out, fname), "w") as fh:
+            json.dump(doc, fh, indent=2)
+        print(f"  wrote generated/{fname}")
+    print("  (Secret intentionally NOT rendered — contains credentials)")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmk-data-transfer/orchestrator/sizing.py
+++ b/cmk-data-transfer/orchestrator/sizing.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-from .config import Config, S2A_VCPU, S2A_RAM_GIB, S2A_NIC_GBPS
+from .config import Config
 
 # leave this many vCPUs per node for the kubelet / CSI / system daemons
 SYSTEM_CPU_HEADROOM = 8
@@ -47,6 +47,7 @@ class Sizing:
     per_stream_mbps: float
     nic_gbps: int
     vcpu: int
+    ram_gib: int
 
     # derived
     per_node_gbps: float
@@ -102,7 +103,7 @@ class Sizing:
             "GiB actual)",
             "-" * 62,
             f"  per-node in-flight streams   : {self.in_flight_per_node} "
-            f"(of {S2A_VCPU} vCPU, {S2A_RAM_GIB} GiB)",
+            f"(of {self.vcpu} vCPU, {self.ram_gib} GiB)",
             f"  fleet in-flight streams      : "
             f"{self.in_flight_per_node * self.num_nodes}",
             f"  fleet worker pods            : {self.total_pods}",
@@ -125,8 +126,8 @@ def _parse_size_to_bytes(s: str) -> int:
 def compute_sizing(cfg: Config) -> Sizing:
     pods_per_node = cfg.effective_pods_per_node()
     total_pods = cfg.effective_num_pods()
-    nic_gbps = S2A_NIC_GBPS
-    vcpu = S2A_VCPU
+    nic_gbps = cfg.node_nic_gbps
+    vcpu = cfg.node_vcpu
 
     # 1) split the target across nodes, cap at 90% of NIC line rate (GB/s)
     per_node_gbps = cfg.target_gbps / cfg.num_nodes
@@ -195,6 +196,7 @@ def compute_sizing(cfg: Config) -> Sizing:
         per_stream_mbps=cfg.per_stream_mbps,
         nic_gbps=nic_gbps,
         vcpu=vcpu,
+        ram_gib=cfg.node_ram_gib,
         per_node_gbps=per_node_gbps,
         per_node_gbps_capped=per_node_gbps_capped,
         bdp_bytes_per_node=bdp_bytes_per_node,

--- a/cmk-data-transfer/orchestrator/sizing.py
+++ b/cmk-data-transfer/orchestrator/sizing.py
@@ -1,0 +1,219 @@
+"""Concurrency sizing, grounded in the discovered s2a hardware and the 150 ms
+bandwidth-delay product (BDP).
+
+THE CORE IDEA
+-------------
+Over a >150 ms intercontinental path, a single TCP stream is window-limited:
+
+    per_stream_throughput  ~=  tcp_window / RTT
+
+With a typical autotuned window (a few MB) that is only a few hundred Mbps,
+*regardless of file size*. So aggregate throughput must come from running many
+streams in parallel to fill the BDP of each node's NIC:
+
+    streams_to_fill_NIC  =  NIC_bps * RTT / window_bits          (the BDP, in streams)
+
+We fill that budget with MULTIPLE worker pods per node (pods_per_node), each an
+independent rclone process — independent processes avoid a single rclone's
+internal ceilings (one http.Transport, GC, lock contention) and saturate the
+shared NIC better than one process. Within each pod, two rclone levers multiply:
+
+    --transfers              : number of files copied in parallel
+    --multi-thread-streams   : ranged-GET streams per file (files > cutoff)
+
+So:  in-flight streams per node  ~=  pods_per_node * transfers * multi_thread_streams.
+We size per-node from the target+BDP, divide across pods, then clamp to the
+node's CPU (split across pods) and the NIC line rate.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from .config import Config, S2A_VCPU, S2A_RAM_GIB, S2A_NIC_GBPS
+
+# leave this many vCPUs per node for the kubelet / CSI / system daemons
+SYSTEM_CPU_HEADROOM = 8
+
+
+@dataclass
+class Sizing:
+    # inputs echoed for the plan
+    target_gbps: float
+    num_nodes: int
+    pods_per_node: int
+    total_pods: int
+    rtt_ms: float
+    per_stream_mbps: float
+    nic_gbps: int
+    vcpu: int
+
+    # derived
+    per_node_gbps: float
+    per_node_gbps_capped: float
+    bdp_bytes_per_node: float
+    streams_needed_per_node: int
+    per_pod_streams: int
+    transfers: int                 # per pod
+    multi_thread_streams: int      # per pod
+    checkers: int                  # per pod
+    checkers_explicit: bool        # whether --checkers is actually passed
+    in_flight_per_pod: int
+    in_flight_per_node: int
+    worker_cpu_request: str
+    worker_mem_request: str
+    est_mem_gib_per_pod: float
+    est_mem_gib_per_node: float
+
+    def explain(self) -> str:
+        lines = [
+            "Sizing plan (grounded in s2a hardware + 150 ms BDP)",
+            "-" * 62,
+            f"  TARGET_GBPS (total)        : {self.target_gbps:.2f} GB/s",
+            f"  nodes x pods/node          : {self.num_nodes} x "
+            f"{self.pods_per_node}  = {self.total_pods} worker pods",
+            f"  per-node target            : {self.per_node_gbps:.2f} GB/s "
+            f"({self.per_node_gbps * 8:.1f} Gbps)",
+            f"  per-node NIC line rate     : {self.nic_gbps} Gbps "
+            f"({self.nic_gbps / 8:.1f} GB/s)  [90% usable cap applied]",
+            f"  per-node target (capped)   : {self.per_node_gbps_capped:.2f} "
+            f"GB/s ({self.per_node_gbps_capped * 8:.1f} Gbps)",
+            f"  RTT                        : {self.rtt_ms:.0f} ms",
+            f"  per-stream assumption      : {self.per_stream_mbps:.0f} Mbps "
+            "(untuned intercontinental TCP)",
+            f"  BDP per node               : "
+            f"{self.bdp_bytes_per_node / 1e9:.2f} GB in flight to fill NIC",
+            f"  streams needed / node      : {self.streams_needed_per_node} "
+            "(incl. safety factor)",
+            f"  streams / pod              : {self.per_pod_streams} "
+            f"(split across {self.pods_per_node} pods)",
+            "",
+            "  => rclone PER POD:",
+            f"       --transfers              {self.transfers}",
+            f"       --multi-thread-streams   {self.multi_thread_streams}",
+            (f"       --checkers               {self.checkers}"
+             if self.checkers_explicit
+             else "       --checkers               (applied only if "
+                  "RCLONE_CHECKERS is set)"),
+            f"     in-flight streams / pod    {self.in_flight_per_pod} "
+            "(transfers x streams)",
+            f"     pod requests               cpu={self.worker_cpu_request} "
+            f"mem={self.worker_mem_request}  (~{self.est_mem_gib_per_pod:.1f} "
+            "GiB actual)",
+            "-" * 62,
+            f"  per-node in-flight streams   : {self.in_flight_per_node} "
+            f"(of {S2A_VCPU} vCPU, {S2A_RAM_GIB} GiB)",
+            f"  fleet in-flight streams      : "
+            f"{self.in_flight_per_node * self.num_nodes}",
+            f"  fleet worker pods            : {self.total_pods}",
+        ]
+        return "\n".join(lines)
+
+
+def _parse_size_to_bytes(s: str) -> int:
+    s = s.strip().upper().rstrip("B")
+    mult = 1
+    if s.endswith("K"):
+        mult, s = 1024, s[:-1]
+    elif s.endswith("M"):
+        mult, s = 1024 ** 2, s[:-1]
+    elif s.endswith("G"):
+        mult, s = 1024 ** 3, s[:-1]
+    return int(float(s) * mult)
+
+
+def compute_sizing(cfg: Config) -> Sizing:
+    pods_per_node = cfg.effective_pods_per_node()
+    total_pods = cfg.effective_num_pods()
+    nic_gbps = S2A_NIC_GBPS
+    vcpu = S2A_VCPU
+
+    # 1) split the target across nodes, cap at 90% of NIC line rate (GB/s)
+    per_node_gbps = cfg.target_gbps / cfg.num_nodes
+    nic_gbps_bytes = nic_gbps / 8.0
+    per_node_gbps_capped = min(per_node_gbps, 0.9 * nic_gbps_bytes)
+
+    # 2) BDP in bytes to fill the NIC at this RTT (informational)
+    rtt_s = cfg.rtt_ms / 1000.0
+    bdp_bytes_per_node = (nic_gbps * 1e9 / 8.0) * rtt_s
+
+    # 3) streams needed/node = required throughput / per-stream, * safety
+    per_node_target_mbps = per_node_gbps_capped * 8 * 1000
+    raw_streams = per_node_target_mbps / cfg.per_stream_mbps
+    streams_needed = max(1, math.ceil(raw_streams * cfg.stream_safety))
+
+    # 4) divide the per-node stream budget across pods
+    per_pod_streams = max(1, math.ceil(streams_needed / pods_per_node))
+
+    # 5) split per-pod streams into transfers x multi_thread_streams
+    if cfg.rclone_multi_thread_streams is not None:
+        mts = cfg.rclone_multi_thread_streams
+    else:
+        mts = min(8, max(4, per_pod_streams))
+
+    if cfg.rclone_transfers is not None:
+        transfers = cfg.rclone_transfers
+    else:
+        transfers = max(1, math.ceil(per_pod_streams / mts))
+        # CPU clamp: transfers are I/O bound; allow ~2x oversub of the cores
+        # available to THIS pod (node cores split across pods_per_node).
+        cores_per_pod = max(1, vcpu // pods_per_node)
+        transfers = min(transfers, 2 * cores_per_pod)
+
+    if cfg.rclone_checkers is not None:
+        checkers = cfg.rclone_checkers
+    else:
+        checkers = min(2 * transfers, 256)
+
+    in_flight_per_pod = transfers * mts
+    in_flight_per_node = in_flight_per_pod * pods_per_node
+
+    # 6) memory estimate per pod: active multi-thread streams buffer ~chunk-size,
+    #    plus per-transfer --buffer-size.
+    chunk_b = _parse_size_to_bytes(cfg.rclone_multi_thread_chunk_size)
+    buf_b = _parse_size_to_bytes(cfg.rclone_buffer_size)
+    est_mem_per_pod = (in_flight_per_pod * chunk_b + transfers * buf_b) / (1024 ** 3)
+    est_mem_per_node = est_mem_per_pod * pods_per_node
+
+    # 7) resource requests (force even, dense packing): blank cfg => derive so
+    #    exactly pods_per_node fit, with system headroom.
+    if cfg.worker_cpu_request:
+        cpu_req = cfg.worker_cpu_request
+    else:
+        cpu_req = str(max(1, (vcpu - SYSTEM_CPU_HEADROOM) // pods_per_node))
+    if cfg.worker_mem_request:
+        mem_req = cfg.worker_mem_request
+    else:
+        mem_req = f"{max(8, math.ceil(est_mem_per_pod * 1.5))}Gi"
+
+    return Sizing(
+        target_gbps=cfg.target_gbps,
+        num_nodes=cfg.num_nodes,
+        pods_per_node=pods_per_node,
+        total_pods=total_pods,
+        rtt_ms=cfg.rtt_ms,
+        per_stream_mbps=cfg.per_stream_mbps,
+        nic_gbps=nic_gbps,
+        vcpu=vcpu,
+        per_node_gbps=per_node_gbps,
+        per_node_gbps_capped=per_node_gbps_capped,
+        bdp_bytes_per_node=bdp_bytes_per_node,
+        streams_needed_per_node=streams_needed,
+        per_pod_streams=per_pod_streams,
+        transfers=transfers,
+        multi_thread_streams=mts,
+        checkers=checkers,
+        checkers_explicit=cfg.rclone_checkers is not None,
+        in_flight_per_pod=in_flight_per_pod,
+        in_flight_per_node=in_flight_per_node,
+        worker_cpu_request=cpu_req,
+        worker_mem_request=mem_req,
+        est_mem_gib_per_pod=est_mem_per_pod,
+        est_mem_gib_per_node=est_mem_per_node,
+    )
+
+
+if __name__ == "__main__":  # quick manual check: python -m orchestrator.sizing
+    from .config import load_config
+    c, _ = load_config([])
+    print(compute_sizing(c).explain())

--- a/cmk-data-transfer/preflight/fio-vast.yaml
+++ b/cmk-data-transfer/preflight/fio-vast.yaml
@@ -1,0 +1,45 @@
+# Reference fio pod for the VAST write-ceiling preflight (one per s2a node).
+# preflight/run_fio.py templates N of these (anti-affinity => one per node),
+# runs a sequential write to the shared PVC, and sums the write bandwidth so a
+# later throughput plateau can be attributed to VAST vs network vs OCI.
+#
+# Why this matters: if the download plateaus at, say, 18 GB/s and fio shows the
+# VAST mount also tops out near there, the binding constraint is the write path,
+# not OCI or the NIC. Run it BEFORE the big pull.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cmk-data-transfer-fio-0
+  labels:
+    app: cmk-data-transfer-fio
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    crusoe.ai/instance.class: ${INSTANCE_CLASS}   # s2a
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: cmk-data-transfer-fio
+          topologyKey: kubernetes.io/hostname
+  containers:
+    - name: fio
+      image: alpine:3.20
+      command:
+        - /bin/sh
+        - -c
+        - >
+          apk add --no-cache fio >/dev/null &&
+          mkdir -p /data/fio/$(hostname) &&
+          fio --name=vastwrite --directory=/data/fio/$(hostname)
+          --rw=write --bs=${FIO_BS} --size=${FIO_SIZE} --numjobs=${FIO_JOBS}
+          --ioengine=libaio --iodepth=32 --direct=0 --group_reporting
+          --output-format=json
+      volumeMounts:
+        - name: shared
+          mountPath: /data
+  volumes:
+    - name: shared
+      persistentVolumeClaim:
+        claimName: ${PVC_NAME}

--- a/cmk-data-transfer/preflight/run_fio.py
+++ b/cmk-data-transfer/preflight/run_fio.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""VAST write-ceiling preflight.
+
+Launches one fio pod per s2a node (anti-affinity on hostname), each doing a
+sequential buffered write to the shared RWX PVC, then sums per-pod write
+bandwidth into an aggregate. This establishes the destination write ceiling so a
+later download plateau can be attributed correctly (VAST vs NIC vs OCI).
+
+Safe to run before the big pull — it only writes to /data/fio and is cleaned up.
+
+Usage:
+    python3 preflight/run_fio.py --nodes 4 --size 20G --jobs 8 --bs 4M
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from orchestrator.config import load_config  # noqa: E402
+
+LABEL = "cmk-data-transfer-fio"
+
+
+def kc(ns, *args, check=True, capture=True):
+    return subprocess.run(["kubectl", "-n", ns, *args],
+                          capture_output=capture, text=True, check=check)
+
+
+def fio_pod(cfg, index, size, jobs, bs, direct):
+    # direct=1 (O_DIRECT) bypasses the page cache so we measure the real VAST
+    # write path, not RAM. end_fsync=1 forces a flush so the reported bandwidth
+    # reflects bytes durably on VAST. If the mount rejects O_DIRECT, rerun with
+    # --direct 0 (buffered) and a size well above node RAM.
+    cmd = (
+        "apk add --no-cache fio >/dev/null && "
+        "mkdir -p /data/fio/$(hostname) && "
+        f"fio --name=vastwrite --directory=/data/fio/$(hostname) "
+        f"--rw=write --bs={bs} --size={size} --numjobs={jobs} "
+        f"--ioengine=libaio --iodepth=32 --direct={direct} --end_fsync=1 "
+        "--group_reporting --output-format=json"
+    )
+    return {
+        "apiVersion": "v1", "kind": "Pod",
+        "metadata": {"name": f"{LABEL}-{index}", "namespace": cfg.k8s_namespace,
+                     "labels": {"app": LABEL}},
+        "spec": {
+            "restartPolicy": "Never",
+            "nodeSelector": {"crusoe.ai/instance.class": cfg.instance_class},
+            "affinity": {"podAntiAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": [{
+                    "labelSelector": {"matchLabels": {"app": LABEL}},
+                    "topologyKey": "kubernetes.io/hostname"}]}},
+            "containers": [{
+                "name": "fio", "image": "alpine:3.20",
+                "command": ["/bin/sh", "-c", cmd],
+                "volumeMounts": [{"name": "shared", "mountPath": "/data"}],
+            }],
+            "volumes": [{"name": "shared",
+                         "persistentVolumeClaim": {"claimName": cfg.pvc_name}}],
+        },
+    }
+
+
+def parse_write_bw_bytes(log: str) -> float:
+    """Extract aggregate write bw (bytes/s) from fio --output-format=json."""
+    # fio may emit apk noise before JSON; find the JSON object.
+    start = log.find("{")
+    if start < 0:
+        return 0.0
+    try:
+        data = json.loads(log[start:])
+    except json.JSONDecodeError:
+        return 0.0
+    bw = 0.0
+    for job in data.get("jobs", []):
+        # bw is in KiB/s in fio json
+        bw += float(job.get("write", {}).get("bw", 0.0)) * 1024
+    return bw
+
+
+def main(argv=None) -> int:
+    # Config from env/.env; this tool owns its own CLI flags.
+    cfg, _ = load_config([])
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--nodes", type=int, default=None,
+                   help="number of fio pods (default: NUM_NODES)")
+    p.add_argument("--size", default="20G", help="per-job file size")
+    p.add_argument("--jobs", type=int, default=8, help="fio numjobs per pod")
+    p.add_argument("--bs", default="4M", help="block size")
+    p.add_argument("--direct", type=int, default=1, choices=(0, 1),
+                   help="1=O_DIRECT (true ceiling); 0=buffered (fallback)")
+    p.add_argument("--timeout", default="900s")
+    args, _ = p.parse_known_args(argv)
+
+    n = args.nodes or cfg.num_nodes
+    ns = cfg.k8s_namespace
+    print(f"Launching {n} fio pods on {cfg.instance_class} "
+          f"(size={args.size} jobs={args.jobs} bs={args.bs} "
+          f"direct={args.direct})")
+
+    for i in range(n):
+        body = json.dumps(fio_pod(cfg, i, args.size, args.jobs, args.bs,
+                                  args.direct))
+        subprocess.run(["kubectl", "-n", ns, "apply", "-f", "-"],
+                       input=body, text=True, check=True)
+
+    # wait for all to complete (Succeeded/Failed)
+    print("waiting for fio pods to finish...")
+    while True:
+        pods = json.loads(kc(ns, "get", "pods", "-l", f"app={LABEL}",
+                             "-o", "json").stdout)["items"]
+        pending = [p["metadata"]["name"] for p in pods
+                   if p["status"]["phase"] not in ("Succeeded", "Failed")]
+        if not pending:
+            break
+        time.sleep(10)
+
+    total = 0.0
+    print("\n--- per-node write bandwidth ---")
+    for p in pods:
+        name = p["metadata"]["name"]
+        log = kc(ns, "logs", name, check=False).stdout or ""
+        bw = parse_write_bw_bytes(log)
+        total += bw
+        print(f"  {name}: {bw/1e9:.2f} GB/s")
+    print(f"\nVAST aggregate write ceiling (this fleet): {total/1e9:.2f} GB/s")
+    print(f"  => download throughput cannot durably exceed this. Compare to "
+          f"TARGET_GBPS={cfg.target_gbps}.")
+
+    # cleanup
+    subprocess.run(["kubectl", "-n", ns, "delete", "pod", "-l",
+                    f"app={LABEL}", "--ignore-not-found"], check=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmk-data-transfer/requirements.txt
+++ b/cmk-data-transfer/requirements.txt
@@ -1,0 +1,9 @@
+# Orchestrator runs on stdlib only and shells out to `kubectl` (mirrors the
+# Crusoe reference implementation). No third-party packages are required.
+#
+# Optional, only if you prefer richer .env parsing locally:
+#   python-dotenv>=1.0
+#
+# Hard requirements on the operator workstation:
+#   - python3 >= 3.9
+#   - kubectl (configured KUBECONFIG with access to the CMK cluster)

--- a/cmk-data-transfer/shard/__init__.py
+++ b/cmk-data-transfer/shard/__init__.py
@@ -1,0 +1,1 @@
+"""Keyspace sharding (size-balanced LPT bin-pack)."""

--- a/cmk-data-transfer/shard/shard_manifest.py
+++ b/cmk-data-transfer/shard/shard_manifest.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Deterministic, size-balanced keyspace sharder.
+
+Reads a listing (TSV of "<size>\\t<path>", as produced by
+`rclone lsf --recursive --files-only --format sp --separator '\\t'`) and
+bin-packs the objects into N balanced shard files using the Longest-Processing-
+Time (LPT) greedy multiway partition: sort objects by size descending, then
+repeatedly assign the next object to the currently-smallest bin. This is the
+same algorithm the Crusoe AWS-S3 reference uses, and it keeps each worker's
+total byte load within a small factor of perfectly balanced.
+
+Deterministic: same listing + same N => identical shards (ties broken by path).
+
+Usage (standalone):
+    python3 shard_manifest.py --listing listing.tsv --num 4 --out ./shards
+Reads stdin if --listing is omitted.
+"""
+from __future__ import annotations
+
+import argparse
+import heapq
+import os
+import sys
+from typing import Iterable, Iterator
+
+
+def parse_tsv(lines: Iterable[str]) -> Iterator[tuple[int, str]]:
+    """Yield (size, path) from 'size\\tpath' lines. Skips blanks/garbage."""
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if not line:
+            continue
+        size_str, sep, path = line.partition("\t")
+        if not sep:
+            # tolerate space-separated fallback
+            size_str, _, path = line.partition(" ")
+        path = path.strip()
+        if not path:
+            continue
+        try:
+            size = int(size_str)
+        except ValueError:
+            continue
+        yield size, path
+
+
+def bin_pack(objects: list[tuple[int, str]], num_bins: int
+             ) -> tuple[list[list[str]], list[int]]:
+    """LPT greedy partition. Returns (bins_of_paths, bin_total_sizes)."""
+    if num_bins < 1:
+        raise ValueError("num_bins must be >= 1")
+    # sort by size desc, then path asc for determinism
+    objects.sort(key=lambda o: (-o[0], o[1]))
+    bins: list[list[str]] = [[] for _ in range(num_bins)]
+    sizes = [0] * num_bins
+    # min-heap of (current_size, bin_index)
+    heap = [(0, i) for i in range(num_bins)]
+    heapq.heapify(heap)
+    for size, path in objects:
+        cur, idx = heapq.heappop(heap)
+        bins[idx].append(path)
+        sizes[idx] = cur + size
+        heapq.heappush(heap, (cur + size, idx))
+    return bins, sizes
+
+
+def human(n: int) -> str:
+    f = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB", "PiB"):
+        if f < 1024 or unit == "PiB":
+            return f"{f:.2f} {unit}"
+        f /= 1024
+    return f"{f:.2f} PiB"
+
+
+def write_shards(bins: list[list[str]], out_dir: str) -> list[str]:
+    os.makedirs(out_dir, exist_ok=True)
+    paths = []
+    for i, keys in enumerate(bins):
+        fp = os.path.join(out_dir, f"shard-{i}.txt")
+        with open(fp, "w") as fh:
+            fh.write("\n".join(keys))
+            if keys:
+                fh.write("\n")
+        paths.append(fp)
+    return paths
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--listing", help="TSV file (default: stdin)")
+    p.add_argument("--num", type=int, required=True, help="number of shards")
+    p.add_argument("--out", default="./shards", help="output directory")
+    args = p.parse_args(argv)
+
+    src = open(args.listing) if args.listing else sys.stdin
+    try:
+        objects = list(parse_tsv(src))
+    finally:
+        if args.listing:
+            src.close()
+
+    if not objects:
+        print("ERROR: no objects parsed from listing", file=sys.stderr)
+        return 2
+
+    bins, sizes = bin_pack(objects, args.num)
+    write_shards(bins, args.out)
+
+    total = sum(sizes)
+    print(f"Sharded {len(objects)} objects ({human(total)}) into "
+          f"{args.num} shards -> {args.out}")
+    for i, (b, s) in enumerate(zip(bins, sizes)):
+        print(f"  shard-{i}.txt: {len(b):>8} files  {human(s):>12}")
+    spread = (max(sizes) - min(sizes)) / max(1, total) * 100
+    print(f"  balance spread (max-min)/total: {spread:.3f}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `cmk-data-transfer/` — a reference solution that parallel-pulls a dataset from **any S3-compatible object store** (OCI Object Storage is the worked example) to a **VAST-backed RWX shared disk** on **Crusoe Managed Kubernetes**, tuned to saturate worker hosts over a high-RTT path.

- A **master pod** lists the source and LPT-bin-packs it into balanced shards; **N worker pods** each `rclone copy` one shard in parallel (`hostNetwork`, unique rc port, topology-spread).
- Concurrency is derived from a single `TARGET_GBPS` knob via a bandwidth-delay-product model (`--transfers` × `--multi-thread-streams` across `PODS_PER_NODE` independent rclone processes). Node hardware is env-configurable (`NODE_VCPU`/`NODE_RAM_GIB`/`NODE_NIC_GBPS`) so the sizing model works on any SKU.
- **Three destination modes:** `dynamic` (CSI-provisioned), `import` (existing disk via static PV), and `nfs` (in-tree NFS PV straight to the VAST DNS endpoint, for when a CSI mount falls back to an unroutable IP).
- **Benchmarking harness:** fio write-ceiling preflight, per-node fio read/write matrix, throughput collector, parameter sweep, and an experiment runner that reports both rclone stats and **node-NIC ground truth**.

## Notes

- Source backend is rclone `provider = Other`, so AWS S3 / MinIO / Ceph / GCS (S3 interop) / R2 / B2 also work — point `OCI_ENDPOINT` at the store.
- Secrets are assembled into an `rclone.conf` and placed **only** in a read-only Kubernetes Secret; `.env`, credentials, and benchmark results are git-ignored.
- Python stdlib + `kubectl` only (no pip installs).
- Provided AS IS — see the README disclaimer.

## Validation

Exercised end-to-end pulling a multi-TiB dataset: sizing, listing/sharding, all three destination modes, and the benchmarking tools were validated on live clusters.