### PR TITLE
crusoe-kserve-example: add distributed gateway load-test harness

### DIFF
--- a/crusoe-kserve-example/Makefile
+++ b/crusoe-kserve-example/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-amd install-kserve patch-storage-initializer install-amd-gpu-operator deploy-basic deploy-large deploy-multi-node deploy-disaggregated deploy-amd-basic deploy-amd-large redeploy-amd-large deploy-amd-multi-node install-lb-controller install-crusoe-autoscaler destroy-crusoe-autoscaler install-vllm-hpa destroy-vllm-hpa install-gateway-scaling destroy-gateway-scaling install-gateway-bypass destroy-gateway-bypass deploy-openwebui openwebui-forward openwebui-url destroy-openwebui watch watch-metrics test chat bench bench-all bench-all-amd bench-amd monitor-up monitor-up-nvidia monitor-up-amd monitor-down monitor-clean destroy
+.PHONY: help setup setup-amd install-kserve patch-storage-initializer install-amd-gpu-operator deploy-basic deploy-large deploy-multi-node deploy-disaggregated deploy-amd-basic deploy-amd-large redeploy-amd-large deploy-amd-multi-node install-lb-controller install-crusoe-autoscaler destroy-crusoe-autoscaler install-vllm-hpa destroy-vllm-hpa install-gateway-scaling destroy-gateway-scaling install-gateway-bypass destroy-gateway-bypass deploy-openwebui openwebui-forward openwebui-url destroy-openwebui loadtest-distributed loadtest-report loadtest-clean watch watch-metrics test chat bench bench-all bench-all-amd bench-amd monitor-up monitor-up-nvidia monitor-up-amd monitor-down monitor-clean destroy
 
 SHELL := /bin/bash
 NAMESPACE ?= kserve-test
@@ -36,6 +36,25 @@ KEDA_VERSION    ?= 2.16.1
 SCALE_MIN       ?= 2
 SCALE_MAX       ?= 4
 SCALE_THRESHOLD ?= 100   # target running seqs per replica (num_requests_running); scale out above this
+
+# Distributed gateway load test — fan out LOADTEST_PODS pods, each driving
+# LOADTEST_CONCURRENCY persistent-connection workers. Total offered concurrency =
+# LOADTEST_PODS * LOADTEST_CONCURRENCY. Deploy on a SEPARATE cluster (set KUBECONFIG/context
+# to it) and point LOADTEST_TARGET_URL at the serving cluster's gateway VIP to simulate
+# cross-region traffic. Get the VIP: kubectl get gateway kserve-ingress-gateway -n kserve \
+#   -o jsonpath='{.status.addresses[0].value}' (run against the SERVING cluster).
+LOADTEST_TARGET_URL ?=
+LOADTEST_PODS        ?= 10
+LOADTEST_CONCURRENCY ?= 256
+LOADTEST_DURATION    ?= 60
+LOADTEST_MODEL       ?= qwen3
+LOADTEST_INPUT_LEN   ?= 512
+LOADTEST_OUTPUT_LEN  ?= 150
+LOADTEST_IMAGE       ?= python:3.12-slim
+LOADTEST_NS          ?= loadtest
+# Pin load-gen pods to a node pool (one "key: value"). Default is a no-op (always-true label);
+# override to keep load-gen off serving/gateway nodes, e.g. LOADTEST_NODE_SELECTOR='node.kubernetes.io/instance-type: c1a.8x'.
+LOADTEST_NODE_SELECTOR ?= kubernetes.io/os: linux
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
@@ -503,7 +522,7 @@ bench-amd-mi355x-all: ## Benchmark EVERY replica pod at once (loads all nodes; r
 	    --model /mnt/models --served-model-name $(or $(BENCH_MODEL),qwen3) \
 	    --base-url http://localhost:8000 --backend openai-chat --endpoint /v1/chat/completions \
 	    --dataset-name random --random-input-len $(BENCH_INPUT_LEN) --random-output-len $(BENCH_OUTPUT_LEN) \
-	    --num-prompts $(BENCH_NUM_PROMPTS) --request-rate $(BENCH_RATE) > "$$TMP/$$POD.log" 2>&1 & \
+	    --num-prompts $(BENCH_NUM_PROMPTS) --request-rate $(BENCH_RATE) --disable-tqdm $(if $(BENCH_CONCURRENCY),--max-concurrency $(BENCH_CONCURRENCY),) > "$$TMP/$$POD.log" 2>&1 & \
 	done; \
 	wait; \
 	echo ""; echo "===== per-pod results ====="; \
