### PR TITLE
crusoe-kserve-example: fix autoscaler pool default + helm replicas conflict on MI355X scale-out

### DIFF
--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -23,7 +23,10 @@ AMD_DRIVER_IMAGE ?= docker.io/$(DOCKER_USERNAME)/amd-gpu-driver
 AUTOSCALER_IMAGE ?= ghcr.io/crusoecloud/cluster-autoscaler-crusoecloud:1.33.2-crusoe.8
 AUTOSCALER_MIN   ?= 2
 AUTOSCALER_MAX   ?= 4
-AUTOSCALER_POOL  ?= mi355-workers
+# Must match the GPU node pool's NAME (not its k8s node prefix). The terraform-amd
+# default is "amd-pool" (var.amd_pool_name); override if you renamed the pool. A
+# mismatch here fails silently — the autoscaler logs "skipping nodepool" and never scales.
+AUTOSCALER_POOL  ?= amd-pool
 
 # vLLM pod HPA (KEDA + Prometheus on vllm:num_requests_running) between SCALE_MIN/MAX.
 # NOTE: on KServe LLMInferenceService the standalone ScaledObject does not actuate — KServe owns
@@ -243,8 +246,14 @@ REPLICAS ?= 1
 # AUTOSCALE=1 hands replica count to the autoscaler (emits spec.scaling instead of a fixed replicas).
 AUTOSCALE ?=
 
+# --force-conflicts (below): re-running deploy-amd-mi355x to change REPLICAS re-applies the
+# LLMInferenceService via server-side apply (helm 3.18+/4). KServe's controller (and any prior
+# `kubectl patch/scale`) co-own spec.replicas, so a plain apply fails with "conflicts with
+# before-first-apply". Forcing conflicts lets the chart reclaim the helm-templated fields it
+# owns (spec.replicas, resources.limits) -- the intended source of truth.
 deploy-amd-mi355x: ## Deploy large single-node LLM on AMD MI355X gfx950 (Qwen3-235B on 8x MI355X, TP=8+EP) w/ RWX shared disk + tool calling. REPLICAS=N to use N nodes.
 	helm upgrade --install crusoe-kserve-example ./helm/crusoe-kserve-example \
+	  --force-conflicts \
 	  --set hfToken=$(HF_TOKEN) \
 	  --set basic.enabled=false \
 	  --set large.enabled=false \


### PR DESCRIPTION
## Summary
Two bugs surfaced while scaling the MI355X deployment from 1 → 2 nodes. Both are one-line-ish Makefile fixes; no chart or infra changes.

### 1. Autoscaler used a non-existent pool name (silent no-scale)
`install-crusoe-autoscaler` defaulted `AUTOSCALER_POOL ?= mi355-workers`, but `terraform-amd` creates the GPU pool as **`amd-pool`** (`var.amd_pool_name`). With a wrong pool name the Crusoe cluster-autoscaler just logs `Skipping nodepool ... not listed` and **never provisions a node** for Pending pods — a silent failure that looks like "autoscaling doesn't work."
- Default to `amd-pool` (matches terraform-amd) and document that it must match the pool **name**.

### 2. `deploy-amd-mi355x REPLICAS=N` failed on a server-side-apply conflict
Re-running the target to scale out failed under helm 3.18+/4:
```
UPGRADE FAILED: conflict ... Apply failed with 2 conflicts: conflicts with "before-first-apply"
- .spec.replicas
- .spec.template.containers[name="main"].resources.limits.memory
```
KServe's controller (and any prior `kubectl patch/scale`) co-own those fields, so helm's SSA refuses to overwrite them.
- Add **`--force-conflicts`** to the helm upgrade so the chart reclaims the fields it templates (the intended source of truth), making the target safe to re-run for scaling.

## Testing
- `make -n install-crusoe-autoscaler` → `--nodes=2:4:amd-pool`.
- `make -n deploy-amd-mi355x` → renders `--force-conflicts`; Makefile parses clean, no stray echoed comments.
- End-to-end: re-pointed a live autoscaler to `amd-pool` (2:2) → it provisioned a 2nd MI355X node for the Pending replica; scaled the ISVC to 2 replicas and benchmarked 1→2-node throughput scaling (~1.8–1.95× on the gateway bypass path).

## Note (not in this PR)
The same SSA `--force-conflicts` need could affect other re-run-to-change helm targets (`deploy-amd-large`, `deploy-large`, `deploy-multi-node`) on helm 3.18+. Scoped this PR to the observed MI355X target; happy to extend if desired.