### PR TITLE
crusoe-kserve-example: add Open WebUI frontend (LoadBalancer + self-signed TLS on :443)

### DIFF
--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -124,7 +124,10 @@ deploy-basic: ## Deploy single-GPU LLM (Qwen2.5-0.5B on 1x A100 or H100)
 	  --set basic.args[1]="0.95" \
 	  --set basic.args[2]="--enable-chunked-prefill" \
 	  --set basic.args[3]="--max-num-batched-tokens" \
-	  --set-string basic.args[4]="4096"
+	  --set-string basic.args[4]="4096" \
+	  --set basic.args[5]="--enable-auto-tool-choice" \
+	  --set basic.args[6]="--tool-call-parser" \
+	  --set basic.args[7]="hermes"
 
 deploy-large: ## Deploy large single-node LLM (Qwen2.5-72B on 8x H100, TP=8) — edit values.yaml large: to change model/resources
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \

--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -1,9 +1,12 @@
-.PHONY: help setup setup-amd install-kserve patch-storage-initializer install-amd-gpu-operator deploy-basic deploy-large deploy-multi-node deploy-disaggregated deploy-amd-basic deploy-amd-large redeploy-amd-large deploy-amd-multi-node watch watch-metrics test chat bench bench-all bench-all-amd bench-amd monitor-up monitor-up-nvidia monitor-up-amd monitor-down monitor-clean destroy
+.PHONY: help setup setup-amd install-kserve patch-storage-initializer install-amd-gpu-operator deploy-basic deploy-large deploy-multi-node deploy-disaggregated deploy-amd-basic deploy-amd-large redeploy-amd-large deploy-amd-multi-node install-lb-controller deploy-openwebui openwebui-forward openwebui-url destroy-openwebui watch watch-metrics test chat bench bench-all bench-all-amd bench-amd monitor-up monitor-up-nvidia monitor-up-amd monitor-down monitor-clean destroy
 
 SHELL := /bin/bash
 NAMESPACE ?= kserve-test
 HF_TOKEN       ?= $(shell grep '^hf_token'       terraform/terraform.tfvars     2>/dev/null | sed 's/.*= *"//;s/"//')
 KSERVE_VERSION ?= v0.19.0
+
+# Open WebUI frontend — the vLLM OpenAI endpoint it talks to (default: the deploy-basic model).
+OPENWEBUI_BACKEND_URL ?= http://qwen-llm-kserve-workload-svc.$(NAMESPACE).svc.cluster.local:8000/v1
 
 # AMD config — all values read from terraform-amd/terraform.tfvars
 _AMD_TFVARS    := terraform-amd/terraform.tfvars
@@ -217,6 +220,52 @@ deploy-disaggregated: ## Deploy disaggregated prefill-decode (needs KServe v0.19
 	  --set basic.enabled=false \
 	  --set multiNode.enabled=false \
 	  --set disaggregated.enabled=true
+
+# ---------------------------------------------------------------------------
+# Frontend (Open WebUI)
+# ---------------------------------------------------------------------------
+
+install-lb-controller: ## Install the Crusoe load-balancer controller (enables type=LoadBalancer external IPs)
+	@if helm status crusoe-lb-controller -n crusoe-system >/dev/null 2>&1; then \
+	  echo "crusoe-lb-controller already installed."; \
+	else \
+	  echo "Installing crusoe-lb-controller into crusoe-system..."; \
+	  TMP=$$(mktemp -d); \
+	  git clone --depth 1 https://github.com/crusoecloud/crusoe-load-balancer-controller-helm-charts.git $$TMP; \
+	  helm install crusoe-lb-controller $$TMP/charts/crusoe-lb-controller -n crusoe-system; \
+	  rm -rf $$TMP; \
+	fi
+	@kubectl wait --for=condition=Ready pod -n crusoe-system -l app=crusoe-lb-controller --timeout=120s
+
+deploy-openwebui: install-lb-controller ## Deploy Open WebUI chat frontend with self-signed TLS on :443 via a Crusoe LoadBalancer
+	kubectl apply -f frontend/manifests/00-namespace.yaml
+	kubectl apply -f frontend/manifests/20-tls.yaml
+	@echo "Waiting for the self-signed certificate to be issued..."
+	kubectl wait --for=condition=Ready certificate/openwebui-tls -n openwebui --timeout=120s
+	kubectl apply -f frontend/manifests/
+	kubectl set env deploy/open-webui -n openwebui OPENAI_API_BASE_URL="$(OPENWEBUI_BACKEND_URL)"
+	kubectl rollout status deploy/open-webui -n openwebui --timeout=600s
+	@echo "Waiting for the LoadBalancer VIP (crusoe-lb-controller)..."
+	@IP=""; for i in $$(seq 1 30); do \
+	  IP=$$(kubectl get svc openwebui-lb -n openwebui -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null); \
+	  [ -n "$$IP" ] && break; sleep 6; done; \
+	echo ""; \
+	echo "=== Open WebUI is up ==="; \
+	echo "  Public HTTPS : https://$$IP  (self-signed cert — accept the browser warning)"; \
+	echo "  Backend      : $(OPENWEBUI_BACKEND_URL)"; \
+	echo "  Port-forward : make openwebui-forward   (then http://localhost:8080)"; \
+	echo "  First visitor signs up and becomes admin (WEBUI_AUTH=True)."
+
+openwebui-forward: ## Port-forward Open WebUI to http://localhost:8080 (no public IP needed)
+	@echo "Open WebUI at http://localhost:8080 (Ctrl-C to stop)"
+	kubectl port-forward -n openwebui svc/openwebui 8080:8080
+
+openwebui-url: ## Print the Open WebUI public HTTPS URL
+	@IP=$$(kubectl get svc openwebui-lb -n openwebui -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null); \
+	if [ -n "$$IP" ]; then echo "https://$$IP"; else echo "LoadBalancer VIP not assigned yet — check 'kubectl get svc openwebui-lb -n openwebui'"; fi
+
+destroy-openwebui: ## Remove Open WebUI (leaves the LB controller and KServe in place)
+	kubectl delete -f frontend/manifests/ --ignore-not-found
 
 # ---------------------------------------------------------------------------
 # Test & Benchmark