@@ -532,6 +551,58 @@ bench-amd-mi355x-lb: ## Benchmark THROUGH the Envoy gateway/EPP — production p
 	  --dataset-name random --random-input-len $(BENCH_INPUT_LEN) --random-output-len $(BENCH_OUTPUT_LEN) \
 	  --num-prompts $(BENCH_NUM_PROMPTS) --request-rate $(BENCH_RATE) \
 	  $(if $(BENCH_CONCURRENCY),--max-concurrency $(BENCH_CONCURRENCY),)
+
+# ---------------------------------------------------------------------------
+# Distributed gateway load test (deploy on a SEPARATE cluster to simulate cross-region load)
+# ---------------------------------------------------------------------------
+
+loadtest-distributed: ## Fan out LOADTEST_PODS load-gen pods at a gateway VIP (set LOADTEST_TARGET_URL). Total users = PODS*CONCURRENCY. Runs on the CURRENT kubecontext.
+	@if [ -z "$(LOADTEST_TARGET_URL)" ]; then \
+	  echo "ERROR: set LOADTEST_TARGET_URL to the serving cluster's gateway base URL, e.g."; \
+	  echo "  make loadtest-distributed LOADTEST_TARGET_URL=http://<VIP>/kserve-test/qwen3-llm LOADTEST_PODS=25"; \
+	  echo "Get <VIP> from the SERVING cluster: kubectl get gateway kserve-ingress-gateway -n kserve -o jsonpath='{.status.addresses[0].value}'"; \
+	  exit 1; fi
+	@echo "Load test -> $(LOADTEST_TARGET_URL)"
+	@echo "  pods=$(LOADTEST_PODS)  concurrency/pod=$(LOADTEST_CONCURRENCY)  => total offered concurrency=$$(( $(LOADTEST_PODS) * $(LOADTEST_CONCURRENCY) ))"
+	@echo "  duration=$(LOADTEST_DURATION)s  input=$(LOADTEST_INPUT_LEN)  output=$(LOADTEST_OUTPUT_LEN)  model=$(LOADTEST_MODEL)"
+	@echo "  running against kubecontext: $$(kubectl config current-context)"
+	kubectl create namespace $(LOADTEST_NS) --dry-run=client -o yaml | kubectl apply -f -
+	kubectl -n $(LOADTEST_NS) delete job gateway-loadtest --ignore-not-found
+	kubectl -n $(LOADTEST_NS) create configmap loadgen-script --from-file=loadgen.py=load-test/loadgen.py \
+	  --dry-run=client -o yaml | kubectl apply -f -
+	@LOADTEST_NS="$(LOADTEST_NS)" LOADTEST_PODS="$(LOADTEST_PODS)" LOADTEST_IMAGE="$(LOADTEST_IMAGE)" \
+	  LOADTEST_TARGET_URL="$(LOADTEST_TARGET_URL)" LOADTEST_MODEL="$(LOADTEST_MODEL)" \
+	  LOADTEST_CONCURRENCY="$(LOADTEST_CONCURRENCY)" LOADTEST_DURATION="$(LOADTEST_DURATION)" \
+	  LOADTEST_INPUT_LEN="$(LOADTEST_INPUT_LEN)" LOADTEST_OUTPUT_LEN="$(LOADTEST_OUTPUT_LEN)" \
+	  LOADTEST_NODE_SELECTOR="$(LOADTEST_NODE_SELECTOR)" \
+	  envsubst < load-test/distributed-loadtest.yaml | kubectl apply -f -
+	@echo ""
+	@echo "Launched. Watch:   kubectl -n $(LOADTEST_NS) get pods -w"
+	@echo "When complete:     make loadtest-report"
+
+loadtest-report: ## Aggregate results from all load-gen pods (sum throughput, total success/fail)
+	@echo "Collecting RESULT_JSON from pods in $(LOADTEST_NS)..."
+	@for p in $$(kubectl -n $(LOADTEST_NS) get pods -l app=gateway-loadtest -o name 2>/dev/null); do \
+	  kubectl -n $(LOADTEST_NS) logs $$p 2>/dev/null | grep '^RESULT_JSON '; \
+	done | sed 's/^RESULT_JSON //' | python3 -c 'import sys,json; \
+rows=[json.loads(l) for l in sys.stdin if l.strip()]; \
+n=len(rows); \
+succ=sum(r.get("success",0) for r in rows); \
+fail=sum(r.get("fail",0) for r in rows); \
+otps=sum(r.get("out_tok_s",0) for r in rows); \
+rps=sum(r.get("req_s",0) for r in rows); \
+tt=sorted(r.get("ttft_ms_median",0) for r in rows if r.get("ttft_ms_median")); \
+med=tt[len(tt)//2] if tt else 0; \
+print("\n===== AGGREGATE across %d pod(s) =====" % n); \
+print("  Successful requests:   %d" % succ); \
+print("  Failed requests:       %d  (%.1f%%)" % (fail, 100.0*fail/max(succ+fail,1))); \
+print("  Output token/s (sum):  %.1f" % otps); \
+print("  Request/s (sum):       %.2f" % rps); \
+print("  Per-pod TTFT median:   min/med/max = %.0f / %.0f / %.0f ms" % (tt[0] if tt else 0, med, tt[-1] if tt else 0)); \
+print("  (per-pod detail: kubectl -n %s logs -l app=gateway-loadtest | grep RESULT_JSON)" % "$(LOADTEST_NS)")'
+
+loadtest-clean: ## Remove the load-test Job, ConfigMap, and namespace
+	-kubectl delete namespace $(LOADTEST_NS) --ignore-not-found
 
 # ---------------------------------------------------------------------------
 # Local monitoring (Grafana + Prometheus via Docker)

