### PR TITLE
crusoe-kserve-example: Open WebUI backend auto-detect, gateway EPP-bypass, managed AMD add-ons

### DIFF
--- a/crusoe-kserve-example/.gitignore
+++ b/crusoe-kserve-example/.gitignore
@@ -5,6 +5,12 @@ terraform/terraform.tfstate
 terraform/terraform.tfstate.backup
 terraform/terraform.tfvars
 terraform/imports.tf
+terraform-amd/.terraform/
+terraform-amd/.terraform.lock.hcl
+terraform-amd/terraform.tfstate
+terraform-amd/terraform.tfstate.backup
+terraform-amd/terraform.tfvars
+terraform-amd/imports.tf
 
 # Secrets
 .env

--- a/crusoe-kserve-example/CLAUDE.md
+++ b/crusoe-kserve-example/CLAUDE.md
@@ -90,7 +90,7 @@ Reports TTFT, TPOT (time per output token), ITL (inter-token latency), and throu
 
 ### AMD Setup
 
-AMD clusters use a separate Terraform directory (`terraform-amd/`) and require the AMD GPU operator (not the NVIDIA operator). Docker Hub credentials are needed to push the AMD GPU driver image.
+AMD clusters use a separate Terraform directory (`terraform-amd/`). By default the cluster enables the **CMK-managed AMD add-ons** (`amd_network_operator`, `amd_gpu_operator`, `crusoe_csi`) via `cluster_add_ons`, so CMK installs/maintains the GPU driver + operator — **no manual GPU-operator install and no Docker Hub credentials**. (Legacy path: set `cluster_add_ons = ["crusoe_csi"]` and run `make install-amd-gpu-operator`, which needs Docker Hub creds.) Managed AMD add-ons require an AMD "Bundle 1" cluster version (e.g. `1.33.4-cmk.93`); MI355X node pools run a gfx950-compatible `node_pool_version` (e.g. `1.33.4-cmk.18`) that differs from the cluster version, with `ephemeral_storage_for_containerd = true` for the ~30 GB ROCm image.
 
 #### 1. Configure `terraform-amd/terraform.tfvars`
 
@@ -99,23 +99,29 @@ cd terraform-amd && cp terraform.tfvars.example terraform.tfvars
 ```
 
 Required values:
-- `project_id` — Crusoe project ID
+- `project_id` — Crusoe project **UUID** (not the name; `crusoe projects list`)
 - `hf_token` — HuggingFace API token
-- `amd_node_type` — AMD GPU instance type (e.g., `mi300x-192gb-ib.8x`)
-- `amd_ib_partition_id` — InfiniBand partition ID for AMD nodes
+- `amd_node_type` — AMD GPU instance type (e.g., `mi355x-288gb-roce.8x`)
+- `amd_ib_partition_id` — IB/RoCE partition ID for AMD nodes (`crusoe networking ib-partitions list --project-id <id>`)
 - `ssh_public_key` — User's SSH public key string; provisioned onto nodes at creation time so the user can SSH in for debugging (e.g. checking driver issues, running `rocm-smi`)
-- `docker_username`, `docker_email`, `docker_password` — Docker Hub credentials (for pushing AMD GPU driver image)
+- `docker_username`, `docker_email`, `docker_password` — **only** for the legacy `crusoe_csi`-only path; unused with the default managed AMD add-ons
 
-#### 2. Provision Infrastructure + Install AMD GPU Operator + KServe
+Optional (defaults in `variables.tf`): `cluster_add_ons` (default = managed AMD bundle), `node_pool_version` (default `1.33.4-cmk.18`, applied to both pools), `amd_ephemeral_storage_for_containerd` (default `true`).
+
+Terraform authenticates via the Crusoe Go SDK (`~/.crusoe/config` / env). Select the target org with `export CRUSOE_PROFILE=<profile>` before `terraform apply`.
+
+#### 2. Provision Infrastructure + Install KServe
 
 ```bash
