### PR TITLE
[managed-ai][finetuning] derive hyperparameters from live swagger

### DIFF
--- a/crusoe-managed-finetuning-example/.gitignore
+++ b/crusoe-managed-finetuning-example/.gitignore
@@ -9,6 +9,8 @@ run.ipynb
 .ipynb_checkpoints/
 .crusoe-finetune-state.json
 *.finetune-state.json
+.crusoe-swagger.json
+.crusoe-swagger.json.tmp
 
 # --- Python ---
 __pycache__/

--- a/crusoe-managed-finetuning-example/README.md
+++ b/crusoe-managed-finetuning-example/README.md
@@ -4,7 +4,7 @@ A runnable end-to-end example that picks a base model, chooses training and vali
 
 The script is **fully resumable**: it writes a small state file after every step, so you can close the terminal during a long-running job and resume later simply by re-running `python3 run.py`.
 
-The same `run.py` runs as a CLI (`python3 run.py` — arrow-key menus + Y/n) or as a Jupyter notebook (`python3 run-jupyter.py` generates `run.ipynb` and opens it in JupyterLab with `input()` boxes and numbered menus, cleaning up on exit). The runtime plumbing (prompts, environment detection, and environment-aware exits) lives in `src/runtime.py`; configuration and state live in `src/config.py`; selection/formatting/builder logic lives in `src/helper.py`; constants live in `src/constants.py`; `run.py` itself reads as a clean demo of the underlying API.
+The same `run.py` runs as a CLI (`python3 run.py` — arrow-key menus + Y/n) or as a Jupyter notebook (`python3 run-jupyter.py` generates `run.ipynb` and opens it in JupyterLab with `input()` boxes and numbered menus, cleaning up on exit). The runtime plumbing (prompts, environment detection, and environment-aware exits) lives in `src/runtime.py`; configuration and state live in `src/config.py`; selection/formatting/builder logic lives in `src/helper.py`; constants live in `src/constants.py`; the supervised hyperparameter catalog is derived from the live gateway swagger at runtime in `src/schema.py`, with generic disk caching (path + TTL + fetcher, atomic write, stale-fallback) in `src/path_cache.py`; `run.py` itself reads as a clean demo of the underlying API.
 
 ## Prerequisites
 
@@ -47,9 +47,11 @@ The script will:
 | File | Purpose |
 |---|---|
 | `run.py` | Main script — the full fine-tuning flow. Percent-format (`# %%` cells) so it converts to a notebook via jupytext. |
-| `src/constants.py` | Non-configurable constants: API base URL, terminal statuses, polling/download tuning, and hyperparameter metadata. |
+| `src/constants.py` | Non-configurable constants: API base URL, swagger URL and cache TTL, terminal statuses, and polling/download tuning. |
 | `src/config.py` | Configuration and state management: `Config` holds hard-coded defaults and the resumable state, receives the API key from `run.py`, and handles the resume prompt. |
 | `src/helper.py` | Formatting, selection, and builder helpers — no API calls; takes API outputs and `Config`, prompts the user, and returns API-ready values. Used by `run.py`. |
+| `src/schema.py` | Fetches `swagger.json` from the gateway and derives the supervised hyperparameter catalog at runtime, so new hyperparameters are picked up without a code change. Disk caching is delegated to `src/path_cache.py`. |
+| `src/path_cache.py` | Generic on-disk JSON cache with a TTL and stale-fallback on fetch failure. Reusable — takes a path, TTL, and fetcher, and abstracts freshness/atomic-write. |
 | `src/runtime.py` | Runtime helper (`pick`, `confirm`, `text`, `multi_pick`, `abort`) — uses questionary on a TTY and a zero-dependency `input()` fallback in notebooks / pipes; stops cleanly in both CLI (`sys.exit`) and Jupyter (`WorkflowError`). |
 | `run-jupyter.py` | Generates `run.ipynb` from `run.py` via jupytext, opens it in JupyterLab, and removes it on exit. Checks for missing deps and offers to install them. |
 | `requirements.txt` | `openai`, `httpx`, `questionary`, `python-dotenv`. |
@@ -76,6 +78,7 @@ Editable defaults in `src/config.py`:
 | `poll_interval` | `10` | Seconds between status polls |
 | `out_dir` | `outputs` | Where to save the downloaded adapter ZIP + extracted files |
 | `state_file_path` | `.crusoe-finetune-state.json` | Path to the resumable state file |
+| `swagger_cache_path` | `.crusoe-swagger.json` | Local cache for the gateway swagger; refreshed when older than 24h |
 
 ## Resuming a job
 

