### PR TITLE
crusoe-kserve-example: add multi-node MI355X benchmarks (bench-amd-mi355x-all + -lb)

### DIFF
--- a/crusoe-kserve-example/CLAUDE.md
+++ b/crusoe-kserve-example/CLAUDE.md
@@ -147,11 +147,14 @@ make test  # Port-forward + curl (works for any deployed model)
 ```bash
 make bench-amd                    # MI300X: 50 req/s, 512 input, 150 output (served-model-name=minimax)
 make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
-make bench-amd-mi355x             # MI355X (served-model-name=qwen3)
+make bench-amd-mi355x             # MI355X: benchmark ONE node (localhost, single replica)
+make bench-amd-mi355x-all         # MI355X: benchmark EVERY node at once (per-pod + aggregate)
 make bench-amd BENCH_MODEL=<name> # override served-model-name on any bench target
 ```
 
-**Note on `served-model-name`**: `bench` defaults to `qwen`, `bench-amd` to `minimax`, `bench-amd-mi355x` to `qwen3`. If your deployment serves a different name, pass `BENCH_MODEL=<name>` — `vllm bench serve` 404s if the name doesn't match what `/v1/models` reports.
+**Note on `served-model-name`**: `bench` defaults to `qwen`, `bench-amd` to `minimax`, `bench-amd-mi355x`/`-all` to `qwen3`. If your deployment serves a different name, pass `BENCH_MODEL=<name>` — `vllm bench serve` 404s if the name doesn't match what `/v1/models` reports.
+
+**Single node vs all nodes**: `bench-amd-mi355x` `exec`s into one pod and drives `localhost:8000`, so it loads exactly one replica/node — the right way to measure per-node throughput. To load **every** node, `bench-amd-mi355x-all` fans the same benchmark out to all replica pods concurrently (each drives its own node) and reports per-pod plus summed aggregate. Don't drive aggregate load through the ClusterIP workload Service — it's L4 and HTTP keep-alive pins connections to one endpoint, so it won't fan out; real client balancing is done by the KServe gateway/EPP scheduler at L7.
 
 #### AMD-Specific vLLM Environment Variables
 

--- a/crusoe-kserve-example/CLAUDE.md
+++ b/crusoe-kserve-example/CLAUDE.md
@@ -149,12 +149,18 @@ make bench-amd                    # MI300X: 50 req/s, 512 input, 150 output (ser
 make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
 make bench-amd-mi355x             # MI355X: benchmark ONE node (localhost, single replica)
 make bench-amd-mi355x-all         # MI355X: benchmark EVERY node at once (per-pod + aggregate)