+export CRUSOE_PROFILE=<your-profile>
 make setup-amd
 ```
 
-This runs three steps:
-1. `terraform apply` in `terraform-amd/` — creates CMK cluster with **`crusoe_csi` add-on only** (no NVIDIA add-ons), AMD GPU node pool, CPU node pool, fetches kubeconfig
-2. `install-amd-gpu-operator` — installs cert-manager v1.15.1, AMD GPU operator v1.4.2, creates Docker registry secret in `kube-amd-gpu`, applies AMD DeviceConfig
-3. `install-kserve` — installs KServe v0.19.0, patches storage-initializer, creates `kserve-test` namespace with HuggingFace secret
+This runs:
+1. `terraform apply` in `terraform-amd/` — creates the CMK cluster with the **managed AMD add-ons** (`amd_network_operator`, `amd_gpu_operator`, `crusoe_csi`), the AMD GPU node pool, and the CPU node pool, then fetches kubeconfig. The GPU driver/operator is reconciled by CMK (no manual step).
+2. `install-kserve` — installs KServe v0.19.0, patches storage-initializer, creates `kserve-test` namespace with HuggingFace secret
+
+Verify the managed operator advertised GPUs before deploying: `kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:'.status.allocatable.amd\.com/gpu'` (expect `8` per MI355X node).
 
 **Key difference from NVIDIA**: AMD clusters use `amd.com/gpu` resource limits instead of `nvidia.com/gpu`, and use the `vllm/vllm-openai-rocm:latest` image (ROCm-based).
 

--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -1,12 +1,14 @@
-.PHONY: help setup setup-amd install-kserve patch-storage-initializer install-amd-gpu-operator deploy-basic deploy-large deploy-multi-node deploy-disaggregated deploy-amd-basic deploy-amd-large redeploy-amd-large deploy-amd-multi-node install-lb-controller install-crusoe-autoscaler destroy-crusoe-autoscaler install-vllm-hpa destroy-vllm-hpa install-gateway-scaling destroy-gateway-scaling deploy-openwebui openwebui-forward openwebui-url destroy-openwebui watch watch-metrics test chat bench bench-all bench-all-amd bench-amd monitor-up monitor-up-nvidia monitor-up-amd monitor-down monitor-clean destroy
+.PHONY: help setup setup-amd install-kserve patch-storage-initializer install-amd-gpu-operator deploy-basic deploy-large deploy-multi-node deploy-disaggregated deploy-amd-basic deploy-amd-large redeploy-amd-large deploy-amd-multi-node install-lb-controller install-crusoe-autoscaler destroy-crusoe-autoscaler install-vllm-hpa destroy-vllm-hpa install-gateway-scaling destroy-gateway-scaling install-gateway-bypass destroy-gateway-bypass deploy-openwebui openwebui-forward openwebui-url destroy-openwebui watch watch-metrics test chat bench bench-all bench-all-amd bench-amd monitor-up monitor-up-nvidia monitor-up-amd monitor-down monitor-clean destroy
 
 SHELL := /bin/bash
 NAMESPACE ?= kserve-test
 HF_TOKEN       ?= $(shell grep '^hf_token'       terraform/terraform.tfvars     2>/dev/null | sed 's/.*= *"//;s/"//')
 KSERVE_VERSION ?= v0.19.0
 
-# Open WebUI frontend — the vLLM OpenAI endpoint it talks to (default: the deploy-basic model).
-OPENWEBUI_BACKEND_URL ?= http://qwen-llm-kserve-workload-svc.$(NAMESPACE).svc.cluster.local:8000/v1
+# Open WebUI frontend — the vLLM OpenAI endpoint it talks to.
+# Leave empty to auto-detect the deployed "*-workload-svc" Service in $(NAMESPACE) (works for any deploy mode);
+# set it explicitly to pin a specific backend, e.g. http://qwen3-llm-kserve-workload-svc.$(NAMESPACE).svc.cluster.local:8000/v1
+OPENWEBUI_BACKEND_URL ?=
 
 # AMD config — all values read from terraform-amd/terraform.tfvars
 _AMD_TFVARS    := terraform-amd/terraform.tfvars
@@ -45,15 +47,17 @@ setup: ## Provision cluster, install KServe, create namespace (terraform apply)
 	  terraform init && \
 	  terraform apply
 
-setup-amd: ## Provision AMD cluster, install AMD GPU operator + KServe (configure terraform-amd/terraform.tfvars first)
+setup-amd: ## Provision AMD cluster (CMK-managed AMD GPU/network add-ons) + install KServe. Edit terraform-amd/terraform.tfvars first.
 	cd terraform-amd && \
 	  cp -n terraform.tfvars.example terraform.tfvars 2>/dev/null || true && \
 	  terraform init && \
 	  terraform apply
-	$(MAKE) install-amd-gpu-operator
+	@echo "AMD GPU + network operators are CMK-managed via cluster add-ons — no manual operator install."
+	@echo "The managed operator reconciles the GPU driver in the background; verify before deploying with:"
+	@echo "  kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:'.status.allocatable.amd\\.com/gpu'"
 	$(MAKE) install-kserve HF_TOKEN=$(AMD_HF_TOKEN)
 
-install-amd-gpu-operator: ## Install cert-manager and AMD GPU operator (requires DOCKER_USERNAME, DOCKER_EMAIL, DOCKER_PASSWORD)
+install-amd-gpu-operator: ## [LEGACY: crusoe_csi-only clusters] Manually install cert-manager + AMD GPU operator (needs DOCKER_USERNAME/EMAIL/PASSWORD). NOT needed with the default managed amd_gpu_operator add-on.
 	@if [ -z "$(DOCKER_USERNAME)" ] || [ -z "$(DOCKER_EMAIL)" ] || [ -z "$(DOCKER_PASSWORD)" ]; then \
 	  echo "ERROR: DOCKER_USERNAME, DOCKER_EMAIL, and DOCKER_PASSWORD are required."; \
 	  echo "  make install-amd-gpu-operator DOCKER_USERNAME=you DOCKER_EMAIL=you@example.com DOCKER_PASSWORD=... AMD_DRIVER_IMAGE=docker.io/you/amd-gpu-driver"; \
@@ -341,22 +345,52 @@ destroy-gateway-scaling: ## Revert gateway data-plane scaling (back to the defau
 	-kubectl patch gatewayclass envoy --type json -p '[{"op":"remove","path":"/spec/parametersRef"}]' 2>/dev/null
 	-kubectl delete -f manifests/gateway-scaling.yaml --ignore-not-found
 
+# Route standard client paths straight to the vLLM Service (Envoy least_request L7 LB),
+# bypassing the InferencePool+EPP whose single ext_proc caps the gateway at ~1.2k tok/s.
+# Measured ~13x throughput and near-linear GPU scaling vs the EPP path. Override the vars
+# below for a different ISVC/namespace.
+ISVC_NAME          ?= qwen3-llm
+ISVC_PATH          ?= /$(NAMESPACE)/$(ISVC_NAME)
+WORKLOAD_SVC       ?= $(ISVC_NAME)-kserve-workload-svc
+GATEWAY_NAME       ?= kserve-ingress-gateway
+GATEWAY_NAMESPACE  ?= kserve
+
+install-gateway-bypass: ## Make the standard gateway path use least_request LB across GPUs (bypass the EPP throughput cap ~1.2k->~15k tok/s). ISVC_NAME/ISVC_PATH/WORKLOAD_SVC to tune.
+	@echo "Routing $(ISVC_PATH)/v1/* -> Service $(WORKLOAD_SVC) (Envoy least_request, bypassing EPP)..."
+	@NAMESPACE="$(NAMESPACE)" ISVC_NAME="$(ISVC_NAME)" ISVC_PATH="$(ISVC_PATH)" WORKLOAD_SVC="$(WORKLOAD_SVC)" \
+	  GATEWAY_NAME="$(GATEWAY_NAME)" GATEWAY_NAMESPACE="$(GATEWAY_NAMESPACE)" \
+	  envsubst < manifests/gateway-bypass-route.yaml | kubectl apply -f -
+	@echo "Done. Standard OpenAI paths now bypass the EPP. Verify: make bench-amd-mi355x-lb"
+
+destroy-gateway-bypass: ## Remove the bypass route (standard paths fall back to EPP/InferencePool routing)
+	-kubectl delete httproute $(ISVC_NAME)-bypass-epp -n $(NAMESPACE) --ignore-not-found
+
 deploy-openwebui: install-lb-controller ## Deploy Open WebUI chat frontend with self-signed TLS on :443 via a Crusoe LoadBalancer
 	kubectl apply -f frontend/manifests/00-namespace.yaml
 	kubectl apply -f frontend/manifests/20-tls.yaml
 	@echo "Waiting for the self-signed certificate to be issued..."
 	kubectl wait --for=condition=Ready certificate/openwebui-tls -n openwebui --timeout=120s
 	kubectl apply -f frontend/manifests/
-	kubectl set env deploy/open-webui -n openwebui OPENAI_API_BASE_URL="$(OPENWEBUI_BACKEND_URL)"
-	kubectl rollout status deploy/open-webui -n openwebui --timeout=600s
-	@echo "Waiting for the LoadBalancer VIP (crusoe-lb-controller)..."
-	@IP=""; for i in $$(seq 1 30); do \
+	@set -e; \
+	BACKEND="$(OPENWEBUI_BACKEND_URL)"; \
+	if [ -z "$$BACKEND" ]; then \
+	  SVC=$$(kubectl get svc -n $(NAMESPACE) -o name | grep workload | head -1 | sed 's|service/||'); \
+	  if [ -z "$$SVC" ]; then echo "ERROR: no '*workload*' Service in $(NAMESPACE) — deploy a model first (e.g. make deploy-amd-mi355x), then re-run."; exit 1; fi; \
+	  BACKEND="http://$$SVC.$(NAMESPACE).svc.cluster.local:8000/v1"; \
+	  echo "Auto-detected backend Service: $$SVC"; \
+	fi; \
+	echo "Open WebUI backend -> $$BACKEND"; \
+	kubectl set env deploy/open-webui -n openwebui OPENAI_API_BASE_URL="$$BACKEND"; \
+	kubectl rollout status deploy/open-webui -n openwebui --timeout=600s; \
+	echo "Waiting for the LoadBalancer VIP (crusoe-lb-controller)..."; \
+	IP=""; for i in $$(seq 1 30); do \
 	  IP=$$(kubectl get svc openwebui-lb -n openwebui -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null); \
 	  [ -n "$$IP" ] && break; sleep 6; done; \
 	echo ""; \
 	echo "=== Open WebUI is up ==="; \
 	echo "  Public HTTPS : https://$$IP  (self-signed cert — accept the browser warning)"; \
-	echo "  Backend      : $(OPENWEBUI_BACKEND_URL)"; \
+	echo "  Backend      : $$BACKEND"; \
+	echo "  The model appears automatically from the backend's /v1/models (served-model-name, e.g. qwen3)."; \
 	echo "  Port-forward : make openwebui-forward   (then http://localhost:8080)"; \
 	echo "  First visitor signs up and becomes admin (WEBUI_AUTH=True)."
 

--- a/crusoe-kserve-example/README.md
+++ b/crusoe-kserve-example/README.md
@@ -21,7 +21,7 @@ Deploy open-source LLMs from HuggingFace on Crusoe Managed Kubernetes (CMK) usin
 - [Helm](https://helm.sh/docs/intro/install/) >= 3.0
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - A [HuggingFace](https://huggingface.co/) account and API token
-- **AMD only**: Docker Hub account (for building AMD GPU driver image)
+- **AMD legacy path only**: Docker Hub account (not needed with the default managed AMD add-ons)
 
 ## Quick Start — NVIDIA
 
@@ -110,7 +110,7 @@ make bench BENCH_RATE=inf BENCH_NUM_PROMPTS=300 # Max throughput
 
 ## Quick Start — AMD
 
-AMD clusters use a separate Terraform directory and require the AMD GPU operator instead of the NVIDIA operator.
+AMD clusters use a separate Terraform directory (`terraform-amd/`). By default the cluster enables the **CMK-managed AMD add-ons** (`amd_gpu_operator`, `amd_network_operator`, `crusoe_csi`), so CMK installs and maintains the GPU driver/operator — no manual operator install and **no Docker Hub credentials**.
 
 ### 1. Configure
 
@@ -118,18 +118,20 @@ AMD clusters use a separate Terraform directory and require the AMD GPU operator
 cd terraform-amd
 cp terraform.tfvars.example terraform.tfvars
 ```