--- a/crusoe-managed-finetuning-example/src/config.py
+++ b/crusoe-managed-finetuning-example/src/config.py
@@ -51,6 +51,7 @@ class Config:
     poll_interval: int = 10
     out_dir: str = "outputs"
     state_file_path: str = ".crusoe-finetune-state.json"
+    swagger_cache_path: str = ".crusoe-swagger.json"
 
     # Runtime flag (not persisted).
     resuming: bool = False

--- a/crusoe-managed-finetuning-example/src/constants.py
+++ b/crusoe-managed-finetuning-example/src/constants.py
@@ -9,6 +9,9 @@ BASE_URL = "https://api.intelligence.crusoecloud.com/v1"
 # Console base URL for linking to job pages in the Crusoe Console.
 CONSOLE_BASE_URL = "https://console.crusoecloud.com"
 
+SWAGGER_URL = f"{BASE_URL}/swagger.json"
+SWAGGER_CACHE_TTL_SECONDS = 24 * 60 * 60
+
 TERMINAL_STATUSES = {"succeeded", "failed", "cancelled"}
 
 # Polling / download tuning values.
@@ -16,41 +19,3 @@ ADAPTER_REGISTRATION_TIMEOUT_SECONDS = 120
 ADAPTER_REGISTRATION_INTERVAL_SECONDS = 5
 ADAPTER_DOWNLOAD_TIMEOUT_SECONDS = 120
 DOWNLOAD_CHUNK_SIZE_BYTES = 8192
-
-# Hyperparameter metadata derived from the gateway schema
-# (FineTuneSupervisedHyperparameters). Each entry records the default the
-# server uses, the allowed type/choices, and a short description.
-HYPERPARAMS = [
-    {"name": "n_epochs", "default": "auto", "kind": "int_or_auto", "min": 1, "max": 50,
-     "help": "Number of training epochs"},
-    {"name": "batch_size", "default": "auto", "kind": "enum", "choices": ["auto", 16, 32, 64, 128, 256, 512, 1024],
-     "help": "Examples per batch"},
-    {"name": "learning_rate_multiplier", "default": "auto", "kind": "float_or_auto",
-     "help": "Learning-rate scaling factor (must be > 0)"},
-    {"name": "learning_rate", "default": "auto", "kind": "float_or_auto",
-     "help": "Absolute learning rate"},
-    {"name": "lr_scheduler", "default": "cosine", "kind": "enum", "choices": ["cosine", "constant", "constant_with_warmup", "linear"],
-     "help": "Learning-rate scheduler"},
-    {"name": "lora_variant", "default": "lora", "kind": "enum", "choices": ["lora", "rslora"],
-     "help": "LoRA variant"},
-    {"name": "lora_rank", "default": None, "kind": "enum_or_null", "choices": [2, 4, 8, 16, 32, 64, 128, 256],
-     "help": "LoRA attention dimension"},
-    {"name": "lora_alpha", "default": None, "kind": "enum_or_null", "choices": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
-     "help": "LoRA scaling parameter"},
-    {"name": "lora_dropout", "default": None, "kind": "float_or_null", "min": 0, "max": 1,
-     "help": "LoRA dropout probability"},
-    {"name": "early_stopping_patience", "default": None, "kind": "int_or_null", "min": 1,
-     "help": "Eval calls without improvement before early stopping"},
-    {"name": "warmup_ratio", "default": None, "kind": "float_or_null", "min": 0, "max": 1,
-     "help": "Fraction of steps used for linear warmup"},
-    {"name": "weight_decay", "default": None, "kind": "float_or_null", "min": 0,
-     "help": "Weight decay (L2 regularization) coefficient"},
-    {"name": "top_k_gating", "default": None, "kind": "enum_or_null", "choices": [1, 2, 4, 8, 16],
-     "help": "Number of experts activated per token"},
-    {"name": "checkpoint_steps", "default": None, "kind": "float_or_null", "min": 20,
-     "help": "Update steps between checkpoint saves"},
-    {"name": "eval_steps_per_epoch", "default": None, "kind": "float_or_null", "min": 1,
-     "help": "Evaluation steps per epoch"},
-    {"name": "overlong_row_behavior", "default": "error", "kind": "enum", "choices": ["error", "drop"],
-     "help": "How to handle rows exceeding max sequence length"},
-]

--- a/crusoe-managed-finetuning-example/src/helper.py
+++ b/crusoe-managed-finetuning-example/src/helper.py
@@ -17,8 +17,9 @@ from typing import Any, TYPE_CHECKING
 
 from openai.types import FileObject, Model
 
