### PR TITLE
crusoe-kserve-example: add AMD MI355X (gfx950) large single-node mode

### DIFF
--- a/crusoe-kserve-example/CLAUDE.md
+++ b/crusoe-kserve-example/CLAUDE.md
@@ -127,11 +127,14 @@ make deploy-amd-large      # MiniMax-M2 on 8x MI300X (TP=8, EP, 1500Gi PVC) — 
 make redeploy-amd-large    # Update AMD large model args WITHOUT deleting PVC (preserves downloaded model)
 make deploy-amd-multi-node # MiniMax-M2 on 2x8 MI300X (TP=8, 2 replicas)
 make deploy-amd-mi355x     # Qwen3-235B on 8x MI355X gfx950 (TP=8, EP, tool calling) — RWX shared disk; re-run to update args (weights persist)
+make deploy-amd-mi355x REPLICAS=2  # Scale to 2 data-parallel replicas (use both nodes) — run AFTER the first deploy
 ```
 
 **Note**: `deploy-amd-large` deletes the PVC before deploying. Use `redeploy-amd-large` to update args while preserving already-downloaded model weights.
 
 **MI355X (`deploy-amd-mi355x`) differs from `deploy-amd-large`**: it uses a gfx950-specific ROCm image (`rocm/vllm:...gfx950-dcgpu...`), a **ReadWriteMany** shared disk (`fs.csi.crusoe.ai`, 1 TiB min) instead of a RWO PVC, and a long startupProbe budget for the 235B AITER MoE compile. The RWX disk lets a rolling update stage the new pod on an idle node before the old one exits (zero-downtime, no single-GPU-node deadlock), so `deploy-amd-mi355x` is safe to re-run to update args — it does **not** delete the PVC and weights persist. Model/resources/labels live in the `amd.mi355x:` block of `values.yaml`; vLLM args are set via `--set` in the Makefile target.
+
+**Using all nodes (data parallelism)**: Qwen3-235B fits on one 8-GPU node, so `replicas: 1` leaves other nodes idle and only one node is stressed under load. To use every node, scale to `REPLICAS=<node count>` — each replica is a full TP=8 model copy on one node, and the router's scheduler (EPP) load-balances across them. This is the right lever here; **multi-node tensor parallel is wrong** for a model that fits on one node (it only adds inter-node comms overhead). Because all replicas share the one RWX disk, added replicas **skip the download** — verified: replica 2's storage-initializer completed in ~1 min (`snapshot_download` sees the weights present) vs ~14 min for the first. **Deploy at `REPLICAS=1` first, then scale**: a fresh `REPLICAS>1` deploy would have every replica's storage-initializer racing to write the same shared volume.
 
 #### 4. Test AMD
 

--- a/crusoe-kserve-example/CLAUDE.md
+++ b/crusoe-kserve-example/CLAUDE.md
@@ -4,7 +4,7 @@ This project deploys open-source LLMs on Crusoe Managed Kubernetes (CMK) using K
 
 ## What This Does
 
-Provisions a CMK cluster with GPU node pools and installs KServe for LLM inference. Supports six deployment modes:
+Provisions a CMK cluster with GPU node pools and installs KServe for LLM inference. Supports these deployment modes:
 - **Basic (NVIDIA)**: Single-GPU serving (e.g., Qwen2.5-0.5B on 1x A100)
 - **Large (NVIDIA)**: Multi-GPU single-node serving (e.g., Qwen2.5-72B on 8x H100, TP=8)
 - **Multi-Node (NVIDIA)**: Tensor-parallel across multiple nodes (e.g., Qwen2.5-72B on 16 GPUs)
@@ -12,6 +12,7 @@ Provisions a CMK cluster with GPU node pools and installs KServe for LLM inferen
 - **Basic (AMD)**: Single-GPU serving on MI300X (e.g., Qwen2.5-0.5B on 1x MI300X)
 - **Large (AMD)**: Multi-GPU single-node serving on MI300X (e.g., MiniMax-M2 on 8x MI300X, TP=8)
 - **Multi-Node (AMD)**: Multi-node tensor-parallel on MI300X (e.g., MiniMax-M2 on 2x8 MI300X)
+- **Large (AMD MI355X)**: Multi-GPU single-node serving on MI355X gfx950 (e.g., Qwen3-235B on 8x MI355X, TP=8+EP) — gfx950 ROCm image, RWX shared disk, tool calling
 
 ## Setup Flow
 
@@ -125,9 +126,12 @@ make deploy-amd-basic      # Qwen2.5-0.5B on 1x MI300X
 make deploy-amd-large      # MiniMax-M2 on 8x MI300X (TP=8, EP, 1500Gi PVC) — deletes existing PVC first
 make redeploy-amd-large    # Update AMD large model args WITHOUT deleting PVC (preserves downloaded model)
 make deploy-amd-multi-node # MiniMax-M2 on 2x8 MI300X (TP=8, 2 replicas)
+make deploy-amd-mi355x     # Qwen3-235B on 8x MI355X gfx950 (TP=8, EP, tool calling) — RWX shared disk; re-run to update args (weights persist)
 ```
 
 **Note**: `deploy-amd-large` deletes the PVC before deploying. Use `redeploy-amd-large` to update args while preserving already-downloaded model weights.