-Edit terraform.tfvars with your project ID, HuggingFace token, AMD node type/count, IB partition ID, and Docker Hub credentials.
+Edit terraform.tfvars with your project **UUID** (`crusoe projects list`), HuggingFace token, AMD node type/count, IB/RoCE partition ID, and SSH key. For MI355X use an AMD "Bundle 1" `cluster_version` (e.g. `1.33.4-cmk.93`). Docker Hub credentials are only needed for the legacy path (`cluster_add_ons = ["crusoe_csi"]` + `make install-amd-gpu-operator`).
 
-### 2. Provision cluster + install AMD GPU operator + KServe
+### 2. Provision cluster + KServe
 
 ```bash
+export CRUSOE_PROFILE=<your-profile>   # selects the target org for Terraform
 make setup-amd
 ```
 
 This single command:
-- Creates the CMK cluster and node pools (MI300X, CPU)
-- Installs cert-manager + AMD GPU operator v1.4.2
+- Creates the CMK cluster (managed AMD GPU + network operators) and node pools (MI355X, CPU)
 - Installs KServe v0.19.0
+
+Verify GPUs are advertised before deploying: `kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:'.status.allocatable.amd\.com/gpu'`
 
 ### 3. Deploy a model
 

--- a/crusoe-kserve-example/frontend/manifests/40-openwebui.yaml
+++ b/crusoe-kserve-example/frontend/manifests/40-openwebui.yaml
@@ -24,8 +24,15 @@ spec:
           ports:
             - containerPort: 8080
           env:
-            # Points at the KServe workload Service for the deployed model. Change
-            # if you serve a different model (see `make deploy-openwebui` notes).
+            # Open WebUI treats OPENAI_API_BASE_URL/KEY as "PersistentConfig": by default they
+            # seed the DB (on the PVC) only on first boot, then the DB value wins and later env
+            # changes are IGNORED. Setting this False makes Open WebUI read config from env on
+            # every start, so `make deploy-openwebui` reliably re-points the backend (no stale
+            # connection surviving on the PVC, no manual UI fix).
+            - name: ENABLE_PERSISTENT_CONFIG
+              value: "False"
+            # Backend vLLM endpoint. This is a placeholder — `make deploy-openwebui` overwrites it
+            # via `kubectl set env` with the auto-detected "*-workload-svc" for the deployed model.
             - name: OPENAI_API_BASE_URL
               value: "http://qwen-llm-kserve-workload-svc.kserve-test.svc.cluster.local:8000/v1"
             - name: OPENAI_API_KEY

--- a/crusoe-kserve-example/manifests/gateway-bypass-route.yaml
+++ b/crusoe-kserve-example/manifests/gateway-bypass-route.yaml
@@ -1,0 +1,48 @@
+# High-throughput serving route: sends the standard OpenAI paths straight to the vLLM
+# workload Service, where Envoy load-balances across pods with `least_request` (L7).
+# This BYPASSES KServe's InferencePool + EPP (endpoint-picker), whose single, leader-elected
+# ext_proc serializes routing and caps the gateway at ~1.2k tok/s regardless of GPU count.
+#
+# Measured on 2x MI355X (Qwen3-235B, 512/150): EPP path ~1.2k tok/s vs this route ~9k @256
+# and ~15.8k @512 concurrent (94% of raw 2-node capacity), 0 failures, TTFT 5s -> 0.12s.
+# And unlike the EPP path, throughput scales ~linearly as GPU replicas/nodes are added.
+#
+# Why it works as the DEFAULT path: these Exact path matches outrank KServe's PathPrefix
+# InferencePool rules in Gateway API precedence, so normal client URLs hit this route
+# without any /bypass/ prefix. Delete this HTTPRoute to fall back to EPP routing.
+#
+# Trade-off: you lose the EPP's prefix-cache-/queue-aware routing (great for shared-prefix
+# chat) in exchange for full throughput. Applied by `make install-gateway-bypass`.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${ISVC_NAME}-bypass-epp
+  namespace: ${NAMESPACE}
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: ${GATEWAY_NAME}
+    namespace: ${GATEWAY_NAMESPACE}
+  rules:
+  - matches:
+    - path: { type: Exact, value: ${ISVC_PATH}/v1/chat/completions }
+    filters:
+    - type: URLRewrite
+      urlRewrite: { path: { type: ReplaceFullPath, replaceFullPath: /v1/chat/completions } }
+    backendRefs: [{ group: "", kind: Service, name: ${WORKLOAD_SVC}, port: 8000 }]
+    timeouts: { backendRequest: "0s", request: "0s" }
+  - matches:
+    - path: { type: Exact, value: ${ISVC_PATH}/v1/completions }
+    filters:
+    - type: URLRewrite
+      urlRewrite: { path: { type: ReplaceFullPath, replaceFullPath: /v1/completions } }
+    backendRefs: [{ group: "", kind: Service, name: ${WORKLOAD_SVC}, port: 8000 }]
+    timeouts: { backendRequest: "0s", request: "0s" }
+  - matches:
+    - path: { type: Exact, value: ${ISVC_PATH}/v1/models }
+    filters:
+    - type: URLRewrite
+      urlRewrite: { path: { type: ReplaceFullPath, replaceFullPath: /v1/models } }
+    backendRefs: [{ group: "", kind: Service, name: ${WORKLOAD_SVC}, port: 8000 }]
+    timeouts: { backendRequest: "0s", request: "0s" }