-from . import constants  # constants.HYPERPARAMS
+from . import constants
 from . import runtime    # pick, confirm, text, multi_pick, abort
+from . import schema
 
 if TYPE_CHECKING:
     from .config import Config
@@ -332,13 +333,14 @@ def gather_hyperparameter_overrides(config: "Config") -> dict:
         config.save()
         return {}
 
-    options = [f"{spec['name']}  (default: {display_default(spec['default'])})  — {spec['help']}" for spec in constants.HYPERPARAMS]
+    hyperparams = schema.load_supervised_hyperparams(config)
+    options = [f"{spec['name']}  (default: {display_default(spec['default'])})  — {spec['help']}" for spec in hyperparams]
     selected = runtime.multi_pick(options, "Select hyperparameters to override")
 
     overrides = {}
     for item in selected:
         name = item.split("  ", 1)[0]
-        spec = next(s for s in constants.HYPERPARAMS if s["name"] == name)
+        spec = next(s for s in hyperparams if s["name"] == name)
         value = _prompt_for_hyperparam(spec)
         if value is not None:
             overrides[name] = value
@@ -355,7 +357,7 @@ def print_job_params(config: "Config", hyperparameters: dict) -> None:
     print(f"    validation:   {config.val_id or '(none)'}")
     print(f"    suffix:       {config.suffix}")
     print("    hyperparameters:")
-    for spec in constants.HYPERPARAMS:
+    for spec in schema.load_supervised_hyperparams(config):
         name = spec["name"]
         sent = hyperparameters.get(name)
         display = display_default(sent) if sent is not None else display_default(spec["default"])