+make bench-amd-mi355x-lb          # MI355X: benchmark THROUGH the Envoy gateway (production path, EPP-balanced)
 make bench-amd BENCH_MODEL=<name> # override served-model-name on any bench target
 ```
 
-**Note on `served-model-name`**: `bench` defaults to `qwen`, `bench-amd` to `minimax`, `bench-amd-mi355x`/`-all` to `qwen3`. If your deployment serves a different name, pass `BENCH_MODEL=<name>` — `vllm bench serve` 404s if the name doesn't match what `/v1/models` reports.
+**Note on `served-model-name`**: `bench` defaults to `qwen`, `bench-amd` to `minimax`, `bench-amd-mi355x`/`-all`/`-lb` to `qwen3`. If your deployment serves a different name, pass `BENCH_MODEL=<name>` — `vllm bench serve` 404s if the name doesn't match what `/v1/models` reports.
 
-**Single node vs all nodes**: `bench-amd-mi355x` `exec`s into one pod and drives `localhost:8000`, so it loads exactly one replica/node — the right way to measure per-node throughput. To load **every** node, `bench-amd-mi355x-all` fans the same benchmark out to all replica pods concurrently (each drives its own node) and reports per-pod plus summed aggregate. Don't drive aggregate load through the ClusterIP workload Service — it's L4 and HTTP keep-alive pins connections to one endpoint, so it won't fan out; real client balancing is done by the KServe gateway/EPP scheduler at L7.
+**Three ways to benchmark, by what they exercise**:
+- `bench-amd-mi355x` — `exec`s into one pod and drives `localhost:8000`, so it loads exactly one replica/node. Cleanest per-node throughput number; bypasses the gateway.
+- `bench-amd-mi355x-all` — fans the same benchmark out to all replica pods concurrently (each drives its own node's `localhost`); reports per-pod + summed aggregate. Deterministic raw multi-node capacity; still bypasses the gateway.
+- `bench-amd-mi355x-lb` — drives load **through the Envoy gateway** (`kserve-ingress-gateway` VIP + `/<namespace>/<isvc>` path prefix → InferencePool → EPP), so requests are load-balanced per-request across replicas. This is the real client/production path. Don't use the ClusterIP workload Service for aggregate load — it's L4 and HTTP keep-alive pins connections to one endpoint; only the L7 gateway/EPP balances.
+
+**Load model (`vllm bench serve`)**: requests are concurrent (async), never serial. `--request-rate`/`BENCH_RATE` is **open-loop** (fires at that arrival rate regardless of server state; in-flight count floats and piles up unboundedly if arrival > capacity — this produces gateway 500s at high rates). `--max-concurrency`/`BENCH_CONCURRENCY` caps simultaneous in-flight requests (a semaphore); with `BENCH_RATE=inf` it's **closed-loop** — exactly N requests always outstanding, i.e. **N concurrent users**. To simulate hundreds of users: `make bench-amd-mi355x-lb BENCH_CONCURRENCY=<users> BENCH_RATE=inf`. The output's "Peak concurrent requests" shows actual in-flight count; TPOT rises with concurrency (more sequences batched per node) — that's the real per-user latency and the signal to add replicas.
 
 #### AMD-Specific vLLM Environment Variables
 

--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -338,6 +338,9 @@ BENCH_RATE        ?= 50
 BENCH_INPUT_LEN   ?= 512
 BENCH_OUTPUT_LEN  ?= 150
 BENCH_MODEL       ?=          # served-model-name; blank => each target's default (qwen / minimax / qwen3)
+BENCH_CONCURRENCY ?=          # max in-flight requests (--max-concurrency). Blank = unbounded (open-loop,
+                              # arrival-rate driven). Set to your target concurrent-user count for a
+                              # closed-loop test (e.g. BENCH_CONCURRENCY=200 BENCH_RATE=inf ~ 200 active users).
 
 # $(1) is the per-target default served-model-name; BENCH_MODEL on the command line overrides it.
 _bench_run = kubectl exec -n $(NAMESPACE) deploy/$$DEPLOY -c main -- \
@@ -400,6 +403,22 @@ bench-amd-mi355x-all: ## Benchmark EVERY replica pod at once (loads all nodes; r
 	grep -hiE '^output token throughput' "$$TMP"/*.log | awk '{s+=$$NF} END{printf "  Output token throughput (tok/s): %.1f\n", s}'; \
 	grep -hiE '^total token throughput'  "$$TMP"/*.log | awk '{s+=$$NF} END{printf "  Total token throughput (tok/s):  %.1f\n", s}'; \
 	rm -rf "$$TMP"
+
+bench-amd-mi355x-lb: ## Benchmark THROUGH the Envoy gateway/EPP — production path, requests load-balanced per-request across replicas. BENCH_CONCURRENCY=N caps in-flight.
+	@GW=$$(kubectl get gateway kserve-ingress-gateway -n kserve -o jsonpath='{.status.addresses[0].value}' 2>/dev/null); \
+	ISVC=$$(kubectl get llminferenceservice -n $(NAMESPACE) -o name 2>/dev/null | head -1 | sed 's|.*/||'); \
+	DEPLOY=$$(kubectl get deploy -n $(NAMESPACE) -o name | grep -v router | head -1 | sed 's|deployment.apps/||'); \
+	if [ -z "$$GW" ] || [ -z "$$ISVC" ]; then echo "Could not resolve the Envoy gateway (kserve/kserve-ingress-gateway) address or an LLMInferenceService in $(NAMESPACE)."; exit 1; fi; \
+	BASE="http://$$GW/$(NAMESPACE)/$$ISVC"; \
+	echo "Driving load THROUGH the Envoy gateway (EPP load-balances each request across replicas):"; \
+	echo "  endpoint:        $$BASE/v1/chat/completions"; \
+	echo "  arrival rate:    $(BENCH_RATE) req/s   |   in-flight cap: $(if $(BENCH_CONCURRENCY),$(BENCH_CONCURRENCY),unbounded)   |   prompts: $(BENCH_NUM_PROMPTS)"; \
+	kubectl exec -n $(NAMESPACE) deploy/$$DEPLOY -c main -- vllm bench serve \
+	  --model /mnt/models --served-model-name $(or $(BENCH_MODEL),qwen3) \
+	  --base-url $$BASE --backend openai-chat --endpoint /v1/chat/completions \
+	  --dataset-name random --random-input-len $(BENCH_INPUT_LEN) --random-output-len $(BENCH_OUTPUT_LEN) \
+	  --num-prompts $(BENCH_NUM_PROMPTS) --request-rate $(BENCH_RATE) \
+	  $(if $(BENCH_CONCURRENCY),--max-concurrency $(BENCH_CONCURRENCY),)
 
 # ---------------------------------------------------------------------------
 # Local monitoring (Grafana + Prometheus via Docker)

--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -374,6 +374,33 @@ bench-amd-mi355x: ## Run a benchmark (AMD MI355X; served-model-name qwen3 — ov
 	    --num-prompts $(BENCH_NUM_PROMPTS) \
 	    --request-rate $(BENCH_RATE)
 
+bench-amd-mi355x-all: ## Benchmark EVERY replica pod at once (loads all nodes; reports per-pod + aggregate). BENCH_* apply per node.
+	@DEPLOY=$$(kubectl get deploy -n $(NAMESPACE) -o name | grep -v router | head -1 | sed 's|deployment.apps/||'); \
+	PODS=$$(kubectl get pods -n $(NAMESPACE) -o name | sed 's|pod/||' | grep "^$$DEPLOY-" | grep -vE 'router|epp|scheduler'); \
+	N=$$(printf '%s\n' "$$PODS" | grep -c .); \
+	if [ "$$N" -lt 1 ]; then echo "No workload pods found for $$DEPLOY"; exit 1; fi; \
+	echo "Benchmarking $$N replica pod(s) concurrently — each drives its own node at $(BENCH_RATE) req/s:"; \
+	printf '  - %s\n' $$PODS; \
+	TMP=$$(mktemp -d); \
+	for POD in $$PODS; do \
+	  kubectl exec -n $(NAMESPACE) $$POD -c main -- vllm bench serve \
+	    --model /mnt/models --served-model-name $(or $(BENCH_MODEL),qwen3) \
+	    --base-url http://localhost:8000 --backend openai-chat --endpoint /v1/chat/completions \
+	    --dataset-name random --random-input-len $(BENCH_INPUT_LEN) --random-output-len $(BENCH_OUTPUT_LEN) \
+	    --num-prompts $(BENCH_NUM_PROMPTS) --request-rate $(BENCH_RATE) > "$$TMP/$$POD.log" 2>&1 & \
+	done; \
+	wait; \
+	echo ""; echo "===== per-pod results ====="; \
+	for POD in $$PODS; do \
+	  echo "--- $$POD ---"; \
+	  grep -iE '^(request throughput|output token throughput|median ttft|median tpot)' "$$TMP/$$POD.log" || echo "  (no results — see $$TMP/$$POD.log)"; \
+	done; \
+	echo ""; echo "===== aggregate across $$N node(s) ====="; \
+	grep -hiE '^request throughput'      "$$TMP"/*.log | awk '{s+=$$NF} END{printf "  Request throughput (req/s):      %.2f\n", s}'; \
+	grep -hiE '^output token throughput' "$$TMP"/*.log | awk '{s+=$$NF} END{printf "  Output token throughput (tok/s): %.1f\n", s}'; \
+	grep -hiE '^total token throughput'  "$$TMP"/*.log | awk '{s+=$$NF} END{printf "  Total token throughput (tok/s):  %.1f\n", s}'; \
+	rm -rf "$$TMP"
+
 # ---------------------------------------------------------------------------
 # Local monitoring (Grafana + Prometheus via Docker)
 # ---------------------------------------------------------------------------

--- a/crusoe-kserve-example/README.md
+++ b/crusoe-kserve-example/README.md
@@ -165,9 +165,12 @@ make chat
 ```bash
 make bench-amd                                      # MI300X: 50 req/s, 512 input, 150 output (served-model-name minimax)
 make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
