### PR TITLE
Add Google ADK integration example for Crusoe Managed Inference

### DIFF
--- a/google-adk-crusoe/.env.example
+++ b/google-adk-crusoe/.env.example
@@ -1,0 +1,1 @@
+CRUSOE_API_KEY=your-api-key

--- a/google-adk-crusoe/README.md
+++ b/google-adk-crusoe/README.md
@@ -1,0 +1,79 @@
+# Google ADK × Crusoe AI
+
+Use [Crusoe Managed Inference](https://www.crusoe.ai/cloud/managed-inference) models in agents built with [Google's Agent Development Kit (ADK)](https://google.github.io/adk-docs/).
+
+Crusoe exposes an OpenAI-compatible API and is a first-class [LiteLLM](https://docs.litellm.ai/) provider, so ADK agents can use Crusoe models through ADK's built-in `LiteLlm` wrapper — no extra adapter code required.
+
+## Setup
+
+1. Create an account at [Crusoe Cloud](https://console.crusoecloud.com/) and generate an Inference API key in the **Security** tab.
+2. Install the dependencies:
+
+```bash
+pip install google-adk litellm
+```
+
+3. Set your API key:
+
+```bash
+export CRUSOE_API_KEY="your-api-key"
+```
+
+> **Note:** If your installed LiteLLM version predates the endpoint update ([BerriAI/litellm#33121](https://github.com/BerriAI/litellm/pull/33121)), also set
+> `export CRUSOE_API_BASE="https://api.inference.crusoecloud.com/v1"`.
+
+## Quick start
+
+Point ADK's `LiteLlm` model wrapper at a Crusoe model using the `crusoe/` prefix:
+
+```python
+from google.adk.agents import Agent
+from google.adk.models.lite_llm import LiteLlm
+
+root_agent = Agent(
+    name="crusoe_agent",
+    model=LiteLlm(model="crusoe/zai/GLM-5.2"),
+    instruction="You are a helpful assistant.",
+)
+```
+
+A complete tool-calling agent lives in [`agent.py`](agent.py). Run it from the parent directory with the ADK CLI:
+
+```bash
+adk run google-adk-crusoe   # interactive terminal session
+adk web                     # browser-based dev UI
+```
+
+## Available models
+
+| Model | Context window |
+|---|---|
+| `crusoe/zai/GLM-5.2` | 262,144 |
+| `crusoe/zai/GLM-5.1` | 202,000 |
+| `crusoe/nvidia/Nemotron-3-Nano-30B-A3B` | 262,144 |
+| `crusoe/nvidia/Nemotron-3-Nano-Omni-Reasoning-30B-A3B` | 262,144 |
+| `crusoe/nvidia/Nemotron-3-Super-120B-A12B` | 262,144 |
+| `crusoe/nvidia/Nemotron-3-Ultra-550B` | 262,144 |
+| `crusoe/google/gemma-4-31b-it` | 262,144 |
+| `crusoe/meta-llama/Llama-3.3-70B-Instruct` | 131,072 |
+| `crusoe/deepseek-ai/DeepSeek-V3-0324` | 163,840 |
+| `crusoe/deepseek-ai/DeepSeek-V4-Flash` | 1,000,000 |
+| `crusoe/deepseek-ai/DeepSeek-V4-Pro` | 1,000,000 |
+| `crusoe/openai/gpt-oss-120b` | 131,072 |
+| `crusoe/qwen/Qwen3-235B-A22B` | 131,072 |
+| `crusoe/moonshotai/Kimi-K2.6` | 262,144 |
+
+See the [Crusoe Managed Inference docs](https://docs.crusoecloud.com/managed-inference/overview) for the current catalog.
+
+## Model parameters
+
+`LiteLlm` forwards generation parameters to the Crusoe API:
+
+```python
+model = LiteLlm(
+    model="crusoe/nvidia/Nemotron-3-Super-120B-A12B",
+    temperature=0.2,
+    max_tokens=1024,
+    top_p=0.95,
+)
+```

--- a/google-adk-crusoe/__init__.py
+++ b/google-adk-crusoe/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/google-adk-crusoe/agent.py
+++ b/google-adk-crusoe/agent.py
@@ -1,0 +1,57 @@
+"""Google ADK agent powered by Crusoe Managed Inference via LiteLLM.
+
+Run interactively from the parent directory:
+    adk run google-adk-crusoe
+or launch the dev UI:
+    adk web
+"""
+
+import datetime
+from zoneinfo import ZoneInfo
+
+from google.adk.agents import Agent
+from google.adk.models.lite_llm import LiteLlm
+
+
+def get_current_time(city: str) -> dict:
+    """Return the current time in a specified city.
+
+    Args:
+        city: The name of the city (e.g. "New York").
+
+    Returns:
+        A dict with the status and the current time report.
+    """
+    timezones = {
+        "new york": "America/New_York",
+        "london": "Europe/London",
+        "tokyo": "Asia/Tokyo",
+        "san francisco": "America/Los_Angeles",
+    }
+    tz_name = timezones.get(city.lower())
+    if tz_name is None:
+        return {
+            "status": "error",
+            "error_message": f"No timezone info available for '{city}'.",
+        }
+    now = datetime.datetime.now(ZoneInfo(tz_name))
+    return {
+        "status": "success",
+        "report": f"The current time in {city} is {now.strftime('%Y-%m-%d %H:%M:%S %Z')}.",
+    }
+
+
+root_agent = Agent(
+    name="crusoe_time_agent",
+    model=LiteLlm(
+        model="crusoe/zai/GLM-5.2",
+        temperature=0.2,
+        max_tokens=1024,
+    ),
+    description="Agent that answers time questions using Crusoe Managed Inference.",
+    instruction=(
+        "You are a helpful assistant. Use the get_current_time tool whenever "
+        "the user asks about the current time in a city."
+    ),
+    tools=[get_current_time],
+)

--- a/google-adk-crusoe/requirements.txt
+++ b/google-adk-crusoe/requirements.txt
@@ -1,0 +1,2 @@
+google-adk>=1.0.0
+litellm>=1.75.0


### PR DESCRIPTION
## What

Adds `google-adk-crusoe/` — an integration example showing how to use Crusoe Managed Inference in agents built with Google's Agent Development Kit (ADK), mirroring the recipe pattern other providers publish (e.g. Nebius's Token Factory ADK guide).

Since Crusoe is a LiteLLM provider, ADK's built-in `LiteLlm` wrapper reaches Crusoe models with zero adapter code: `LiteLlm(model="crusoe/zai/GLM-5.2")`.

## Contents

- `README.md` — setup, quickstart, current model catalog with context windows, parameter examples
- `agent.py` — runnable tool-calling agent (`adk run` / `adk web`) using `crusoe/zai/GLM-5.2`
- `requirements.txt`, `.env.example`, `__init__.py`

## Notes

- Uses the current endpoint (`api.inference.crusoecloud.com`); README notes the `CRUSOE_API_BASE` override for LiteLLM versions predating BerriAI/litellm#33121.
- Featured models follow the standard set: GLM-5.2 (default), Nemotron-3-Super (parameters example).