--- a/crusoe-kserve-example/load-test/.gitignore
+++ b/crusoe-kserve-example/load-test/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/crusoe-kserve-example/load-test/README.md
+++ b/crusoe-kserve-example/load-test/README.md
@@ -1,0 +1,65 @@
+# Gateway load test
+
+Drives high concurrent load at a KServe/vLLM deployment's **Envoy gateway VIP** to
+find the throughput ceiling and size node count vs. concurrent users. Run from a
+**separate cluster** (ideally a different region) so you exercise the real
+client → LB → gateway → EPP → replica path, not just in-cluster localhost.
+
+Each load-gen pod holds **persistent keep-alive connections** and fires OpenAI
+chat-completions back-to-back (`min_tokens`+`ignore_eos` force a fixed output
+length so throughput is comparable run-to-run). The client leg stays keep-alive —
+a pod never churns ephemeral ports — while the L7 gateway still load-balances every
+*request* across all upstream replicas. Scale total offered load by **pod count**,
+not by hammering one pod until its sockets exhaust.
+
+## Two harnesses
+
+| File | Model | Per-pod density | Use for |
+|------|-------|-----------------|---------|
+| `loadgen.py` | threaded (one thread/conn) | ~hundreds | Standard runs; wired into the Makefile |
+| `loadgen_async.py` | asyncio (one task/conn) | ~thousands | Extreme concurrency to stress the gateway |
+
+Both are pure stdlib (run on any `python:3.x` image), emit a heartbeat plus a final
+`RESULT_JSON {...}` line, and always exit 0 so the Job completes and logs stay
+collectible. The async harness needs the container fd limit raised above the
+per-pod concurrency — its Job (`gateway-stress-job.yaml`) does `ulimit -n` and adds
+the `SYS_RESOURCE` capability.
+
+## Quick start (threaded, via Makefile)
+
+```bash
+# On the SERVING cluster — get the gateway VIP:
+kubectl get gateway kserve-ingress-gateway -n kserve -o jsonpath='{.status.addresses[0].value}'
+
+# On a SEPARATE cluster (set KUBECONFIG/context to it):
+make loadtest-distributed \
+  LOADTEST_TARGET_URL=http://<VIP>/<namespace>/<isvc> \
+  LOADTEST_PODS=25 LOADTEST_CONCURRENCY=256 LOADTEST_DURATION=120
+# total offered concurrency = PODS * CONCURRENCY
+
+make loadtest-report    # aggregate throughput / success / fail / TTFT across pods
+make loadtest-clean     # tear down the Job + namespace
+```
+
+Pin load-gen off serving/gateway nodes with `LOADTEST_NODE_SELECTOR='node.kubernetes.io/instance-type: <cpu-type>'`.
+The `TARGET_URL` path is the gateway route prefix for the ISVC (`/<namespace>/<isvc>`);
+`served-model-name` must match what `/v1/models` reports or requests 404.
+
+## Async harness (high density)
+
+`gateway-stress-job.yaml` is an Indexed Job templated with `envsubst` (vars:
+`REGION PODS CONCURRENCY DURATION RAMP_SECONDS OUTPUT_LEN TARGET_URL NODE_SELECTOR CPU_REQ MEM_REQ MEM_LIM`).
+It mounts `loadgen_async.py` from a `loadgen-async` ConfigMap. Keep per-node
+connection density modest (≤ ~2–3k conn/node) — beyond that, network-softirq /
+kubelet starvation flips load-gen nodes `NotReady` before the gateway is stressed;
+add pods/nodes to go higher.
+
+## Notes
+
+- **Open vs closed loop:** these harnesses are closed-loop — exactly `CONCURRENCY`
+  requests outstanding per pod (a fixed number of simulated users), so throughput
+  reflects sustainable capacity rather than an unbounded arrival rate.
+- The gateway itself is rarely the ceiling — with a scaled Envoy tier
+  (`make install-gateway-scaling`), the load generator's CPU/connection budget
+  usually tips first. Watch `downstream_cx_active` / 5xx on Envoy and
+  `num_requests_running` on the replicas to identify the binding layer.