--- a/crusoe-managed-finetuning-example/src/path_cache.py
+++ b/crusoe-managed-finetuning-example/src/path_cache.py
@@ -1,0 +1,63 @@
+"""Generic on-disk JSON cache with TTL and stale-fallback on fetch failure."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+class CacheMissError(RuntimeError):
+    pass
+
+
+class PathCache:
+    def __init__(self, path: str | Path, ttl_seconds: int, fetch: Callable[[], dict]):
+        self.path = Path(path)
+        self.ttl_seconds = ttl_seconds
+        self._fetch = fetch
+
+    def load(self) -> dict:
+        fresh = self._read_fresh()
+        if fresh is not None:
+            return fresh
+
+        try:
+            data = self._fetch()
+        except Exception as e:
+            stale = self._read_any()
+            if stale is not None:
+                log.warning("fetch failed (%s); using stale cache at %s", e, self.path)
+                return stale
+            raise CacheMissError(
+                f"fetch failed and no cache exists at {self.path}: {e}"
+            ) from e
+
+        self._write(data)
+        return data
+
+    def _read_fresh(self) -> dict | None:
+        if not self.path.exists():
+            return None
+        if time.time() - self.path.stat().st_mtime > self.ttl_seconds:
+            return None
+        return self._read_any()
+
+    def _read_any(self) -> dict | None:
+        if not self.path.exists():
+            return None
+        try:
+            return json.loads(self.path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            log.warning("cache at %s is unreadable (%s)", self.path, e)
+            return None
+
+    def _write(self, data: dict) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data))
+        tmp.replace(self.path)

--- a/crusoe-managed-finetuning-example/src/schema.py
+++ b/crusoe-managed-finetuning-example/src/schema.py
@@ -1,0 +1,142 @@
+"""Derive the supervised fine-tuning hyperparameter catalog from the live
+gateway swagger, so schema changes are picked up without a code update."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, TYPE_CHECKING
+
+import httpx
+
+from . import constants, path_cache, runtime
+
+if TYPE_CHECKING:
+    from .config import Config
+
+
+log = logging.getLogger(__name__)
+
+_MEMO: dict[str, list[dict]] = {}
+
+
+def load_supervised_hyperparams(config: "Config") -> list[dict]:
+    """Return specs: {"name", "default", "kind", "help", optional "choices"/"min"/"max"}."""
+    key = config.swagger_cache_path
+    if key not in _MEMO:
+        swagger = _load_swagger(config)
+        _MEMO[key] = _parse_params(swagger, "FineTuneSupervisedHyperparameters")
+    return _MEMO[key]
+
+
+def _load_swagger(config: "Config") -> dict:
+    cache = path_cache.PathCache(
+        path=config.swagger_cache_path,
+        ttl_seconds=constants.SWAGGER_CACHE_TTL_SECONDS,
+        fetch=lambda: _fetch_swagger(constants.SWAGGER_URL),
+    )
+    try:
+        return cache.load()
+    except path_cache.CacheMissError as e:
+        runtime.abort(f"error: {e}")
+
+
+def _fetch_swagger(url: str) -> dict:
+    with httpx.Client(timeout=30) as client:
+        resp = client.get(url)
+        resp.raise_for_status()
+        return resp.json()
+
+
+def _get_schemas(swagger: dict) -> dict:
+    # OpenAPI 3.x uses components.schemas; Swagger 2.x uses definitions.
+    return swagger.get("components", {}).get("schemas") or swagger.get("definitions") or {}
+
+
+def _resolve_ref(swagger: dict, ref: str) -> dict:
+    node: Any = swagger
+    for part in ref.lstrip("#/").split("/"):
+        node = node[part]
+    return node
+
+
+def _parse_params(swagger: dict, schema_name: str) -> list[dict]:
+    schemas = _get_schemas(swagger)
+    if schema_name not in schemas:
+        runtime.abort(
+            f"error: could not find schema {schema_name!r} in swagger. "
+            f"Available: {sorted(schemas.keys())[:10]}{'...' if len(schemas) > 10 else ''}"
+        )
+    schema = schemas[schema_name]
+
+    specs = []
+    for name, prop in schema.get("properties", {}).items():
+        spec = _property_to_spec(name, prop, swagger)
+        if spec is not None:
+            specs.append(spec)
+    return specs
+
+
+def _property_to_spec(name: str, prop: dict, swagger: dict) -> dict | None:
+    if "$ref" in prop:
+        prop = _resolve_ref(swagger, prop["$ref"])
+
+    types: set[str] = set()
+    enum = None
+    minimum = prop.get("minimum")
+    maximum = prop.get("maximum")
+    has_auto = False
+    nullable = bool(prop.get("nullable", False))
+
+    for branch in [prop] + prop.get("anyOf", []) + prop.get("oneOf", []):
+        if "$ref" in branch:
+            branch = _resolve_ref(swagger, branch["$ref"])
+        for t in (branch.get("type") if isinstance(branch.get("type"), list) else [branch.get("type")]):
+            if t == "null":
+                nullable = True
+            elif t is not None:
+                types.add(t)
+        if "enum" in branch:
+            enum = list(branch["enum"])
+            if "auto" in enum:
+                has_auto = True
+        if branch.get("const") == "auto":
+            has_auto = True
+        if minimum is None:
+            minimum = branch.get("minimum")
+        if maximum is None:
+            maximum = branch.get("maximum")
+
+    kind = _kind_for(types, enum, has_auto, nullable)
+    if kind is None:
+        log.warning("skipping %r: types=%s enum=%s auto=%s null=%s",
+                    name, sorted(types), enum, has_auto, nullable)
+        return None
+
+    spec: dict = {
+        "name": name,
+        "default": prop.get("default"),
+        "kind": kind,
+        "help": (prop.get("description") or "").strip() or name,
+    }
+    if enum is not None and kind in ("enum", "enum_or_null"):
+        spec["choices"] = enum
+    if minimum is not None:
+        spec["min"] = minimum
+    if maximum is not None:
+        spec["max"] = maximum
+    return spec
+
+
+def _kind_for(types: set[str], enum: list | None, has_auto: bool, nullable: bool) -> str | None:
+    is_num = "integer" in types or "number" in types
+    if enum:
+        return "enum_or_null" if nullable else "enum"
+    if "integer" in types and has_auto:
+        return "int_or_auto"
+    if is_num and has_auto:
+        return "float_or_auto"
+    if "integer" in types and nullable:
+        return "int_or_null"
+    if is_num and nullable:
+        return "float_or_null"
+    return None