+
+**MI355X (`deploy-amd-mi355x`) differs from `deploy-amd-large`**: it uses a gfx950-specific ROCm image (`rocm/vllm:...gfx950-dcgpu...`), a **ReadWriteMany** shared disk (`fs.csi.crusoe.ai`, 1 TiB min) instead of a RWO PVC, and a long startupProbe budget for the 235B AITER MoE compile. The RWX disk lets a rolling update stage the new pod on an idle node before the old one exits (zero-downtime, no single-GPU-node deadlock), so `deploy-amd-mi355x` is safe to re-run to update args — it does **not** delete the PVC and weights persist. Model/resources/labels live in the `amd.mi355x:` block of `values.yaml`; vLLM args are set via `--set` in the Makefile target.
 
 #### 4. Test AMD
 
@@ -138,9 +142,13 @@ make test  # Port-forward + curl (works for any deployed model)
 #### 5. Benchmark AMD
 
 ```bash
-make bench-amd                    # Default: 50 req/s, 512 input, 150 output (served-model-name=minimax)
+make bench-amd                    # MI300X: 50 req/s, 512 input, 150 output (served-model-name=minimax)
 make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
+make bench-amd-mi355x             # MI355X (served-model-name=qwen3)
+make bench-amd BENCH_MODEL=<name> # override served-model-name on any bench target
 ```
+
+**Note on `served-model-name`**: `bench` defaults to `qwen`, `bench-amd` to `minimax`, `bench-amd-mi355x` to `qwen3`. If your deployment serves a different name, pass `BENCH_MODEL=<name>` — `vllm bench serve` 404s if the name doesn't match what `/v1/models` reports.
 
 #### AMD-Specific vLLM Environment Variables
 
@@ -185,6 +193,8 @@ The Terraform setup also patches the KServe `inferenceservice-config` configmap 
 - `helm/crusoe-kserve-example/templates/amd-basic-llm.yaml` — AMD single-GPU manifest
 - `helm/crusoe-kserve-example/templates/amd-large-llm.yaml` — AMD multi-GPU single-node manifest
 - `helm/crusoe-kserve-example/templates/amd-multi-node-llm.yaml` — AMD multi-node manifest
+- `helm/crusoe-kserve-example/templates/amd-mi355x-llm.yaml` — AMD MI355X gfx950 single-node manifest (RWX disk, startupProbe, tool calling)
+- `helm/crusoe-kserve-example/templates/amd-mi355x-storage.yaml` — RWX shared disk (crusoe-fs StorageClass + `model-storage-shared` PVC) for MI355X weights
 - `monitoring/docker-compose.yml` — Grafana container (port 3000)
 - `monitoring/setup.py` — Configures Grafana datasource + prints dashboard URL
 - `monitoring/env.example` — Template for monitoring credentials (copy to `env` and fill in values)