--- a/crusoe-kserve-example/frontend/README.md
+++ b/crusoe-kserve-example/frontend/README.md
@@ -1,0 +1,54 @@
+# Open WebUI Frontend
+
+A chat UI ([Open WebUI](https://github.com/open-webui/open-webui)) in front of the vLLM/KServe model, exposed to the internet over HTTPS with a self-signed certificate — and also reachable via `kubectl port-forward`.
+
+## What it deploys
+
+- **Open WebUI** Deployment (SSD-backed PVC for users/chats), pointed at the vLLM OpenAI-compatible endpoint.
+- A **Caddy TLS sidecar** terminating HTTPS on `:8443` from a cert-manager–issued self-signed cert.
+- A **`LoadBalancer` Service** on `:443`, provisioned by the Crusoe load-balancer controller (annotation `crusoe.ai/manage-firewall-rule: "true"` also opens the firewall).
+- A **ClusterIP Service** on `:8080` for port-forwarding.
+
+```
+internet ──HTTPS:443──▶ Crusoe LB (VIP) ──nodePort──▶ Caddy :8443 (self-signed TLS) ──▶ Open WebUI :8080 ──▶ vLLM /v1
+```
+
+## Prerequisites
+
+- A CMK cluster with KServe installed (`make setup`) and a model deployed (e.g. `make deploy-basic`).
+- cert-manager (installed with KServe) for the self-signed cert.
+
+## Deploy
+
+```bash
+make deploy-openwebui
+```
+
+This installs the Crusoe load-balancer controller if missing, issues the self-signed cert, applies the manifests, and prints the public URL. To point at a model other than the `deploy-basic` default:
+
+```bash
+make deploy-openwebui OPENWEBUI_BACKEND_URL=http://<model>-kserve-workload-svc.kserve-test.svc.cluster.local:8000/v1
+```
+
+## Access
+
+```bash
+make openwebui-url        # public HTTPS URL (self-signed — accept the browser warning)
+make openwebui-forward    # http://localhost:8080 (no public IP needed)
+```
+
+The first visitor signs up and becomes the admin (`WEBUI_AUTH=True`).
+
+## Security
+
+The `LoadBalancer` exposes the app to `0.0.0.0/0` by default and the cert is self-signed. Before anything beyond a demo:
+
+- Restrict access — add `loadBalancerSourceRanges: ["<your-cidr>"]` to `manifests/50-service-lb.yaml`.
+- Swap the self-signed `Issuer` in `manifests/20-tls.yaml` for a real (ACME/DNS) issuer once you have a hostname.
+- Claim the admin account immediately so a stranger can't.
+
+## Teardown
+
+```bash
+make destroy-openwebui    # removes Open WebUI; leaves KServe + the LB controller
+```

--- a/crusoe-kserve-example/frontend/manifests/00-namespace.yaml
+++ b/crusoe-kserve-example/frontend/manifests/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openwebui

--- a/crusoe-kserve-example/frontend/manifests/10-storage.yaml
+++ b/crusoe-kserve-example/frontend/manifests/10-storage.yaml
@@ -1,0 +1,22 @@
+# SSD-backed persistence for Open WebUI (users, chats, settings live in SQLite at
+# /app/backend/data). Same Crusoe SSD CSI driver the LLM chart uses for model weights.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: crusoe-ssd
+provisioner: ssd.csi.crusoe.ai
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openwebui-data
+  namespace: openwebui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: crusoe-ssd
+  resources:
+    requests:
+      storage: 5Gi

--- a/crusoe-kserve-example/frontend/manifests/20-tls.yaml
+++ b/crusoe-kserve-example/frontend/manifests/20-tls.yaml
@@ -1,0 +1,27 @@
+# Self-signed TLS for :443, minted by cert-manager (installed with KServe).
+# The Certificate produces the `openwebui-tls` Secret (kubernetes.io/tls) that the
+# Caddy sidecar serves. Browsers show a "not secure" warning (no public CA) — the
+# transport is still encrypted. Swap this Issuer for a real ClusterIssuer + DNS
+# name once you have one; no other manifest changes needed.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: openwebui-selfsigned
+  namespace: openwebui
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openwebui-tls
+  namespace: openwebui
+spec:
+  secretName: openwebui-tls
+  duration: 8760h   # 1 year
+  commonName: openwebui.local
+  dnsNames:
+    - openwebui.local
+  issuerRef:
+    name: openwebui-selfsigned
+    kind: Issuer

--- a/crusoe-kserve-example/frontend/manifests/30-caddy-config.yaml
+++ b/crusoe-kserve-example/frontend/manifests/30-caddy-config.yaml
@@ -1,0 +1,17 @@
+# Caddy TLS-terminating sidecar config. Serves HTTPS on :8443 using the
+# cert-manager-issued cert and reverse-proxies to Open WebUI on localhost:8080.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openwebui-caddy
+  namespace: openwebui
+data:
+  Caddyfile: |
+    {
+      admin off
+      auto_https off          # we supply the cert; don't attempt ACME
+    }
+    :8443 {
+      tls /etc/caddy/certs/tls.crt /etc/caddy/certs/tls.key
+      reverse_proxy localhost:8080
+    }

--- a/crusoe-kserve-example/frontend/manifests/40-openwebui.yaml
+++ b/crusoe-kserve-example/frontend/manifests/40-openwebui.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-webui
+  namespace: openwebui
+  labels:
+    app: open-webui
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate          # RWO PVC — never run two pods mounting it at once
+  selector:
+    matchLabels:
+      app: open-webui
+  template:
+    metadata:
+      labels:
+        app: open-webui
+    spec:
+      containers:
+        # Open WebUI — the chat frontend. Talks to the vLLM OpenAI-compatible API.
+        - name: open-webui
+          image: ghcr.io/open-webui/open-webui:main
+          ports:
+            - containerPort: 8080
+          env:
+            # Points at the KServe workload Service for the deployed model. Change
+            # if you serve a different model (see `make deploy-openwebui` notes).
+            - name: OPENAI_API_BASE_URL
+              value: "http://qwen-llm-kserve-workload-svc.kserve-test.svc.cluster.local:8000/v1"
+            - name: OPENAI_API_KEY
+              value: "sk-noauth"      # vLLM ignores this unless started with --api-key
+            - name: WEBUI_AUTH
+              value: "True"           # first visitor signs up and becomes admin
+            - name: WEBUI_NAME
+              value: "Crusoe KServe Chat"
+          volumeMounts:
+            - name: data
+              mountPath: /app/backend/data
+          readinessProbe:
+            httpGet: { path: /health, port: 8080 }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            httpGet: { path: /health, port: 8080 }
+            initialDelaySeconds: 60
+            periodSeconds: 20
+        # Caddy TLS sidecar — terminates HTTPS on :8443 from the self-signed cert.
+        - name: caddy-tls
+          image: caddy:2-alpine
+          command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+          ports:
+            - containerPort: 8443
+          volumeMounts:
+            - name: caddy-config
+              mountPath: /etc/caddy/Caddyfile
+              subPath: Caddyfile
+            - name: tls
+              mountPath: /etc/caddy/certs
+              readOnly: true
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: openwebui-data
+        - name: caddy-config
+          configMap:
+            name: openwebui-caddy
+        - name: tls
+          secret:
+            secretName: openwebui-tls
+---
+# ClusterIP — the port-forward target (plaintext :8080).
+apiVersion: v1
+kind: Service
+metadata:
+  name: openwebui
+  namespace: openwebui
+  labels:
+    app: open-webui
+spec:
+  type: ClusterIP
+  selector:
+    app: open-webui
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/crusoe-kserve-example/frontend/manifests/40-openwebui.yaml
+++ b/crusoe-kserve-example/frontend/manifests/40-openwebui.yaml
@@ -34,6 +34,10 @@ spec:
               value: "True"           # first visitor signs up and becomes admin
             - name: WEBUI_NAME
               value: "Crusoe KServe Chat"
+            # Let every signed-up user see/use the served model. Without this,
+            # non-admin users are gated by model access control and see no models.
+            - name: BYPASS_MODEL_ACCESS_CONTROL
+              value: "True"
           volumeMounts:
             - name: data
               mountPath: /app/backend/data

--- a/crusoe-kserve-example/frontend/manifests/40-openwebui.yaml
+++ b/crusoe-kserve-example/frontend/manifests/40-openwebui.yaml
@@ -38,6 +38,10 @@ spec:
             # non-admin users are gated by model access control and see no models.
             - name: BYPASS_MODEL_ACCESS_CONTROL
               value: "True"
+            # Drop Open WebUI's built-in "arena-model" blind-comparison entry so the
+            # model dropdown shows only the served model(s).
+            - name: ENABLE_EVALUATION_ARENA_MODELS
+              value: "False"
           volumeMounts:
             - name: data
               mountPath: /app/backend/data

--- a/crusoe-kserve-example/frontend/manifests/50-service-lb.yaml
+++ b/crusoe-kserve-example/frontend/manifests/50-service-lb.yaml
@@ -1,0 +1,23 @@
+# Public HTTPS entrypoint. The crusoe-lb-controller provisions a Crusoe external
+# load balancer and assigns a VIP; `manage-firewall-rule` makes it open the firewall
+# to the backing nodePort automatically (on CMK the LB DNATs to a nodePort before
+# the project firewall is evaluated, so the rule must target the nodePort, not 443).
+#
+# WARNING: this exposes the app to the public internet (0.0.0.0/0). To restrict,
+# add `loadBalancerSourceRanges: ["<your-cidr>"]` below.
+apiVersion: v1
+kind: Service
+metadata:
+  name: openwebui-lb
+  namespace: openwebui
+  annotations:
+    crusoe.ai/manage-firewall-rule: "true"
+spec:
+  type: LoadBalancer
+  selector:
+    app: open-webui
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443     # Caddy TLS sidecar
+      protocol: TCP


### PR DESCRIPTION
## What

Adds an [Open WebUI](https://github.com/open-webui/open-webui) chat frontend in front of the vLLM/KServe model, exposed to the internet over **HTTPS on :443 with a self-signed cert** — and via `kubectl port-forward` — plus the vLLM/Open WebUI configuration needed for it to actually work end-to-end.

```
internet ──HTTPS:443──▶ Crusoe LB (VIP) ──nodePort──▶ Caddy :8443 (self-signed TLS) ──▶ Open WebUI :8080 ──▶ vLLM /v1
```

## Changes

- **`frontend/manifests/`** — Open WebUI Deployment (SSD-backed PVC) + a **Caddy TLS sidecar** (`:8443`, serving a cert-manager self-signed cert) + a ClusterIP Service (port-forward) + a `type: LoadBalancer` Service on `:443` annotated `crusoe.ai/manage-firewall-rule: "true"`.
- **`make deploy-openwebui`** — installs the **crusoe-lb-controller** if missing (required for CMK `LoadBalancer` VIPs; not a create-time add-on), issues the cert, applies the manifests, points Open WebUI at the vLLM endpoint (`OPENWEBUI_BACKEND_URL`), and prints the URL. Plus `install-lb-controller` / `openwebui-forward` / `openwebui-url` / `destroy-openwebui`.
- **`deploy-basic`** — enable vLLM tool calling (`--enable-auto-tool-choice --tool-call-parser hermes`); Open WebUI sends `tool_choice: "auto"`, which vLLM otherwise rejects.
- **Open WebUI env** — `BYPASS_MODEL_ACCESS_CONTROL=True` (so non-admin users see the served model) and `ENABLE_EVALUATION_ARENA_MODELS=False` (drops the built-in `arena-model` from the dropdown).
- **`frontend/README.md`** — exposure diagram, prerequisites, and security notes.

## Prerequisites

KServe (`make setup`) + a deployed model (`make deploy-basic`) + cert-manager (installed with KServe).

## Verified end-to-end (live CMK cluster, 2× A100)

- `crusoe-lb-controller` install → `LoadBalancer` gets a VIP (~15s).
- Public HTTPS `:443` with the self-signed cert → Open WebUI → **vLLM chat returns**.
- A regular (non-admin, approved) user sees the model and can chat.
- Smoke-tested the Makefile: `help`, dry-run of all deploy targets, `helm lint` + render of all 7 deploy modes, `bench`, and the `openwebui-*` helpers.

## Security

The `LoadBalancer` exposes the app to `0.0.0.0/0` and the cert is self-signed (browser warning). The README documents restricting with `loadBalancerSourceRanges` and swapping the self-signed issuer for a real one once you have DNS.
