### PR TITLE
crusoe-kserve-example: fix disaggregated serving on KServe v0.19.0

### DIFF
--- a/crusoe-kserve-example/.gitignore
+++ b/crusoe-kserve-example/.gitignore
@@ -4,6 +4,7 @@ terraform/.terraform.lock.hcl
 terraform/terraform.tfstate
 terraform/terraform.tfstate.backup
 terraform/terraform.tfvars
+terraform/imports.tf
 
 # Secrets
 .env
@@ -12,6 +13,7 @@ terraform/terraform.tfvars
 
 # OS
 .DS_Store
+.claude/
 
 env
 prometheus/prometheus.yml

--- a/crusoe-kserve-example/CLAUDE.md
+++ b/crusoe-kserve-example/CLAUDE.md
@@ -50,7 +50,7 @@ This runs `terraform apply` which:
 1. Creates the CMK cluster with `nvidia_gpu_operator`, `nvidia_network_operator`, and `crusoe_csi` add-ons
 2. Creates node pools (A100, H100, CPU — counts configurable in tfvars)
 3. Fetches kubeconfig
-4. Installs KServe v0.17.0 (standard mode + LLMInferenceService CRDs)
+4. Installs KServe v0.19.0 (standard mode + LLMInferenceService CRDs)
 5. Creates the `kserve-test` namespace with the HuggingFace secret
 
 #### 3. Deploy a Model
@@ -114,7 +114,7 @@ make setup-amd
 This runs three steps:
 1. `terraform apply` in `terraform-amd/` — creates CMK cluster with **`crusoe_csi` add-on only** (no NVIDIA add-ons), AMD GPU node pool, CPU node pool, fetches kubeconfig
 2. `install-amd-gpu-operator` — installs cert-manager v1.15.1, AMD GPU operator v1.4.2, creates Docker registry secret in `kube-amd-gpu`, applies AMD DeviceConfig
-3. `install-kserve` — installs KServe v0.17.0, patches storage-initializer, creates `kserve-test` namespace with HuggingFace secret
+3. `install-kserve` — installs KServe v0.19.0, patches storage-initializer, creates `kserve-test` namespace with HuggingFace secret
 
 **Key difference from NVIDIA**: AMD clusters use `amd.com/gpu` resource limits instead of `nvidia.com/gpu`, and use the `vllm/vllm-openai-rocm:latest` image (ROCm-based).
 