@@ -221,8 +231,11 @@ nodeSelector labels: `nvidia-a100-80gb-sxm-ib`, `nvidia-h100-80gb-sxm-ib`, `nvid
 | Node Type              | GPU          | GPUs | VRAM     | Best For                              |
 |------------------------|--------------|------|----------|---------------------------------------|
 | mi300x-192gb-ib.8x     | MI300X       | 8    | 1536 GB  | Large MoE models, high-memory serving |
+| mi355x-288gb-roce.8x   | MI355X (gfx950) | 8 | 2304 GB  | Large MoE (235B+), gfx950/CDNA4       |
 
-nodeSelector label: `amd-mi300x-192gb-ib`
+nodeSelector labels: `amd-mi300x-192gb-ib`, `amd-mi355x-288gb-roce`
+
+MI355X requires a gfx950-specific ROCm image (`rocm/vllm:...gfx950-dcgpu...`); the default `vllm/vllm-openai-rocm:latest` lacks MI355X kernels.
 
 Resource key: `amd.com/gpu` (not `nvidia.com/gpu`)
 vLLM image: `vllm/vllm-openai-rocm:latest`
@@ -362,3 +375,12 @@ This uninstalls the Helm release and runs `terraform destroy` to tear down all i
 - `VLLM_ROCM_USE_AITER=1` is injected automatically by the AMD Helm templates. Do not set it to `0` unless debugging — it significantly reduces throughput on MI300X
 - AMD clusters use `crusoe_csi` add-on only — no `nvidia_gpu_operator` or `nvidia_network_operator`. If you accidentally create an AMD cluster with NVIDIA add-ons, recreate it
 - For MiniMax-M2 (MoE model), `--enable-expert-parallel` is required alongside `--tensor-parallel-size 8`. Without it, the model may OOM or perform poorly
+
+#### MI355X (gfx950) — `deploy-amd-mi355x`
+
+- Must use a **gfx950-specific ROCm image** (`rocm/vllm:...gfx950-dcgpu...`, set in `amd.mi355x.image`). The default `vllm/vllm-openai-rocm:latest` lacks MI355X kernels and will fail to load
+- If the pod restarts in a loop with **exit 137** during first startup, it's the **startup probe timing out**, not OOM: the 235B AITER MoE kernel compile exceeds KServe's default 10-min budget. The `amd.mi355x.startupProbe` (periodSeconds 15 × failureThreshold 200 ≈ 50 min) covers it. A restart recompiles (~10-15 min) but does not re-download (weights are on the shared disk)
+- Uses a **ReadWriteMany** shared disk (`fs.csi.crusoe.ai`, StorageClass `crusoe-fs`, min **1 TiB**), not the RWO `model-storage` PVC. If the PVC is stuck `Pending`, check the size is ≥ 1 TiB (`disk size too small: minimum size: 1099511627776`)
+- On a **2-node** MI355X pool, a re-run of `deploy-amd-mi355x` cuts over with zero downtime (new pod stages on the idle node, then the old one exits). On a **single-node** pool there's no idle node to stage onto — delete the old pod to free the 8 GPUs, or expect the new pod to stay `Pending` until it does
+- Open WebUI (and other clients) send `tool_choice: auto`; the target passes `--enable-auto-tool-choice --tool-call-parser hermes` so vLLM accepts it. Qwen3 emits Hermes-style `<tool_call>` blocks, so `hermes` is the correct parser
+- Benchmark with `make bench-amd-mi355x` (served-model-name `qwen3`), not `make bench`/`bench-amd` (those default to `qwen`/`minimax` and will 404)

--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -17,7 +17,7 @@ DOCKER_PASSWORD  ?= $(shell grep '^docker_password' $(_AMD_TFVARS) 2>/dev/null |
 AMD_DRIVER_IMAGE ?= docker.io/$(DOCKER_USERNAME)/amd-gpu-driver
 
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
 
 # ---------------------------------------------------------------------------
 # Setup (cluster + KServe + namespace — all via Terraform)
@@ -217,6 +217,31 @@ deploy-amd-multi-node: ## Deploy multi-node LLM on AMD MI300X (MiniMax-M2 on 2x8
 	  --set amd.multiNode.enabled=true \
 	  --set disaggregated.enabled=false
 
+deploy-amd-mi355x: ## Deploy large single-node LLM on AMD MI355X gfx950 (Qwen3-235B on 8x MI355X, TP=8+EP) w/ RWX shared disk + tool calling
+	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
+	  --set hfToken=$(HF_TOKEN) \
+	  --set basic.enabled=false \
+	  --set large.enabled=false \
+	  --set multiNode.enabled=false \
+	  --set disaggregated.enabled=false \
+	  --set amd.basic.enabled=false \
+	  --set amd.large.enabled=false \
+	  --set amd.multiNode.enabled=false \
+	  --set amd.mi355x.enabled=true \
+	  --set amd.mi355x.args[0]="--gpu-memory-utilization" \
+	  --set amd.mi355x.args[1]="0.9" \
+	  --set amd.mi355x.args[2]="--tensor-parallel-size" \
+	  --set-string amd.mi355x.args[3]="8" \
+	  --set amd.mi355x.args[4]="--enable-expert-parallel" \
+	  --set amd.mi355x.args[5]="--max-model-len" \
+	  --set-string amd.mi355x.args[6]="32768" \
+	  --set amd.mi355x.args[7]="--enable-auto-tool-choice" \
+	  --set amd.mi355x.args[8]="--tool-call-parser" \
+	  --set amd.mi355x.args[9]="hermes"
+	@echo ""
+	@echo "Weights persist on the RWX shared disk (model-storage-shared). Re-run this target"
+	@echo "to update args: the pod recompiles AITER kernels (~10-15 min) but does not re-download."
+
 deploy-disaggregated: ## Deploy disaggregated prefill-decode (needs KServe v0.19.0+; set model/TP/GPUs/labels in values.yaml disaggregated:)
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
 	  --set hfToken=$(HF_TOKEN) \
@@ -304,39 +329,39 @@ BENCH_NUM_PROMPTS ?= 200
 BENCH_RATE        ?= 50
 BENCH_INPUT_LEN   ?= 512
 BENCH_OUTPUT_LEN  ?= 150
+BENCH_MODEL       ?=          # served-model-name; blank => each target's default (qwen / minimax / qwen3)
 
+# $(1) is the per-target default served-model-name; BENCH_MODEL on the command line overrides it.
 _bench_run = kubectl exec -n $(NAMESPACE) deploy/$$DEPLOY -c main -- \
 	  vllm bench serve \
 	    --model /mnt/models \
-	    --served-model-name qwen \
+	    --served-model-name $(or $(BENCH_MODEL),$(1)) \
 	    --base-url http://localhost:8000 \
 	    --backend openai-chat \
 	    --endpoint /v1/chat/completions \
 	    --dataset-name random \
 	    --random-output-len $(BENCH_OUTPUT_LEN)
 
-_bench_run_amd = kubectl exec -n $(NAMESPACE) deploy/$$DEPLOY -c main -- \
-	  vllm bench serve \
-	    --model /mnt/models \
-	    --served-model-name minimax \
-	    --base-url http://localhost:8000 \
-	    --backend openai-chat \
-	    --endpoint /v1/chat/completions \
-	    --dataset-name random \
-	    --random-output-len $(BENCH_OUTPUT_LEN)
-
-bench: ## Run a single benchmark profile (configure with BENCH_RATE, BENCH_INPUT_LEN, BENCH_NUM_PROMPTS)
+bench: ## Run a benchmark (NVIDIA; served-model-name qwen — override with BENCH_MODEL=, plus BENCH_RATE/BENCH_INPUT_LEN/BENCH_NUM_PROMPTS)
 	@DEPLOY=$$(kubectl get deploy -n $(NAMESPACE) -o name | grep -v router | head -1 | sed 's|deployment.apps/||') && \
 	echo "Running vLLM benchmark on $$DEPLOY..." && \
-	$(call _bench_run) \
+	$(call _bench_run,qwen) \
 	    --random-input-len $(BENCH_INPUT_LEN) \
 	    --num-prompts $(BENCH_NUM_PROMPTS) \
 	    --request-rate $(BENCH_RATE)
 
-bench-amd: ## Run AMD benchmark profile (same params as bench — configure with BENCH_RATE, BENCH_INPUT_LEN, BENCH_NUM_PROMPTS)
+bench-amd: ## Run a benchmark (AMD MI300X; served-model-name minimax — override with BENCH_MODEL=)
 	@DEPLOY=$$(kubectl get deploy -n $(NAMESPACE) -o name | grep -v router | head -1 | sed 's|deployment.apps/||') && \
 	echo "Running vLLM benchmark on $$DEPLOY (AMD)..." && \
-	$(call _bench_run_amd) \
+	$(call _bench_run,minimax) \
+	    --random-input-len $(BENCH_INPUT_LEN) \
+	    --num-prompts $(BENCH_NUM_PROMPTS) \
+	    --request-rate $(BENCH_RATE)
+
+bench-amd-mi355x: ## Run a benchmark (AMD MI355X; served-model-name qwen3 — override with BENCH_MODEL=)
+	@DEPLOY=$$(kubectl get deploy -n $(NAMESPACE) -o name | grep -v router | head -1 | sed 's|deployment.apps/||') && \
+	echo "Running vLLM benchmark on $$DEPLOY (AMD MI355X)..." && \
+	$(call _bench_run,qwen3) \
 	    --random-input-len $(BENCH_INPUT_LEN) \
 	    --num-prompts $(BENCH_NUM_PROMPTS) \
 	    --request-rate $(BENCH_RATE)

--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -217,7 +217,11 @@ deploy-amd-multi-node: ## Deploy multi-node LLM on AMD MI300X (MiniMax-M2 on 2x8
 	  --set amd.multiNode.enabled=true \
 	  --set disaggregated.enabled=false
 
-deploy-amd-mi355x: ## Deploy large single-node LLM on AMD MI355X gfx950 (Qwen3-235B on 8x MI355X, TP=8+EP) w/ RWX shared disk + tool calling
+# Replicas for the MI355X mode. Deploy at 1 first (weights download once to the
+# shared disk), THEN re-run with REPLICAS=<node count> to put every node to work.
+REPLICAS ?= 1
+
+deploy-amd-mi355x: ## Deploy large single-node LLM on AMD MI355X gfx950 (Qwen3-235B on 8x MI355X, TP=8+EP) w/ RWX shared disk + tool calling. REPLICAS=N to use N nodes.
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
 	  --set hfToken=$(HF_TOKEN) \
 	  --set basic.enabled=false \
@@ -228,6 +232,7 @@ deploy-amd-mi355x: ## Deploy large single-node LLM on AMD MI355X gfx950 (Qwen3-2
 	  --set amd.large.enabled=false \
 	  --set amd.multiNode.enabled=false \
 	  --set amd.mi355x.enabled=true \
+	  --set amd.mi355x.replicas=$(REPLICAS) \
 	  --set amd.mi355x.args[0]="--gpu-memory-utilization" \
 	  --set amd.mi355x.args[1]="0.9" \
 	  --set amd.mi355x.args[2]="--tensor-parallel-size" \
@@ -241,6 +246,7 @@ deploy-amd-mi355x: ## Deploy large single-node LLM on AMD MI355X gfx950 (Qwen3-2
 	@echo ""
 	@echo "Weights persist on the RWX shared disk (model-storage-shared). Re-run this target"
 	@echo "to update args: the pod recompiles AITER kernels (~10-15 min) but does not re-download."
+	@echo "Scale to all nodes once weights are downloaded: make deploy-amd-mi355x REPLICAS=<node count>"
 
 deploy-disaggregated: ## Deploy disaggregated prefill-decode (needs KServe v0.19.0+; set model/TP/GPUs/labels in values.yaml disaggregated:)
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \

--- a/crusoe-kserve-example/README.md
+++ b/crusoe-kserve-example/README.md
@@ -10,7 +10,7 @@ Deploy open-source LLMs from HuggingFace on Crusoe Managed Kubernetes (CMK) usin
   - Single-node multi-GPU inference (Qwen2.5-72B on 8x H100, TP=8)
   - Multi-node tensor-parallel inference (Qwen2.5-72B across 16 GPUs)
   - Disaggregated prefill-decode with H100 (prefill) and A100 (decode)
-- AMD MI300X support with ROCm vLLM (MiniMax-M2)
+- AMD MI300X and MI355X (gfx950) support with ROCm vLLM (MiniMax-M2, Qwen3-235B)
 - Helm chart for model deployments
 - OpenAI-compatible `/v1/chat/completions` endpoint
 
@@ -142,7 +142,12 @@ make deploy-amd-large
 
 # Multi-node (MiniMax-M2 on 2x8 MI300X)
 make deploy-amd-multi-node
+
+# Large single-node on MI355X gfx950 (Qwen3-235B on 8x MI355X — TP=8, expert parallel, tool calling)
+make deploy-amd-mi355x
 ```