--- a/crusoe-kserve-example/load-test/distributed-loadtest.yaml
+++ b/crusoe-kserve-example/load-test/distributed-loadtest.yaml
@@ -1,0 +1,57 @@
+# Distributed gateway load test — fans out ${LOADTEST_PODS} pods, each driving
+# ${LOADTEST_CONCURRENCY} persistent-connection workers at the target gateway.
+# Total offered concurrency = LOADTEST_PODS * LOADTEST_CONCURRENCY.
+#
+# Deploy on a SEPARATE cluster (e.g. a different region) and point TARGET_URL at
+# the serving cluster's gateway VIP to simulate cross-region client traffic.
+# Applied + parameterized by `make loadtest-distributed` (envsubst). The loadgen.py
+# script is mounted from the `loadgen-script` ConfigMap the make target creates.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gateway-loadtest
+  namespace: ${LOADTEST_NS}
+  labels:
+    app: gateway-loadtest
+spec:
+  parallelism: ${LOADTEST_PODS}
+  completions: ${LOADTEST_PODS}
+  completionMode: Indexed
+  backoffLimit: 0                 # a pod that errors is not retried — we want raw results
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app: gateway-loadtest
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        ${LOADTEST_NODE_SELECTOR}
+      containers:
+        - name: loadgen
+          image: ${LOADTEST_IMAGE}
+          command: ["python", "/scripts/loadgen.py"]
+          env:
+            - name: POD_NAME
+              valueFrom: { fieldRef: { fieldPath: metadata.name } }
+            - name: TARGET_URL
+              value: "${LOADTEST_TARGET_URL}"
+            - name: MODEL
+              value: "${LOADTEST_MODEL}"
+            - name: CONCURRENCY
+              value: "${LOADTEST_CONCURRENCY}"
+            - name: DURATION
+              value: "${LOADTEST_DURATION}"
+            - name: INPUT_LEN
+              value: "${LOADTEST_INPUT_LEN}"
+            - name: OUTPUT_LEN
+              value: "${LOADTEST_OUTPUT_LEN}"
+          resources:
+            requests: { cpu: "500m", memory: "256Mi" }
+            limits:   { cpu: "2",    memory: "1Gi" }
+          volumeMounts:
+            - { name: script, mountPath: /scripts }
+      volumes:
+        - name: script
+          configMap:
+            name: loadgen-script

--- a/crusoe-kserve-example/load-test/gateway-stress-job.yaml
+++ b/crusoe-kserve-example/load-test/gateway-stress-job.yaml
@@ -1,0 +1,59 @@
+# High-concurrency gateway stress Job — fans out ${PODS} pods, each holding
+# ${CONCURRENCY} persistent async connections at the target VIP. Deploy on
+# load-gen clusters (a different region) to stress the Envoy gateway's connection
+# handling. The command raises the fd limit above CONCURRENCY. loadgen_async.py is
+# mounted as /scripts/loadgen.py from the `loadgen-async` ConfigMap.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gw-stress-${REGION}
+  namespace: loadtest
+  labels: { app: gw-stress }
+spec:
+  parallelism: ${PODS}
+  completions: ${PODS}
+  completionMode: Indexed
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels: { app: gw-stress }
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        node.kubernetes.io/instance-type: ${NODE_SELECTOR}
+      containers:
+        - name: loadgen
+          image: python:3.12-slim
+          command: ["sh", "-c", "ulimit -n 1048576 2>/dev/null || true; echo fd_limit=$(ulimit -n); exec python3 /scripts/loadgen.py"]
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+          env:
+            - name: POD_NAME
+              valueFrom: { fieldRef: { fieldPath: metadata.name } }
+            - name: TARGET_URL
+              value: "${TARGET_URL}"
+            - name: MODEL
+              value: "qwen3"
+            - name: CONCURRENCY
+              value: "${CONCURRENCY}"
+            - name: DURATION
+              value: "${DURATION}"
+            - name: RAMP_SECONDS
+              value: "${RAMP_SECONDS}"
+            - name: REQ_TIMEOUT
+              value: "300"
+            - name: INPUT_LEN
+              value: "512"
+            - name: OUTPUT_LEN
+              value: "${OUTPUT_LEN}"
+          resources:
+            requests: { cpu: "${CPU_REQ}", memory: "${MEM_REQ}" }
+            limits:   { cpu: "3",           memory: "${MEM_LIM}" }
+          volumeMounts:
+            - { name: script, mountPath: /scripts }
+      volumes:
+        - name: script
+          configMap:
+            name: loadgen-async

