### PR TITLE
crusoe-kserve-example: make `make test` model-agnostic + fix port-forward leak

### DIFF
--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -311,7 +311,7 @@ MODEL ?=
 chat: ## Interactive streaming chat with the deployed model (MODEL=<name> to override auto-detect)
 	@SVC=$$(kubectl get svc -n $(NAMESPACE) -o name | grep workload | head -1) && \
 	echo "Port-forwarding $$SVC to localhost:$(PORT)..." && \
-	kubectl port-forward -n $(NAMESPACE) $$SVC $(PORT):8000 >/dev/null 2>/dev/null & \
+	{ kubectl port-forward -n $(NAMESPACE) $$SVC $(PORT):8000 >/dev/null 2>/dev/null & } && \
 	PF_PID=$$! && \
 	sleep 2 && \
 	python3 scripts/chat.py \
@@ -319,17 +319,19 @@ chat: ## Interactive streaming chat with the deployed model (MODEL=<name> to ove
 	  $$([ -n "$(MODEL)" ] && echo "--model $(MODEL)" || true) || true; \
 	kill $$PF_PID 2>/dev/null || true
 
-test: ## Port-forward and send a test chat request
-	@echo "Finding workload service..."
+test: ## Port-forward and send a test chat request (auto-detects the served model; MODEL=<name> to override)
 	@SVC=$$(kubectl get svc -n $(NAMESPACE) -o name | grep workload | head -1) && \
-	  echo "Port-forwarding $$SVC to localhost:$(PORT)..." && \
-	  kubectl port-forward -n $(NAMESPACE) $$SVC $(PORT):8000 &
-	@sleep 3
-	@echo "Sending test request..."
-	@curl -s -H "Content-Type: application/json" \
-	  http://localhost:$(PORT)/v1/chat/completions \
-	  -d @chat-test.json | jq .
-	@kill %1 2>/dev/null || true
+	echo "Port-forwarding $$SVC to localhost:$(PORT)..." && \
+	{ kubectl port-forward -n $(NAMESPACE) $$SVC $(PORT):8000 >/dev/null 2>/dev/null & } && \
+	PF_PID=$$! && \
+	sleep 3 && \
+	MODEL_NAME="$(MODEL)"; \
+	[ -n "$$MODEL_NAME" ] || MODEL_NAME=$$(curl -s http://localhost:$(PORT)/v1/models | jq -r '.data[0].id'); \
+	echo "Testing model '$$MODEL_NAME'..." && \
+	jq --arg m "$$MODEL_NAME" '.model = $$m' chat-test.json | \
+	  curl -s -H "Content-Type: application/json" \
+	    http://localhost:$(PORT)/v1/chat/completions -d @- | jq . || true; \
+	kill $$PF_PID 2>/dev/null || true
 
 BENCH_NUM_PROMPTS ?= 200
 BENCH_RATE        ?= 50


### PR DESCRIPTION
## What

`make test` was hardcoded to model `qwen` (via `chat-test.json`) and 404'd against any other deployment — e.g. **qwen3** on MI355X returned `"model `qwen` does not exist"`. It also leaked a `kubectl port-forward` on every run, eventually failing with `address already in use`.

## Fix

- **Model auto-detect** — `make test` now reads the served model from `/v1/models` and injects it into the request via `jq`, so it works on **any** deployed model (qwen / qwen3 / minimax) with no flag. `MODEL=<name>` overrides it. (Same spirit as the `BENCH_MODEL` fix already in the repo.)
- **Port-forward cleanup** — the forwarder was written as `A && B && kubectl … &`, where `&` backgrounds the whole `&&` chain as a subshell, so `$!` captured the *subshell* PID and the cleanup `kill` missed the real `kubectl`. Wrapping only the port-forward in `{ … & }` makes `$!` the kubectl PID. Applied to both `test` and `chat` (identical latent bug). `test` also previously used `kill %1` in a separate recipe shell, which never saw the job.

## Verified (live MI355X cluster serving qwen3)

- `make test` → auto-detects `qwen3`, returns a completion (was a 404 before).
- `make test MODEL=qwen3` → override honored.
- **0 leaked forwarders** after each run (was 1 leaked per run before).