+
+> **MI355X (gfx950)** uses a gfx950-specific ROCm image (the default `vllm-openai-rocm` lacks MI355X kernels) and a **ReadWriteMany shared disk** instead of a single-attach PVC — so a rolling update can bring the new pod up on an idle node before the old one exits (zero downtime, no single-GPU-node deadlock). The first-run AITER MoE kernel compile for a 235B model gets a longer startup-probe budget so it isn't probe-killed mid-compile. Re-run `make deploy-amd-mi355x` to change args; weights persist on the shared disk (no re-download). Set model/resources/labels in the `amd.mi355x:` block of `values.yaml`.
 
 ### 4. Chat
 Enter an interactive chat interface.
@@ -153,8 +158,10 @@ make chat
 ### 5. Test and benchmark
 
 ```bash
-make bench-amd                                      # 50 req/s, 512 input, 150 output
+make bench-amd                                      # MI300X: 50 req/s, 512 input, 150 output (served-model-name minimax)
 make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
+make bench-amd-mi355x                               # MI355X (served-model-name qwen3)
+make bench-amd BENCH_MODEL=<name>                   # override the served-model-name for any bench target
 ```
 
 ---
@@ -205,6 +212,7 @@ Once KServe is installed, proceed directly to the deploy commands (`make deploy-
 | **Basic (AMD)** | 1x MI300X | Qwen2.5-0.5B | Dev/test on AMD |
 | **Large (AMD)** | 8x MI300X TP=8 | MiniMax-M2 | Large MoE models, high-memory serving |
 | **Multi-Node (AMD)** | 16x MI300X (2 nodes) | MiniMax-M2 | Multi-node MoE on AMD |
+| **Large (AMD MI355X)** | 8x MI355X TP=8 | Qwen3-235B | Large MoE on gfx950, RWX shared disk, tool calling |
 
 ### NVIDIA Cluster Layout
 
@@ -284,8 +292,10 @@ crusoe-kserve-example/
 │       ├── multi-node-llm.yaml        # NVIDIA multi-node tensor parallel
 │       ├── disaggregated-llm.yaml     # NVIDIA prefill-decode split
 │       ├── amd-basic-llm.yaml         # AMD single-GPU deployment
-│       ├── amd-large-llm.yaml         # AMD multi-GPU single-node deployment
-│       └── amd-multi-node-llm.yaml    # AMD multi-node tensor parallel
+│       ├── amd-large-llm.yaml         # AMD MI300X multi-GPU single-node deployment
+│       ├── amd-multi-node-llm.yaml    # AMD multi-node tensor parallel
+│       ├── amd-mi355x-llm.yaml        # AMD MI355X gfx950 single-node deployment
+│       └── amd-mi355x-storage.yaml    # RWX shared disk for MI355X model weights
 └── monitoring/
     ├── docker-compose.yml             # Grafana container (port 3000)
     ├── env                            # Crusoe credentials (not committed)

--- a/crusoe-kserve-example/README.md
+++ b/crusoe-kserve-example/README.md
@@ -145,9 +145,14 @@ make deploy-amd-multi-node
 
 # Large single-node on MI355X gfx950 (Qwen3-235B on 8x MI355X — TP=8, expert parallel, tool calling)
 make deploy-amd-mi355x
+
+# Use every node: scale to N data-parallel replicas (one full model per node), after the first deploy
+make deploy-amd-mi355x REPLICAS=2
 ```
 
 > **MI355X (gfx950)** uses a gfx950-specific ROCm image (the default `vllm-openai-rocm` lacks MI355X kernels) and a **ReadWriteMany shared disk** instead of a single-attach PVC — so a rolling update can bring the new pod up on an idle node before the old one exits (zero downtime, no single-GPU-node deadlock). The first-run AITER MoE kernel compile for a 235B model gets a longer startup-probe budget so it isn't probe-killed mid-compile. Re-run `make deploy-amd-mi355x` to change args; weights persist on the shared disk (no re-download). Set model/resources/labels in the `amd.mi355x:` block of `values.yaml`.
+>
+> **Using all nodes (data parallelism):** Qwen3-235B fits on one 8-GPU node, so the way to use additional nodes is **horizontal replicas**, not multi-node tensor parallel. Each replica is a full TP=8 model copy on one node; the router's scheduler load-balances across them. Deploy at `REPLICAS=1` first so the weights download once to the shared disk, then `make deploy-amd-mi355x REPLICAS=<node count>` — added replicas mount the same shared disk and **skip the download** (verified: the second replica's storage-initializer finishes in ~1 min instead of re-pulling 235GB). Avoid a fresh `REPLICAS>1` deploy — every replica's storage-initializer would race to write the same shared volume.
 
 ### 4. Chat
 Enter an interactive chat interface.

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-mi355x-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-mi355x-llm.yaml
@@ -8,7 +8,12 @@ spec:
   model:
     uri: {{ .Values.amd.mi355x.model.uri }}
     name: {{ .Values.amd.mi355x.model.name }}