-make bench-amd-mi355x                               # MI355X (served-model-name qwen3)
+make bench-amd-mi355x                               # MI355X: benchmark one node (single replica)
+make bench-amd-mi355x-all                           # MI355X: benchmark every node at once (per-pod + aggregate)
 make bench-amd BENCH_MODEL=<name>                   # override the served-model-name for any bench target
 ```
+
+> `bench-amd-mi355x` drives one pod's `localhost`, so it loads a single node. `bench-amd-mi355x-all` fans the benchmark out to every replica pod concurrently to load all nodes and reports the aggregate — useful once you've scaled with `REPLICAS=<node count>`.
 
 ---
 

--- a/crusoe-kserve-example/README.md
+++ b/crusoe-kserve-example/README.md
@@ -167,10 +167,16 @@ make bench-amd                                      # MI300X: 50 req/s, 512 inpu
 make bench-amd BENCH_RATE=10 BENCH_INPUT_LEN=128
 make bench-amd-mi355x                               # MI355X: benchmark one node (single replica)
 make bench-amd-mi355x-all                           # MI355X: benchmark every node at once (per-pod + aggregate)
+make bench-amd-mi355x-lb                            # MI355X: benchmark through the Envoy gateway (production path)
 make bench-amd BENCH_MODEL=<name>                   # override the served-model-name for any bench target
+
+# Simulate hundreds of concurrent users hitting the load-balanced endpoint:
+make bench-amd-mi355x-lb BENCH_CONCURRENCY=300 BENCH_RATE=inf BENCH_NUM_PROMPTS=3000
 ```
 