--- a/crusoe-kserve-example/terraform-amd/main.tf
+++ b/crusoe-kserve-example/terraform-amd/main.tf
@@ -13,29 +13,37 @@ provider "crusoe" {
 
 # -----------------------------------------------------------------------------
 # CMK Cluster
-# AMD clusters use crusoe_csi only — no nvidia add-ons needed.
-# The AMD GPU operator is installed separately by make setup-amd.
+# Default add-ons enable the CMK-managed AMD GPU + network operators, so CMK
+# installs/maintains the GPU driver & operator — no manual `make install-amd-gpu-operator`
+# and no Docker Hub credentials. Requires an AMD "Bundle 1" cluster version
+# (var.cluster_version, e.g. 1.33.4-cmk.93). See var.cluster_add_ons for the legacy path.
 # -----------------------------------------------------------------------------
 resource "crusoe_kubernetes_cluster" "kserve_amd" {
   name       = var.cluster_name
   version    = var.cluster_version
   location   = var.location
   project_id = var.project_id
-  add_ons    = ["crusoe_csi"]
+  add_ons    = var.cluster_add_ons
+  # Optional: pin the control-plane subnet (leave var empty to let CMK auto-select).
+  subnet_id = var.cluster_subnet_id != "" ? var.cluster_subnet_id : null
 }
 
 # -----------------------------------------------------------------------------
 # Node Pools
 # -----------------------------------------------------------------------------
 resource "crusoe_kubernetes_node_pool" "amd" {
-  count           = var.amd_node_count > 0 ? 1 : 0
-  name            = var.amd_pool_name
-  cluster_id      = crusoe_kubernetes_cluster.kserve_amd.id
-  instance_count  = var.amd_node_count
-  type            = var.amd_node_type
-  ssh_key         = var.ssh_public_key != "" ? var.ssh_public_key : null
-  ib_partition_id = var.amd_ib_partition_id
-  project_id      = var.project_id
+  count          = var.amd_node_count > 0 ? 1 : 0
+  name           = var.amd_pool_name
+  cluster_id     = crusoe_kubernetes_cluster.kserve_amd.id
+  instance_count = var.amd_node_count
+  type           = var.amd_node_type
+  # MI355X node pools run a gfx950-compatible node image that differs from the cluster version.
+  version = var.node_pool_version != "" ? var.node_pool_version : null
+  # The ~30 GB gfx950 ROCm image needs containerd on node ephemeral storage.
+  ephemeral_storage_for_containerd = var.amd_ephemeral_storage_for_containerd
+  ssh_key                          = var.ssh_public_key != "" ? var.ssh_public_key : null
+  ib_partition_id                  = var.amd_ib_partition_id
+  project_id                       = var.project_id
 }
 
 resource "crusoe_kubernetes_node_pool" "cpu" {
@@ -44,8 +52,10 @@ resource "crusoe_kubernetes_node_pool" "cpu" {
   cluster_id     = crusoe_kubernetes_cluster.kserve_amd.id
   instance_count = var.cpu_node_count
   type           = var.cpu_node_type
-  ssh_key        = var.ssh_public_key != "" ? var.ssh_public_key : null
-  project_id     = var.project_id
+  # Keep the CPU pool on the same node-pool version as the AMD pool.
+  version    = var.node_pool_version != "" ? var.node_pool_version : null
+  ssh_key    = var.ssh_public_key != "" ? var.ssh_public_key : null
+  project_id = var.project_id
 }
 
 # -----------------------------------------------------------------------------
@@ -71,5 +81,5 @@ output "cluster_name" {
 }
 
 output "next_steps" {
-  value = "Cluster and node pools are ready. make setup-amd will now install the AMD GPU operator and KServe."
+  value = "Cluster + node pools ready with CMK-managed AMD add-ons. Next: verify 'amd.com/gpu' on nodes, then run 'make install-kserve' and 'make deploy-amd-mi355x'."
 }

--- a/crusoe-kserve-example/terraform-amd/terraform.tfvars.example
+++ b/crusoe-kserve-example/terraform-amd/terraform.tfvars.example
@@ -1,20 +1,33 @@
 # -----------------------------------------------------------------------
 # Crusoe infrastructure
 # -----------------------------------------------------------------------
+# project_id is the project UUID, not its name. Find it: crusoe projects list
 project_id      = "your-project-id"
 cluster_name    = "kserve-amd-cluster"
-cluster_version = "1.33.4-cmk.43"
-location        = "us-east1-a"
+# For MI355X (gfx950), use an AMD "Bundle 1" version so the managed AMD add-ons
+# are available (e.g. 1.33.4-cmk.93). Confirm: crusoe kubernetes versions list
+cluster_version = "1.33.4-cmk.93"
+location        = "us-east2-a"
 
 # AMD GPU node pool
-# Set amd_node_type to your Crusoe AMD GPU SKU
-# Find available SKUs: crusoe compute vms list-types
+# Set amd_node_type to your Crusoe AMD GPU SKU. Find SKUs: crusoe compute vms types
+# Find the matching RoCE/IB partition: crusoe networking ib-partitions list --project-id <id>
 amd_node_type       = ""
 amd_node_count      = 1
 amd_ib_partition_id = "your-ib-partition-id"
 
 # CPU nodes for KServe control plane
 cpu_node_count = 2
+cpu_node_type  = "c1a.4x"
+
+# Node-pool version (applied to BOTH pools). For MI355X this is a gfx950-compatible
+# node image and differs from cluster_version. Leave unset to use the default.
+# node_pool_version = "1.33.4-cmk.18"
+
+# CMK add-ons. Default (in variables.tf) enables the managed AMD GPU + network
+# operators — no manual GPU-operator install and no Docker Hub creds needed.
+# For the legacy manual path, uncomment and run `make install-amd-gpu-operator`:
+# cluster_add_ons = ["crusoe_csi"]
 
 # SSH public key — provisioned onto nodes at creation time (cannot be added later).
 # Set this to SSH into GPU nodes for debugging (e.g. rocm-smi, driver issues).
@@ -25,6 +38,9 @@ ssh_public_key = "ssh-ed25519 AAAA... user@host"
 # -----------------------------------------------------------------------
 hf_token = "hf_your_token_here"
 
+# Docker Hub credentials are ONLY needed for the legacy `make install-amd-gpu-operator`
+# path (cluster_add_ons = ["crusoe_csi"]). With the default managed AMD add-ons they
+# are unused and can be left as-is.
 docker_username = "your-dockerhub-username"
 docker_email    = "you@example.com"
 # Use Docker PAT, not account password

--- a/crusoe-kserve-example/terraform-amd/variables.tf
+++ b/crusoe-kserve-example/terraform-amd/variables.tf
@@ -12,7 +12,28 @@ variable "cluster_name" {
 variable "cluster_version" {
   description = "Kubernetes version for the cluster"
   type        = string
-  default     = "1.33.4-cmk.43"
+  default     = "1.35.5-cmk.13"
+}
+
+variable "cluster_subnet_id" {
+  description = <<-EOT
+    Optional VPC subnet ID to pin the cluster/control-plane into. Leave "" to let
+    CMK auto-select the default subnet for the location. Must be a subnet in the
+    cluster's location (e.g. default-subnet-us-east2-a).
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "cluster_add_ons" {
+  description = <<-EOT
+    CMK add-ons to enable on the cluster. Default enables the CMK-managed AMD
+    GPU + network operators (no manual GPU-operator install / Docker Hub creds
+    needed). Requires an AMD "Bundle 1" cluster version (e.g. 1.33.4-cmk.93).
+    For the legacy path, set to ["crusoe_csi"] and run `make install-amd-gpu-operator`.
+  EOT
+  type        = list(string)
+  default     = ["amd_network_operator", "amd_gpu_operator", "crusoe_csi"]
 }
 
 variable "location" {
@@ -78,6 +99,26 @@ variable "amd_node_count" {
 variable "amd_node_type" {
   description = "AMD GPU node instance type (e.g. mi300x-192gb-ib.8x)"
   type        = string
+}
+
+variable "node_pool_version" {
+  description = <<-EOT
+    Kubernetes version applied to BOTH node pools (AMD GPU + CPU), kept in sync.
+    For MI355X (gfx950) this differs from the cluster version and must be a
+    gfx950-compatible node image (Bundle 1). Leave "" to inherit the cluster version.
+  EOT
+  type        = string
+  default     = "1.33.4-cmk.18"
+}
+
+variable "amd_ephemeral_storage_for_containerd" {
+  description = <<-EOT
+    Use node ephemeral storage for containerd's image/layer store. Recommended for
+    MI355X — the gfx950 ROCm serving image is ~30 GB and overflows the small default
+    containerd partition otherwise.
+  EOT
+  type        = bool
+  default     = true
 }
 
 variable "amd_ib_partition_id" {


### PR DESCRIPTION
## Summary
Three related improvements to the KServe/vLLM solution, plus a gitignore hardening.

### Open WebUI — model now appears reliably
- `deploy-openwebui` **auto-detects the deployed `*-workload-svc`** in the namespace (same pattern as `make chat`/`test`/`bench`) instead of hardcoding the basic model's service. `OPENWEBUI_BACKEND_URL` can still be set to pin a specific backend.
- Set **`ENABLE_PERSISTENT_CONFIG=False`** on the deployment. Open WebUI treats `OPENAI_API_BASE_URL`/`KEY` as *PersistentConfig* — the value is seeded to its DB on first boot and pinned on the PVC, so later env changes are ignored. That produced an empty model list after re-pointing the backend to a different model. Disabling PersistentConfig makes the env authoritative on every start, so the target is idempotent and declarative.

### Gateway — EPP throughput-bypass route
- New `manifests/gateway-bypass-route.yaml` + `install-gateway-bypass` / `destroy-gateway-bypass` targets. Routes the standard OpenAI paths past the InferencePool/EPP straight to the workload `Service` (Envoy `least_request` L7 LB), lifting the single-active-EPP throughput ceiling. Becomes the default path via `Exact` route matches that outrank the EPP's `PathPrefix` rules; delete the route to fall back to EPP routing.

### terraform-amd — one-click managed AMD add-ons
- Default `cluster_add_ons` to the CMK-managed AMD bundle (`amd_network_operator`, `amd_gpu_operator`, `crusoe_csi`) so the GPU driver/operator is reconciled by CMK — no manual operator install, no Docker Hub creds.
- Add `node_pool_version` and an `ephemeral_storage_for_containerd` toggle (large ROCm image); auto-select the cluster subnet when unset.

### .gitignore
- Ignore `terraform-amd/` state + `terraform.tfvars` (mirror the existing `terraform/` rules) so credentials/state can't be committed.

## Testing
- Fresh end-to-end bring-up via `make setup-amd` → `deploy-amd-mi355x` → `install-gateway-scaling` → `install-gateway-bypass` → `deploy-openwebui` on an MI355X cluster.
- Verified Open WebUI lists and chats the served model after the PersistentConfig fix; gateway bypass route serves the standard paths; managed add-ons advertised GPUs without a manual operator step.