-  replicas: 1
+  # Each replica is a full TP=8 copy of the model on one node; the router's
+  # scheduler load-balances across them. Set this to the node count to put every
+  # node to work (data-parallel). Deploy at 1 first so the weights download once
+  # to the shared disk, THEN scale up — a fresh replicas>1 deploy would have
+  # every replica's storage-initializer racing to write the same shared volume.
+  replicas: {{ .Values.amd.mi355x.replicas | default 1 }}
   template:
     {{- if .Values.amd.mi355x.sharedStorage.enabled }}
     securityContext:

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-mi355x-llm.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-mi355x-llm.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.amd.mi355x.enabled }}
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: {{ .Values.amd.mi355x.model.name }}-llm
+  namespace: {{ .Values.namespace }}
+spec:
+  model:
+    uri: {{ .Values.amd.mi355x.model.uri }}
+    name: {{ .Values.amd.mi355x.model.name }}
+  replicas: 1
+  template:
+    {{- if .Values.amd.mi355x.sharedStorage.enabled }}
+    securityContext:
+      fsGroup: 1000            # PVC file ownership for the model download
+    {{- end }}
+    containers:
+      - name: main
+        image: {{ .Values.amd.mi355x.image }}
+        # Relax KServe v0.19.0's hardened pod preset — the ROCm image runs as root
+        # and writes to the container filesystem (torch/AITER compile caches).
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+          readOnlyRootFilesystem: false
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-secret
+                key: HF_TOKEN
+          - name: HF_HUB_DISABLE_XET
+            value: "1"
+          - name: VLLM_ROCM_USE_AITER   # AMD AITER kernels — significant MI355X throughput gain
+            value: "1"
+        {{- if .Values.amd.mi355x.args }}
+        args:
+          {{- toYaml .Values.amd.mi355x.args | nindent 10 }}
+        {{- end }}
+        resources:
+          limits:
+            amd.com/gpu: {{ .Values.amd.mi355x.resources.limits.gpu | quote }}
+            cpu: {{ .Values.amd.mi355x.resources.limits.cpu | quote }}
+            memory: {{ .Values.amd.mi355x.resources.limits.memory }}
+          requests:
+            amd.com/gpu: {{ .Values.amd.mi355x.resources.requests.gpu | quote }}
+            cpu: {{ .Values.amd.mi355x.resources.requests.cpu | quote }}
+            memory: {{ .Values.amd.mi355x.resources.requests.memory }}
+        # First-run AITER MoE kernel compile for a 235B model on gfx950 takes far
+        # longer than KServe's default 10-min startup budget. A generous window lets
+        # the compile complete and cache instead of being probe-killed in a loop.
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          periodSeconds: {{ .Values.amd.mi355x.startupProbe.periodSeconds }}
+          failureThreshold: {{ .Values.amd.mi355x.startupProbe.failureThreshold }}
+          timeoutSeconds: 5
+    {{- if .Values.amd.mi355x.sharedStorage.enabled }}
+    volumes:
+      # Override KServe's default emptyDir provision-location with the RWX PVC so
+      # weights land on the shared disk (do NOT add a second mount at /mnt/models).
+      - name: kserve-provision-location
+        persistentVolumeClaim:
+          claimName: model-storage-shared
+    {{- end }}
+    nodeSelector:
+      {{- toYaml .Values.amd.mi355x.nodeSelector | nindent 6 }}
+  router:
+    gateway: {}
+    route: {}
+    scheduler: {}
+{{- end }}

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-mi355x-storage.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/templates/amd-mi355x-storage.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.amd.mi355x.enabled .Values.amd.mi355x.sharedStorage.enabled }}
+# ReadWriteMany shared disk for the MI355X model weights, backed by the Crusoe
+# shared-fs CSI. RWX attaches to multiple nodes at once, so a rolling update can
+# stage the new pod on an idle node while the old one keeps serving (no RWO
+# Multi-Attach stall, no single-GPU-node deadlock). Minimum size is 1 TiB.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: crusoe-fs
+provisioner: fs.csi.crusoe.ai
+volumeBindingMode: Immediate
+reclaimPolicy: Delete
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-storage-shared
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: crusoe-fs
+  resources:
+    requests:
+      storage: {{ .Values.amd.mi355x.sharedStorage.size }}
+{{- end }}

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
@@ -210,6 +210,10 @@ amd:
     model:
       uri: hf://Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
       name: qwen3