--- a/crusoe-managed-finetuning-example/tests/test_schema.py
+++ b/crusoe-managed-finetuning-example/tests/test_schema.py
@@ -1,0 +1,157 @@
+"""Fixture-driven smoke tests for src/schema.py.
+
+Runnable with plain Python — no pytest dependency required:
+
+    python3 tests/test_schema.py
+
+The fixture below intentionally covers every `kind` that
+`helper._prompt_for_hyperparam` understands, plus a couple of edge cases
+(schema $refs, allOf composition, anyOf-with-null for nullability, and
+const:"auto" for the "or auto" shapes).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.schema import _parse_params
+
+
+FIXTURE = {
+    "components": {
+        "schemas": {
+            "PositiveInteger": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 50,
+            },
+            "FineTuneSupervisedHyperparameters": {
+                "type": "object",
+                "properties": {
+                    # int_or_auto via anyOf(int, const:"auto") + $ref
+                    "n_epochs": {
+                        "anyOf": [
+                            {"$ref": "#/components/schemas/PositiveInteger"},
+                            {"const": "auto"},
+                        ],
+                        "default": "auto",
+                        "description": "Number of training epochs",
+                    },
+                    # enum containing "auto" and integer choices
+                    "batch_size": {
+                        "enum": ["auto", 16, 32, 64, 128],
+                        "default": "auto",
+                        "description": "Examples per batch",
+                    },
+                    # float_or_auto
+                    "learning_rate": {
+                        "anyOf": [
+                            {"type": "number"},
+                            {"const": "auto"},
+                        ],
+                        "default": "auto",
+                        "description": "Absolute learning rate",
+                    },
+                    # pure enum, no null
+                    "lr_scheduler": {
+                        "enum": ["cosine", "constant", "linear"],
+                        "default": "cosine",
+                        "description": "LR scheduler",
+                    },
+                    # enum_or_null (enum + nullable via type array)
+                    "lora_rank": {
+                        "type": ["integer", "null"],
+                        "enum": [2, 4, 8, 16, 32],
+                        "default": None,
+                        "description": "LoRA rank",
+                    },
+                    # float_or_null with min/max
+                    "lora_dropout": {
+                        "type": ["number", "null"],
+                        "minimum": 0,
+                        "maximum": 1,
+                        "default": None,
+                        "description": "LoRA dropout",
+                    },
+                    # int_or_null via anyOf-with-null
+                    "early_stopping_patience": {
+                        "anyOf": [
+                            {"type": "integer", "minimum": 1},
+                            {"type": "null"},
+                        ],
+                        "default": None,
+                        "description": "Early stopping patience",
+                    },
+                    # unknown shape — should be skipped with a warning, not crash
+                    "mystery_param": {
+                        "type": "boolean",
+                        "default": False,
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+def _by_name(specs, name):
+    return next(s for s in specs if s["name"] == name)
+
+
+def main() -> int:
+    specs = _parse_params(FIXTURE, "FineTuneSupervisedHyperparameters")
+    by_name = {s["name"]: s for s in specs}
+
+    # Unknown shape was skipped.
+    assert "mystery_param" not in by_name, "boolean param should have been skipped"
+
+    # n_epochs — int_or_auto with min/max inherited from $ref
+    s = by_name["n_epochs"]
+    assert s["kind"] == "int_or_auto", s
+    assert s["default"] == "auto", s
+    assert s["min"] == 1 and s["max"] == 50, s
+
+    # batch_size — enum with all choices preserved (auto is a valid choice)
+    s = by_name["batch_size"]
+    assert s["kind"] == "enum", s
+    assert s["choices"] == ["auto", 16, 32, 64, 128], s
+    assert s["default"] == "auto", s
+
+    # learning_rate — float_or_auto
+    s = by_name["learning_rate"]
+    assert s["kind"] == "float_or_auto", s
+
+    # lr_scheduler — plain enum
+    s = by_name["lr_scheduler"]
+    assert s["kind"] == "enum", s
+    assert s["choices"] == ["cosine", "constant", "linear"], s
+
+    # lora_rank — enum_or_null
+    s = by_name["lora_rank"]
+    assert s["kind"] == "enum_or_null", s
+    assert s["choices"] == [2, 4, 8, 16, 32], s
+    assert s["default"] is None, s
+
+    # lora_dropout — float_or_null with min/max
+    s = by_name["lora_dropout"]
+    assert s["kind"] == "float_or_null", s
+    assert s["min"] == 0 and s["max"] == 1, s
+    assert s["default"] is None, s
+
+    # early_stopping_patience — int_or_null with min from anyOf branch
+    s = by_name["early_stopping_patience"]
+    assert s["kind"] == "int_or_null", s
+    assert s["min"] == 1, s
+    assert s["default"] is None, s
+
+    print(f"OK — parsed {len(specs)} hyperparameter specs from fixture")
+    for s in specs:
+        print(f"  {s['name']:32s} kind={s['kind']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
 Follow-up to #71. Replaces the hardcoded HYPERPARAMS list with a runtime-derived catalog parsed from the gateway's swagger.json, so new hyperparameters and default changes are picked up without a code update.

  - src/schema.py: swagger → catalog translation (handles $ref, anyOf/oneOf, nullable types, "auto" consts)
  - src/path_cache.py: generic on-disk JSON cache with TTL and stale-fallback on fetch failure
  - tests/test_schema.py: dependency-free fixture test covering every hyperparameter `kind` the prompter understands
  - README + .gitignore updates