--- a/crusoe-kserve-example/load-test/loadgen.py
+++ b/crusoe-kserve-example/load-test/loadgen.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Distributed gateway load generator (pure stdlib — runs on any python:3.x image).
+
+One pod runs CONCURRENCY worker threads, each holding a PERSISTENT keep-alive
+connection to the target gateway and firing OpenAI chat-completions back-to-back
+for DURATION seconds. Persistent connections are deliberate: the client->Envoy
+leg stays keep-alive (so a single pod never churns through ephemeral ports), yet
+Envoy still L7-load-balances every *request* across all upstream replicas. That
+lets each pod sustain a high, stable concurrency; scale total offered load by the
+number of pods (parallelism), not by hammering one pod until its sockets exhaust.
+
+Emits one line `RESULT_JSON {...}` at the end; the Makefile sums these across pods.
+Always exits 0 so the Job completes and logs are collectible.
+"""
+import os, sys, time, json, threading, http.client, urllib.parse
+from concurrent.futures import ThreadPoolExecutor
+
+TARGET   = os.environ["TARGET_URL"].rstrip("/")     # e.g. http://<VIP>/kserve-test/qwen3-llm
+MODEL    = os.environ.get("MODEL", "qwen3")
+CONC     = int(os.environ.get("CONCURRENCY", "256"))
+DURATION = int(os.environ.get("DURATION", "60"))
+IN_LEN   = int(os.environ.get("INPUT_LEN", "512"))
+OUT_LEN  = int(os.environ.get("OUTPUT_LEN", "150"))
+POD      = os.environ.get("POD_NAME", "loadgen")
+
+u        = urllib.parse.urlparse(TARGET)
+HOST     = u.hostname
+PORT     = u.port or (443 if u.scheme == "https" else 80)
+IS_TLS   = u.scheme == "https"
+ENDPOINT = (u.path or "") + "/v1/chat/completions"
+HEADERS  = {"Content-Type": "application/json", "Connection": "keep-alive"}
+
+# Fixed payload. min_tokens + ignore_eos force exactly OUT_LEN output tokens so
+# throughput is comparable run to run (mirrors `vllm bench serve --ignore-eos`).
+# The prompt is padded to ~IN_LEN tokens (1 short word ~ 1 token — close enough for load).
+PROMPT = " ".join(["word"] * IN_LEN)
+BODY = json.dumps({
+    "model": MODEL,
+    "messages": [{"role": "user", "content": PROMPT}],
+    "max_tokens": OUT_LEN, "min_tokens": OUT_LEN, "ignore_eos": True,
+    "temperature": 0.0, "stream": True, "stream_options": {"include_usage": True},
+}).encode()
+
+_lock = threading.Lock()
+_stats = {"success": 0, "fail": 0, "out_tokens": 0}
+_ttfts, _latencies = [], []
+_stop_at = 0.0
+
+
+def _new_conn():
+    cls = http.client.HTTPSConnection if IS_TLS else http.client.HTTPConnection
+    return cls(HOST, PORT, timeout=180)
+
+
+def _completion_tokens(buf):
+    """Prefer usage.completion_tokens from the final SSE chunk; else count content deltas."""
+    usage_ct, delta_ct = None, 0
+    for line in buf.split(b"\n"):
+        line = line.strip()
+        if not line.startswith(b"data: "):
+            continue
+        payload = line[6:]
+        if payload == b"[DONE]":
+            continue
+        try:
+            d = json.loads(payload)
+        except Exception:
+            continue
+        usg = d.get("usage")
+        if usg and usg.get("completion_tokens"):
+            usage_ct = usg["completion_tokens"]
+        ch = d.get("choices") or []
+        if ch and (ch[0].get("delta") or {}).get("content"):
+            delta_ct += 1
+    return usage_ct if usage_ct is not None else delta_ct
+
+
+def worker():
+    conn = None
+    while time.time() < _stop_at:
+        try:
+            if conn is None:
+                conn = _new_conn()
+            t0 = time.time()
+            conn.request("POST", ENDPOINT, body=BODY, headers=HEADERS)
+            resp = conn.getresponse()
+            if resp.status != 200:
+                resp.read()  # drain so the keep-alive connection stays reusable
+                with _lock:
+                    _stats["fail"] += 1
+                continue
+            ttft, buf = None, b""
+            while True:
+                chunk = resp.read(8192)
+                if not chunk:
+                    break
+                if ttft is None:
+                    ttft = (time.time() - t0) * 1000.0
+                buf += chunk
+            total = (time.time() - t0) * 1000.0
+            ct = _completion_tokens(buf)
+            with _lock:
+                _stats["success"] += 1
+                _stats["out_tokens"] += ct
+                if ttft is not None:
+                    _ttfts.append(ttft)
+                _latencies.append(total)
+        except Exception:
+            with _lock:
+                _stats["fail"] += 1
+            try:
+                if conn:
+                    conn.close()
+            except Exception:
+                pass
+            conn = None  # reconnect on next iteration
+
+
+def _pct(a, p):
+    if not a:
+        return 0.0
+    a = sorted(a)
+    return round(a[min(len(a) - 1, int(len(a) * p / 100.0))], 1)
+
+
+def main():
+    global _stop_at
+    print(f"[{POD}] target={TARGET} conc={CONC} duration={DURATION}s "
+          f"in={IN_LEN} out={OUT_LEN} model={MODEL}", flush=True)
+    start = time.time()
+    _stop_at = start + DURATION
+    with ThreadPoolExecutor(max_workers=CONC) as ex:
+        for f in [ex.submit(worker) for _ in range(CONC)]:
+            f.result()
+    elapsed = max(time.time() - start, 1e-6)
+    result = {
+        "pod": POD, "elapsed_s": round(elapsed, 2), "concurrency": CONC,
+        "success": _stats["success"], "fail": _stats["fail"],
+        "out_tokens": _stats["out_tokens"],
+        "out_tok_s": round(_stats["out_tokens"] / elapsed, 1),
+        "req_s": round(_stats["success"] / elapsed, 2),
+        "ttft_ms_median": _pct(_ttfts, 50), "ttft_ms_p99": _pct(_ttfts, 99),
+        "latency_ms_median": _pct(_latencies, 50),
+    }
+    print("RESULT_JSON " + json.dumps(result), flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:  # never fail the Job — emit what we have
+        print(f"RESULT_JSON {json.dumps({'pod': POD, 'error': str(e)[:200], 'success': 0, 'fail': 0, 'out_tok_s': 0, 'req_s': 0})}", flush=True)
+    sys.exit(0)

--- a/crusoe-kserve-example/load-test/loadgen_async.py
+++ b/crusoe-kserve-example/load-test/loadgen_async.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Async high-density gateway load generator (pure stdlib asyncio).
+
+Holds CONCURRENCY persistent keep-alive connections per pod, each looping OpenAI
+chat-completions back-to-back for DURATION seconds. One asyncio task per
+connection (~20 KB each), so a single pod holds thousands of in-flight requests
+on a fraction of a CPU — built to stress the Envoy gateway's connection handling
+at very high concurrency. Scale total offered concurrency by pod count (fan-out).
+
+Raw HTTP/1.1 over asyncio streams (no pip deps). Prints a heartbeat every 15 s and
+a final RESULT_JSON line the Makefile sums across pods. Always exits 0.
+
+Env: TARGET_URL MODEL CONCURRENCY DURATION INPUT_LEN OUTPUT_LEN RAMP_SECONDS
+     REQ_TIMEOUT POD_NAME
+Note: the container must raise its fd limit (ulimit -n) above CONCURRENCY.
+"""
+import asyncio, os, sys, json, time, urllib.parse
+
+TARGET   = os.environ["TARGET_URL"].rstrip("/")
+MODEL    = os.environ.get("MODEL", "qwen3")
+CONC     = int(os.environ.get("CONCURRENCY", "4000"))
+DURATION = int(os.environ.get("DURATION", "120"))
+IN_LEN   = int(os.environ.get("INPUT_LEN", "512"))
+OUT_LEN  = int(os.environ.get("OUTPUT_LEN", "150"))
+RAMP     = float(os.environ.get("RAMP_SECONDS", "15"))
+TIMEOUT  = float(os.environ.get("REQ_TIMEOUT", "300"))
+POD      = os.environ.get("POD_NAME", "loadgen")
+
+u    = urllib.parse.urlparse(TARGET)
+HOST = u.hostname
+PORT = u.port or (443 if u.scheme == "https" else 80)
+TLS  = u.scheme == "https"
+EP   = (u.path or "") + "/v1/chat/completions"
+
+PROMPT = " ".join(["word"] * IN_LEN)
+BODY = json.dumps({
+    "model": MODEL, "messages": [{"role": "user", "content": PROMPT}],
+    "max_tokens": OUT_LEN, "min_tokens": OUT_LEN, "ignore_eos": True,
+    "temperature": 0.0, "stream": True, "stream_options": {"include_usage": True},
+}).encode()
+REQ = (("POST %s HTTP/1.1\r\nHost: %s\r\nContent-Type: application/json\r\n"
+        "Content-Length: %d\r\nConnection: keep-alive\r\n\r\n"
+        % (EP, HOST, len(BODY))).encode()) + BODY
+
+S = {"established": 0, "active": 0, "peak_active": 0, "success": 0, "fail": 0,
+     "conn_err": 0, "http_err": 0, "out_tokens": 0}
+TT, LAT = [], []
+stop_at = 0.0
+
+
+async def _read_headers(reader):
+    line = await reader.readuntil(b"\r\n")
+    parts = line.split(b" ", 2)
+    status = int(parts[1]) if len(parts) >= 2 and parts[1].isdigit() else 0
+    headers = {}
+    while True:
+        h = await reader.readuntil(b"\r\n")
+        if h == b"\r\n":
+            break
+        if b":" in h:
+            k, v = h.split(b":", 1)
+            headers[k.strip().lower()] = v.strip()
+    return status, headers
+
+
+async def _read_body(reader, headers):
+    """Return (body_bytes, ttft_seconds_or_None). Handles chunked + content-length."""
+    if headers.get(b"transfer-encoding", b"").lower() == b"chunked":
+        body = b""; ttft = None; t0 = time.monotonic()
+        while True:
+            size_line = await reader.readuntil(b"\r\n")
+            try:
+                size = int(size_line.strip().split(b";")[0], 16)
+            except ValueError:
+                raise IOError("bad chunk size")
+            if size == 0:
+                await reader.readuntil(b"\r\n")
+                break
+            chunk = await reader.readexactly(size + 2)  # data + trailing CRLF
+            if ttft is None:
+                ttft = time.monotonic() - t0
+            body += chunk[:-2]
+        return body, ttft
+    n = int(headers.get(b"content-length", b"0"))
+    return (await reader.readexactly(n) if n else b""), None
+
+
+def _count_tokens(body):
+    usage, deltas = None, 0
+    for line in body.split(b"\n"):
+        line = line.strip()
+        if not line.startswith(b"data: "):
+            continue
+        p = line[6:]
+        if p == b"[DONE]":
+            continue
+        try:
+            d = json.loads(p)
+        except Exception:
+            continue
+        us = d.get("usage")
+        if us and us.get("completion_tokens"):
+            usage = us["completion_tokens"]
+        ch = d.get("choices") or []
+        if ch and (ch[0].get("delta") or {}).get("content"):
+            deltas += 1
+    return usage if usage is not None else deltas
+
+
+async def _conn_loop(idx):
+    await asyncio.sleep(RAMP * idx / max(CONC, 1))  # stagger connection opens
+    reader = writer = None
+    while time.monotonic() < stop_at:
+        try:
+            if writer is None:
+                reader, writer = await asyncio.wait_for(
+                    asyncio.open_connection(HOST, PORT, ssl=TLS), timeout=30)
+                S["established"] += 1
+            t0 = time.monotonic()
+            writer.write(REQ)
+            await writer.drain()
+            S["active"] += 1
+            if S["active"] > S["peak_active"]:
+                S["peak_active"] = S["active"]
+            status, headers = await asyncio.wait_for(_read_headers(reader), TIMEOUT)
+            body, ttft = await asyncio.wait_for(_read_body(reader, headers), TIMEOUT)
+            S["active"] -= 1
+            if status == 200:
+                S["success"] += 1
+                S["out_tokens"] += _count_tokens(body)
+                if ttft is not None:
+                    TT.append(ttft * 1000)
+                LAT.append((time.monotonic() - t0) * 1000)
+            else:
+                S["fail"] += 1; S["http_err"] += 1
+            if headers.get(b"connection", b"").lower() == b"close":
+                writer.close(); reader = writer = None
+        except Exception:
+            S["fail"] += 1; S["conn_err"] += 1
+            if S["active"] > 0:
+                S["active"] -= 1
+            try:
+                if writer:
+                    writer.close()
+            except Exception:
+                pass
+            reader = writer = None
+            await asyncio.sleep(0.5)
+    try:
+        if writer:
+            writer.close()
+    except Exception:
+        pass
+
+
+async def _heartbeat():
+    while time.monotonic() < stop_at:
+        await asyncio.sleep(15)
+        print("[%s] est=%d active=%d peak=%d ok=%d fail=%d(conn=%d,http=%d) tok=%d"
+              % (POD, S["established"], S["active"], S["peak_active"], S["success"],
+                 S["fail"], S["conn_err"], S["http_err"], S["out_tokens"]), flush=True)
+
+
+async def main():
+    global stop_at
+    print("[%s] async target=%s conc=%d dur=%ds ramp=%ss in=%d out=%d"
+          % (POD, TARGET, CONC, DURATION, RAMP, IN_LEN, OUT_LEN), flush=True)
+    start = time.monotonic()
+    stop_at = start + RAMP + DURATION
+    hb = asyncio.create_task(_heartbeat())
+    await asyncio.gather(*[asyncio.create_task(_conn_loop(i)) for i in range(CONC)],
+                         return_exceptions=True)
+    hb.cancel()
+    elapsed = max(time.monotonic() - start, 1e-6)
+
+    def pct(a, p):
+        if not a:
+            return 0.0
+        a = sorted(a)
+        return round(a[min(len(a) - 1, int(len(a) * p / 100))], 1)
+
+    r = {"pod": POD, "elapsed_s": round(elapsed, 1), "target_conc": CONC,
+         "established": S["established"], "peak_active": S["peak_active"],
+         "success": S["success"], "fail": S["fail"], "conn_err": S["conn_err"],
+         "http_err": S["http_err"], "out_tokens": S["out_tokens"],
+         "out_tok_s": round(S["out_tokens"] / elapsed, 1),
+         "req_s": round(S["success"] / elapsed, 2),
+         "ttft_ms_p50": pct(TT, 50), "ttft_ms_p99": pct(TT, 99),
+         "lat_ms_p50": pct(LAT, 50)}
+    print("RESULT_JSON " + json.dumps(r), flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except Exception as e:
+        print("RESULT_JSON " + json.dumps(
+            {"pod": POD, "error": str(e)[:200], "success": 0, "fail": 0, "out_tok_s": 0}),
+            flush=True)
+    sys.exit(0)


### PR DESCRIPTION
## What

Adds a cross-region **gateway load-test harness** under `crusoe-kserve-example/load-test/` for measuring the throughput ceiling of a KServe/vLLM deployment and building a node-count-vs-concurrent-users sizing guide. Run it from a **separate cluster** (ideally a different region) so it exercises the real `client → external LB → Envoy gateway → EPP → replica` path rather than in-cluster localhost.

Each load-gen pod holds persistent keep-alive connections and fires OpenAI chat-completions back-to-back, forcing a fixed output length (`min_tokens`+`ignore_eos`) so throughput is comparable run-to-run. The client leg stays keep-alive (no ephemeral-port churn) while the L7 gateway still balances every request across replicas. Scale total offered load by **pod count**.

## Contents

| File | What |
|------|------|
| `load-test/loadgen.py` | Threaded harness (one thread/conn), ~hundreds of conns/pod — wired into the Makefile |
| `load-test/loadgen_async.py` | Asyncio harness (one task/conn), ~thousands of conns/pod — for extreme gateway stress |
| `load-test/distributed-loadtest.yaml` | Indexed Job template for the threaded harness (`envsubst`) |
| `load-test/gateway-stress-job.yaml` | Indexed Job for the async harness; raises the fd limit + adds `SYS_RESOURCE` |
| `load-test/README.md` | How to run both, open vs closed loop, per-node connection-density caveat |

Both harnesses are pure stdlib (any `python:3.x` image), emit a final `RESULT_JSON` line, and always exit 0 so logs stay collectible.

### Makefile
- New `loadtest-distributed` / `loadtest-report` / `loadtest-clean` targets with `LOADTEST_*` vars (target URL, pods, concurrency, duration, I/O lengths, node selector).
- `bench-amd-mi355x-all`: add `--disable-tqdm` and optional `--max-concurrency` — tqdm progress streaming over many `kubectl exec` sessions created backpressure that under-measured aggregate throughput.

## Usage

```bash
# On the SERVING cluster — get the gateway VIP:
kubectl get gateway kserve-ingress-gateway -n kserve -o jsonpath='{.status.addresses[0].value}'

# On a SEPARATE cluster:
make loadtest-distributed LOADTEST_TARGET_URL=http://<VIP>/<namespace>/<isvc> \
  LOADTEST_PODS=25 LOADTEST_CONCURRENCY=256 LOADTEST_DURATION=120
make loadtest-report
make loadtest-clean
```

## Notes
- Closed-loop by design: exactly `CONCURRENCY` requests outstanding per pod (a fixed number of simulated users), so numbers reflect sustainable capacity.
- Keep async per-node density modest (≤ ~2–3k conn/node) — beyond that, load-gen nodes flip `NotReady` from network-softirq/kubelet starvation before the gateway is stressed; add pods/nodes to go higher.
- No secrets or cluster-specific metadata — everything is parameterized via env/`LOADTEST_*` vars.