+    # One full TP=8 model copy per replica; set to the node count to use every
+    # node (data-parallel, router load-balanced). Deploy at 1, then scale up so
+    # weights download once to the shared disk (see note in amd-mi355x-llm.yaml).
+    replicas: 1
     sharedStorage:
       enabled: true
       size: 1Ti          # fs.csi.crusoe.ai minimum is 1 TiB (model weights are ~235GB)

--- a/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
+++ b/crusoe-kserve-example/helm/crusoe-kserve-example/values.yaml
@@ -194,3 +194,36 @@ amd:
         memory: 256Gi
     nodeSelector:
       crusoe.ai/accelerator: amd-mi300x-192gb-ib
+
+  # MI355X (gfx950): large single-node MoE serving (e.g., Qwen3-235B on 8x MI355X, TP=8+EP).
+  # Differs from amd.large (MI300X) in three ways that matter:
+  #   1. A gfx950-specific ROCm image — the default vllm-openai-rocm lacks MI355X kernels.
+  #   2. A ReadWriteMany shared disk (fs.csi.crusoe.ai) instead of RWO, so a rolling update
+  #      can bring the new pod up on an idle node before the old one exits — zero-downtime,
+  #      no RWO Multi-Attach stall, no single-GPU-node rollout deadlock.
+  #   3. A long startupProbe budget — the first-run AITER MoE compile for a 235B model far
+  #      exceeds KServe's default 10-min startup window and would otherwise probe-loop.
+  # vLLM args (TP/EP/tool-calling) are set via Makefile --set flags (see deploy-amd-mi355x).
+  mi355x:
+    enabled: false
+    image: rocm/vllm:rocm7.13.0_gfx950-dcgpu_ubuntu24.04_py3.13_pytorch_2.10.0_vllm_0.19.1
+    model:
+      uri: hf://Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
+      name: qwen3
+    sharedStorage:
+      enabled: true
+      size: 1Ti          # fs.csi.crusoe.ai minimum is 1 TiB (model weights are ~235GB)
+    startupProbe:
+      periodSeconds: 15
+      failureThreshold: 200   # ~50 min for the AITER MoE kernel compile to complete + cache
+    resources:
+      limits:
+        gpu: "8"
+        cpu: "64"
+        memory: 1024Gi
+      requests:
+        gpu: "8"
+        cpu: "16"
+        memory: 128Gi
+    nodeSelector:
+      crusoe.ai/accelerator: amd-mi355x-288gb-roce