@@ -343,8 +343,17 @@ This uninstalls the Helm release and runs `terraform destroy` to tear down all i
   kubectl rollout restart deployment kserve-controller-manager -n kserve
   ```
 - If vLLM crashes with "unrecognized arguments: /mnt/models", you have `--model` in your args — remove it, KServe injects this automatically
+- If a model pod is stuck in `CreateContainerConfigError` with "container has runAsNonRoot and image will run as root", KServe v0.19.0's hardened pod securityContext conflicts with the root `vllm/vllm-openai` image. The chart relaxes this via `containerSecurityContext` in values.yaml (applied to basic/large/multi-node); don't remove it unless you switch to a non-root image
 - Check KServe controller logs: `kubectl logs -n kserve -l control-plane=kserve-controller-manager`
 - Check vLLM logs: `kubectl logs -n kserve-test deploy/<model>-kserve -c main`
+
+### Disaggregated Serving
+
+- Requires **KServe v0.19.0+**. On v0.17.0 the router's scheduler (EPP) CrashLoopBackOffs with `invalid decider plugin type: always-disagg-pd-decider` — the bundled scheduler image predates the config the controller generates. `make setup` / `make install-kserve` install v0.19.0 by default (override with `KSERVE_VERSION`).
+- Disaggregated pods use the NIXL-capable `ghcr.io/llm-d/llm-d-cuda` image (set via `disaggregated.image` in values.yaml), not `vllm/vllm-openai`. The plain vLLM image lacks the KV connector and the scheduler warns `no KVConnector found`.
+- If the vLLM engine crashes at startup with `ld: cannot find -l:libcuda.so.1`, the linker can't find the driver lib. The `LIBRARY_PATH=/usr/lib/x86_64-linux-gnu` env in the `disaggregated:` values fixes this — ensure it's set on both prefill and decode (the UBI-based llm-d image searches `/usr/lib64`, but the driver ships `libcuda.so.1` under `/usr/lib/x86_64-linux-gnu`).
+- On single-GPU-per-node pools, a rolling update deadlocks (the new pod can't schedule onto the GPU held by the old one). Set the deployments' strategy to `Recreate`, or delete the old ReplicaSet's pods to force convergence.
+- **Known limitation:** the current config provides prefill/decode *routing* via the scheduler but does not fully wire vLLM's `--kv-transfer-config`, so decode does not yet reuse prefill's KV cache over NIXL. Enabling true KV transfer requires passing a per-role `--kv-transfer-config` to the engines plus NIXL transport config (RDMA on IB fabrics, TCP on non-IB).
 
 ### AMD-Specific
 

--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -3,7 +3,7 @@
 SHELL := /bin/bash
 NAMESPACE ?= kserve-test
 HF_TOKEN       ?= $(shell grep '^hf_token'       terraform/terraform.tfvars     2>/dev/null | sed 's/.*= *"//;s/"//')
-KSERVE_VERSION ?= v0.17.0
+KSERVE_VERSION ?= v0.19.0
 
 # AMD config — all values read from terraform-amd/terraform.tfvars
 _AMD_TFVARS    := terraform-amd/terraform.tfvars
@@ -211,24 +211,12 @@ deploy-amd-multi-node: ## Deploy multi-node LLM on AMD MI300X (MiniMax-M2 on 2x8
 	  --set amd.multiNode.enabled=true \
 	  --set disaggregated.enabled=false
 
-deploy-disaggregated: ## Deploy disaggregated prefill-decode (H100 + A100)
+deploy-disaggregated: ## Deploy disaggregated prefill-decode (needs KServe v0.19.0+; set model/TP/GPUs/labels in values.yaml disaggregated:)
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
 	  --set hfToken=$(HF_TOKEN) \
 	  --set basic.enabled=false \
 	  --set multiNode.enabled=false \
-	  --set disaggregated.enabled=true \
-	  --set disaggregated.decode.args[0]="--tensor-parallel-size" \
-	  --set-string disaggregated.decode.args[1]="8" \
-	  --set disaggregated.decode.args[2]="--enforce-eager" \
-	  --set disaggregated.decode.args[3]="--gpu-memory-utilization" \
-	  --set disaggregated.decode.args[4]="0.90" \
-	  --set disaggregated.prefill.args[0]="--tensor-parallel-size" \
-	  --set-string disaggregated.prefill.args[1]="8" \
-	  --set disaggregated.prefill.args[2]="--enable-chunked-prefill" \
-	  --set disaggregated.prefill.args[3]="--max-num-batched-tokens" \
-	  --set-string disaggregated.prefill.args[4]="8192" \
-	  --set disaggregated.prefill.args[5]="--gpu-memory-utilization" \
-	  --set disaggregated.prefill.args[6]="0.90"
+	  --set disaggregated.enabled=true
 
 # ---------------------------------------------------------------------------
 # Test & Benchmark

--- a/crusoe-kserve-example/README.md
+++ b/crusoe-kserve-example/README.md
@@ -44,13 +44,13 @@ make setup
 This single command:
 - Creates the CMK cluster and node pools (A100, H100, CPU)
 - Fetches kubeconfig
-- Installs KServe v0.17.0 (standard mode + LLMInferenceService CRDs)
+- Installs KServe v0.19.0 (standard mode + LLMInferenceService CRDs)
 - Creates the workload namespace and HuggingFace secret
 
 ### 3. Deploy a model
 
 ```bash
-# Single-GPU (Qwen2.5-0.5B, 1x H100)
+# Single-GPU (Qwen2.5-0.5B, 1x A100)
 make deploy-basic
 
 # Large single-node (Qwen2.5-72B, 8x H100 TP=8, with PVC storage)
@@ -59,13 +59,15 @@ make deploy-large
 # Multi-node (Qwen2.5-72B, 2x8 H100)
 make deploy-multi-node
 