-> `bench-amd-mi355x` drives one pod's `localhost`, so it loads a single node. `bench-amd-mi355x-all` fans the benchmark out to every replica pod concurrently to load all nodes and reports the aggregate — useful once you've scaled with `REPLICAS=<node count>`.
+> **Which one?** `bench-amd-mi355x` loads a single node (localhost). `bench-amd-mi355x-all` fans out to every replica pod concurrently for raw multi-node capacity. `bench-amd-mi355x-lb` drives traffic **through the Envoy gateway** so requests are load-balanced per-request across replicas (the real production path) — use it once you've scaled with `REPLICAS=<node count>`.
+>
+> **Load model:** requests are concurrent, not serial. `BENCH_RATE` is the arrival rate (open-loop; in-flight count floats and can pile up). `BENCH_CONCURRENCY` caps in-flight requests — with `BENCH_RATE=inf` that's a closed-loop **N-concurrent-users** test. The result's "Peak concurrent requests" shows actual in-flight load, and TPOT (per-token latency) rising with concurrency is your signal to add replicas.
 
 ---
 


### PR DESCRIPTION
## What

Two ways to benchmark a scaled (multi-replica) MI355X deployment across nodes — `bench-amd-mi355x` alone only loads one node (it `exec`s into a pod and hits `localhost`).

- **`make bench-amd-mi355x-all`** — fans the benchmark out to **every replica pod concurrently** (each drives its own node's `localhost`); reports per-pod + summed aggregate. Deterministic raw multi-node capacity.
- **`make bench-amd-mi355x-lb`** — drives load **through the Envoy gateway** (`kserve-ingress-gateway` VIP + `/<namespace>/<isvc>` path prefix → InferencePool → EPP), so requests are load-balanced **per request** across replicas. The real production/client path. Gateway VIP + ISVC name resolved dynamically (no hardcoded IP).

## Load model / concurrency

Adds **`BENCH_CONCURRENCY`** (`--max-concurrency`). `vllm bench serve` sends requests concurrently (async), never serially:
- `BENCH_RATE` = arrival rate (**open-loop**) — fires regardless of server state; in-flight count floats and piles up unboundedly if arrival > capacity (this overwhelms the gateway/EPP and returns 500s at high rates).
- `BENCH_CONCURRENCY` caps in-flight requests; with `BENCH_RATE=inf` it's a **closed-loop N-concurrent-users** test.

Simulate hundreds of users: `make bench-amd-mi355x-lb BENCH_CONCURRENCY=300 BENCH_RATE=inf`.

## Verified (live 2-node MI355X, qwen3)

- `bench-amd-mi355x-all`: both nodes symmetric (~2,127 tok/s each), aggregate summed correctly (28.4 req/s, 4,254 output tok/s).
- `bench-amd-mi355x-lb` @ 100 concurrent (`BENCH_CONCURRENCY=100 BENCH_RATE=inf`): **1,500 requests, 0 failed**, both nodes balanced at 100% util through the gateway, 10.2 req/s, 504 ms median TTFT, 62 ms TPOT. (Capping concurrency eliminated the 500-storm seen with unbounded rate=30.)
- Both honor `BENCH_RATE`/`BENCH_INPUT_LEN`/`BENCH_OUTPUT_LEN`/`BENCH_NUM_PROMPTS`/`BENCH_MODEL`; docs (README + CLAUDE) explain when to use which and the open- vs closed-loop model.