### PR DESCRIPTION
## What

Adds a reproducible `deploy-amd-mi355x` deployment mode for large single-node MoE serving on 8× AMD MI355X (gfx950) — e.g. Qwen3-235B-A22B TP=8 + expert parallel, with tool calling.

## Why it's a separate mode (not `amd.large`)

The existing `amd.large` targets MI300X. MI355X (gfx950) needs three things that differ:

1. **A gfx950-specific ROCm image** — the default `vllm-openai-rocm` lacks MI355X kernels.
2. **A ReadWriteMany shared disk** (`fs.csi.crusoe.ai`, 1 TiB min) instead of a RWO PVC — so a rolling update can bring the new pod up on an idle node before the old one exits. Zero-downtime re-deploys, no RWO Multi-Attach stall, no single-GPU-node rollout deadlock. Weights persist across re-deploys.
3. **A long `startupProbe` budget** — the first-run AITER MoE kernel compile for a 235B model far exceeds KServe's default 10-min startup window and would otherwise be probe-killed in a loop.

It also enables tool calling (`--enable-auto-tool-choice --tool-call-parser hermes`) so clients that send `tool_choice: auto` (e.g. Open WebUI) work; Qwen3 emits Hermes-style `<tool_call>` blocks.

## Changes

- **New chart templates** `amd-mi355x-llm.yaml` + `amd-mi355x-storage.yaml`, gated on `amd.mi355x.enabled` (**off by default**).
- **New `amd.mi355x` values profile** (gfx950 image, RWX shared-storage size, startupProbe budget, resources, nodeSelector).
- **`make deploy-amd-mi355x`** — safe to re-run to update args (does not delete the PVC; weights persist).
- **Benchmark parameterization** — `served-model-name` is now overridable via `BENCH_MODEL=`; adds `bench-amd-mi355x` (defaults `qwen3`). Previously `bench`/`bench-amd` hardcoded `qwen`/`minimax` and 404'd against other deployments.
- **`help` target** regex now includes digits, so numeric target names are listed.
- README + CLAUDE.md updated (new mode, SKU table, troubleshooting).

## Validation

- `helm lint` clean; all modes render; the `amd.mi355x` render matches the manifest that was proven in-cluster.
- Verified **end-to-end on an 8× MI355X cluster from a clean slate**: a single `make deploy-amd-mi355x` created the StorageClass + RWX PVC, downloaded weights fresh (~235GB), compiled AITER kernels, and reached `READY` with **0 restarts** (~26 min cold start).
- On the resulting chart-managed deployment: `/v1/models` returns `qwen3`, plain chat returns `finish: stop`, and `tool_choice: auto` with a tools array returns a proper `tool_calls` response — confirming the tool-calling flags took.