-# Disaggregated prefill-decode (H100 prefill + A100 decode)
+# Disaggregated prefill-decode across separate GPU pools (needs KServe v0.19.0+)
 make deploy-disaggregated
 ```
 
 Large models (70B+) require persistent storage. `deploy-large` automatically provisions a 250Gi SSD PVC via the Crusoe CSI driver to store model weights.
 
-> **Using a different GPU type?** The defaults in `helm/crusoe-kserve-example/values.yaml` target H100 nodes. If your cluster uses another GPU SKU, update the `nodeSelector` for the relevant profile, for example:
+> **Disaggregated serving** splits prefill and decode onto separate GPU pools via KServe's inference scheduler. It requires **KServe v0.19.0+** (the earlier scheduler crashes on disaggregated configs) and a NIXL-capable vLLM image (`llm-d-cuda`, preset in `values.yaml`). Set the model, tensor-parallel size, GPU counts, and per-pool `nodeSelector` labels in the `disaggregated:` block of `values.yaml` to match your cluster. On pools with a single GPU per node, set the deployments' update strategy to `Recreate` (a rolling update can't surge onto a busy GPU).
+
+> **Using a different GPU type?** Each profile in `helm/crusoe-kserve-example/values.yaml` sets its own `nodeSelector` (basic defaults to A100; large / multi-node / disaggregated to H100). If your cluster uses another GPU SKU, update the `nodeSelector` for the relevant profile, for example:
 > ```yaml
 > basic:
 >   nodeSelector:
@@ -127,7 +129,7 @@ make setup-amd
 This single command:
 - Creates the CMK cluster and node pools (MI300X, CPU)
 - Installs cert-manager + AMD GPU operator v1.4.2
-- Installs KServe v0.17.0
+- Installs KServe v0.19.0
 
 ### 3. Deploy a model
 
@@ -185,6 +187,8 @@ make install-kserve HF_TOKEN=hf_...
 ```
 
 Once KServe is installed, proceed directly to the deploy commands (`make deploy-basic`, `make deploy-large`, etc.).
+
+> **Managing an existing cluster with Terraform (optional):** to bring a cluster created outside Terraform under `make destroy` lifecycle management, add `import` blocks for the cluster and its node pools, set the matching values in `terraform.tfvars`, and run `terraform plan` — confirm it reports **0 to destroy** before applying. The node-pool resources ignore changes to `ssh_key` / `ib_partition_id` (write-only in the Crusoe API) so import doesn't force node replacement.
 
 ---
 

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/Chart.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: crusoe-kserve-example
 description: Deploy LLM inference on CMK using KServe and vLLM
 version: 0.1.0
-appVersion: "0.17.0"
+appVersion: "0.19.0"

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/basic-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/basic-llm.yaml
@@ -17,6 +17,10 @@ spec:
     containers:
       - name: main
         image: {{ .Values.image }}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           - name: HF_TOKEN
             valueFrom:

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/disaggregated-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/disaggregated-llm.yaml
@@ -20,13 +20,20 @@ spec:
   template:
     containers:
       - name: main
-        image: {{ .Values.image }}
+        image: {{ .Values.disaggregated.image | default .Values.image }}
+        {{- if .Values.disaggregated.decode.securityContext }}
+        securityContext:
+          {{- toYaml .Values.disaggregated.decode.securityContext | nindent 10 }}
+        {{- end }}
         env:
           - name: HF_TOKEN
             valueFrom:
               secretKeyRef:
                 name: hf-secret
                 key: HF_TOKEN
+          {{- with .Values.disaggregated.decode.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- if .Values.disaggregated.decode.args }}
         args:
           {{- toYaml .Values.disaggregated.decode.args | nindent 10 }}
@@ -55,13 +62,20 @@ spec:
     template:
       containers:
         - name: main
-          image: {{ .Values.image }}
+          image: {{ .Values.disaggregated.image | default .Values.image }}
+          {{- if .Values.disaggregated.prefill.securityContext }}
+          securityContext:
+            {{- toYaml .Values.disaggregated.prefill.securityContext | nindent 12 }}
+          {{- end }}
           env:
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: hf-secret
                   key: HF_TOKEN
+            {{- with .Values.disaggregated.prefill.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if .Values.disaggregated.prefill.args }}
           args:
             {{- toYaml .Values.disaggregated.prefill.args | nindent 12 }}

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/large-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/large-llm.yaml
@@ -17,6 +17,10 @@ spec:
     containers:
       - name: main
         image: {{ .Values.image }}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           - name: HF_TOKEN
             valueFrom:

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/multi-node-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/multi-node-llm.yaml
@@ -17,6 +17,10 @@ spec:
     containers:
       - name: main
         image: {{ .Values.image }}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           - name: HF_TOKEN
             valueFrom:
@@ -49,6 +53,10 @@ spec:
     containers:
       - name: main
         image: {{ .Values.image }}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           - name: HF_TOKEN
             valueFrom:

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
@@ -7,6 +7,16 @@ namespace: kserve-test
 # vLLM image
 image: vllm/vllm-openai:latest
 
+# KServe v0.19.0 hardens LLM pods (runAsNonRoot + readOnlyRootFilesystem) for
+# non-root images. The default vllm/vllm-openai image runs as root and writes to
+# the container filesystem, so relax the context for the basic/large/multi-node
+# profiles. (Disaggregated uses the non-root llm-d image and inherits KServe's
+# hardened context instead.)
+containerSecurityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+  readOnlyRootFilesystem: false
+
 # Persistent storage for model weights (required for models >100GB)
 modelStorage:
   enabled: false
@@ -28,7 +38,7 @@ basic:
       cpu: "1"
       memory: 4Gi
   nodeSelector:
-    crusoe.ai/accelerator: nvidia-h100-80gb-sxm-ib
+    crusoe.ai/accelerator: nvidia-a100-80gb
 
 # Large: multi-GPU single-node LLM serving (e.g., Qwen2.5-72B-Instruct on 8x H100, TP=8)
 large:
@@ -71,14 +81,25 @@ multiNode:
   nodeSelector:
     crusoe.ai/accelerator: nvidia-h100-80gb-sxm-ib
 
-# Disaggregated prefill-decode serving
+# Disaggregated prefill-decode serving.
+# Requires KServe v0.19.0+ (its scheduler preset wires the NIXL KV connector; the
+# v0.17.0 scheduler crashes on disaggregated configs).
 disaggregated:
   enabled: false
+  # NIXL-capable vLLM image matching KServe v0.19.0's scheduler preset. The default
+  # vllm/vllm-openai image lacks the NIXL KV connector needed for prefill/decode.
+  image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
   model:
     uri: hf://Qwen/Qwen2.5-72B-Instruct
     name: qwen
   decode:
     replicas: 2
+    # Crusoe's GPU driver ships libcuda.so.1 under /usr/lib/x86_64-linux-gnu, but the
+    # UBI-based llm-d image links against /usr/lib64 during vLLM's Triton compile.
+    # Point the linker at the driver path so the engine initializes.
+    extraEnv:
+      - name: LIBRARY_PATH
+        value: /usr/lib/x86_64-linux-gnu
     parallelism:
       tensor: 8
       data: 16
@@ -96,6 +117,9 @@ disaggregated:
       crusoe.ai/accelerator: nvidia-a100-80gb-sxm-ib
   prefill:
     replicas: 1
+    extraEnv:
+      - name: LIBRARY_PATH
+        value: /usr/lib/x86_64-linux-gnu
     resources:
       limits:
         gpu: "8"

--- a/crusoe-kserve-example/terraform/main.tf
+++ b/crusoe-kserve-example/terraform/main.tf
@@ -17,7 +17,7 @@ provider "crusoe" {
 variable "kserve_version" {
   description = "KServe release version"
   type        = string
-  default     = "v0.17.0"
+  default     = "v0.19.0"
 }
 
 variable "namespace" {
@@ -64,6 +64,14 @@ resource "crusoe_kubernetes_node_pool" "a100" {
   ssh_key         = var.ssh_public_key
   ib_partition_id = var.a100_ib_partition_id
   project_id      = var.project_id
+
+  # ssh_key and ib_partition_id are write-only in the Crusoe API (not returned
+  # on read), so they always read as a change after `terraform import` and would
+  # force pool replacement. Ignoring them lets an existing pool be adopted
+  # without recreating its nodes. Harmless for create-from-scratch.
+  lifecycle {
+    ignore_changes = [ssh_key, ib_partition_id]
+  }
 }
 
 resource "crusoe_kubernetes_node_pool" "h100" {
@@ -75,6 +83,10 @@ resource "crusoe_kubernetes_node_pool" "h100" {
   ssh_key         = var.ssh_public_key
   ib_partition_id = var.h100_ib_partition_id
   project_id      = var.project_id
+
+  lifecycle {
+    ignore_changes = [ssh_key, ib_partition_id]
+  }
 }
 
 resource "crusoe_kubernetes_node_pool" "cpu" {
@@ -85,6 +97,10 @@ resource "crusoe_kubernetes_node_pool" "cpu" {
   type           = var.cpu_node_type
   ssh_key        = var.ssh_public_key
   project_id     = var.project_id
+
+  lifecycle {
+    ignore_changes = [ssh_key]
+  }
 }
 
 # -----------------------------------------------------------------------------

--- a/crusoe-kserve-example/terraform/terraform.tfvars.example
+++ b/crusoe-kserve-example/terraform/terraform.tfvars.example
@@ -10,7 +10,7 @@ hf_token       = "hf_your_token_here"
 ssh_public_key = "ssh-ed25519 AAAA... user@host"
 
 # KServe version
-kserve_version = "v0.17.0"
+kserve_version = "v0.19.0"
 
 # Namespace for LLM workloads
 namespace = "kserve-test"


### PR DESCRIPTION
## What & why

`make deploy-disaggregated` did not work on the pinned KServe **v0.17.0**: the router's scheduler (EPP) CrashLoopBackOffs because the bundled scheduler image rejects the `always-disagg-pd-decider` config that its own controller generates. This PR bumps the default to **KServe v0.19.0** — whose controller, scheduler image, and Gateway Inference Extension are mutually consistent — and adapts the chart so every deploy mode works on it.

## Changes

- **KServe v0.19.0** default (Makefile, Terraform defaults, `tfvars.example`, Chart `appVersion`).
- **Pod hardening compat:** v0.19.0 applies `runAsNonRoot` + `readOnlyRootFilesystem` to LLM pods. The default root `vllm/vllm-openai` image then fails with `CreateContainerConfigError`, so relax it via a shared `containerSecurityContext` value applied to the **basic / large / multi-node** profiles.
- **Disaggregated** now inherits the v0.19.0 scheduler preset instead of overriding it:
  - NIXL-capable `llm-d-cuda` image (non-root — keeps KServe's hardened context)
  - drop the hardcoded vLLM arg overrides from the Makefile target (they replaced the preset's launch command and suppressed the KV connector); TP / model / GPUs now come from `values.yaml`
  - add `image` / `securityContext` / `extraEnv` knobs to the disaggregated template
  - set `LIBRARY_PATH=/usr/lib/x86_64-linux-gnu` so the UBI-based image links the driver's `libcuda.so.1` during vLLM's Triton compile
- **Terraform import support:** `ignore_changes` on node-pool `ssh_key` / `ib_partition_id` (write-only in the Crusoe API) so an existing cluster imports without recreating its nodes.
- **Docs:** disaggregation requirements, the KV-transfer known limitation, the existing-cluster import flow, per-profile `nodeSelector` guidance; default the `basic` profile to A100.
- Restore the neutral `chat-test.json` sample prompt.

## Validation

- `helm lint` + `helm template` render cleanly for all four modes (basic / large / multi-node / disaggregated).
- Verified on a live CMK cluster: v0.19.0 install, control plane healthy, and `make deploy-basic` end-to-end from the committed config (Qwen2.5-0.5B serves correct completions). Disaggregated *routing* (prefill + decode split across pools, served through the gateway) verified separately.

## Known limitation

Disaggregation currently provides prefill/decode **routing** via the scheduler; it does not yet fully wire vLLM's `--kv-transfer-config`, so decode does not reuse prefill's KV cache over NIXL. Enabling true KV transfer requires a per-role `--kv-transfer-config` plus NIXL transport config (RDMA on IB fabrics, TCP on non-IB) — documented in `CLAUDE.md`. Not a regression: v0.17.0's disaggregated path didn't work at all.
