### PR TITLE
Add one-click Kimi K3 TP=8 recipe for MI355X

### DIFF
--- a/crusoe-kserve-example/recipes/kimi-k3-mi355x-tp8/README.md
+++ b/crusoe-kserve-example/recipes/kimi-k3-mi355x-tp8/README.md
@@ -1,0 +1,55 @@
+# Kimi K3 on MI355X — one-click TP=8 recipe
+
+Serve **Moonshot AI Kimi K3** (2.8T-param MoE, ~104B active, native MXFP4, 1M context) on a
+**single 8-GPU AMD MI355X (gfx950/CDNA4)** node with KServe + vLLM (ROCm), using the model's
+**native tiktoken tokenizer**. One `LLMInferenceService`, tensor-parallel across the 8 GPUs.
+
+## Prerequisites
+
+- A Crusoe Managed Kubernetes cluster with an **MI355X node pool** and **KServe v0.19+** installed,
+  plus a namespace holding a HuggingFace secret named `hf-secret`. The repo root automates this:
+  `make setup-amd` then confirm the AMD add-ons advertise `amd.com/gpu: 8` per node.
+- HuggingFace access to `moonshotai/Kimi-K3` (the token in `hf-secret`).
+
+## Deploy
+
+```bash
+kubectl apply -n kserve-test -f kimi-k3.yaml
+```
+
+This creates a ReadWriteMany weights disk (`kimi-k3-weights`, 2 TiB) and the `kimi-k3`
+`LLMInferenceService`. **First start is ~15–20 min** — the ~1.56 TB MXFP4 weights download to the
+shared disk once, then the AITER MoE kernels compile. Watch it:
+
+```bash
+kubectl -n kserve-test get llminferenceservice kimi-k3 -w
+kubectl -n kserve-test logs -l app.kubernetes.io/instance=kimi-k3 -c main -f   # or the workload pod
+```
+
+## Use
+
+The model is served OpenAI-compatibly as `kimi-k3`. In-cluster:
+
+```bash
+curl http://kimi-k3-kserve-workload-svc.kserve-test.svc.cluster.local:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"kimi-k3","messages":[{"role":"user","content":"Hello"}],"max_tokens":64}'
+```
+
+Externally it is reachable through the KServe gateway at `/<namespace>/kimi-k3` (see the repo's
+benchmark/monitoring docs). Tool calling and reasoning parsing are enabled.
+
+## Notes
+
+- **Day-0 image caveats** are baked into `kimi-k3.yaml` as comments: use the hyphen image
+  `vllm/vllm-openai-rocm:kimi-k3`, keep **bf16 KV** (no `--kv-cache-dtype fp8`), and
+  `VLLM_USE_BREAKABLE_CUDAGRAPH=0`. Treat throughput as day-0 — AITER improves fast post-launch.
+- **Prefix caching** is enabled and runs on K3's hybrid KDA(mamba)+MLA attention via an
+  **experimental** Mamba "align" cache mode. It helps stable-prefix (RAG / API) traffic; remove the
+  `--enable-prefix-caching` arg to disable.
+- **Weights on network storage:** the RWX disk lets a rolling `kubectl apply` (e.g. to change args)
+  stage the new pod on a second node before the old one exits — zero downtime, weights are not
+  re-downloaded. Avoid `--model-loader-extra-config` multithread loading here: concurrent readers
+  contend on the shared filesystem and load *slower*, not faster.
+- Single-node TP=8 is the recommended layout for K3 on MI355X. To add capacity, run more replicas
+  (independent full copies behind the router), rather than multi-node tensor/expert parallel.

--- a/crusoe-kserve-example/recipes/kimi-k3-mi355x-tp8/kimi-k3.yaml
+++ b/crusoe-kserve-example/recipes/kimi-k3-mi355x-tp8/kimi-k3.yaml
@@ -1,0 +1,122 @@
+# Kimi K3 on AMD MI355X (gfx950) — single-node TP=8, native tiktoken tokenizer.
+#
+# One-click serving recipe for Moonshot AI's Kimi K3 (2.8T MoE, MXFP4, 1M ctx)
+# on one 8-GPU MI355X node via KServe + vLLM (ROCm). See README.md for prerequisites.
+#
+# Apply into the namespace that holds your HuggingFace secret (default: kserve-test):
+#   kubectl apply -n kserve-test -f kimi-k3.yaml
+#
+# The model is served OpenAI-compatibly as `kimi-k3` once the pod is Ready
+# (first start ~15-20 min: ~1.56 TB weight pull to the shared disk + AITER MoE compile).
+---
+# ReadWriteMany shared disk for the ~1.56 TB MXFP4 weights (min 1 TiB). RWX lets a
+# rolling update stage the new pod on another node while the old one keeps serving
+# (zero downtime, no single-GPU-node deadlock). Backed by the Crusoe shared-fs CSI.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: crusoe-fs
+provisioner: fs.csi.crusoe.ai
+volumeBindingMode: Immediate
+reclaimPolicy: Delete
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kimi-k3-weights
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: crusoe-fs
+  resources:
+    requests:
+      storage: 2Ti
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: kimi-k3
+spec:
+  model:
+    uri: hf://moonshotai/Kimi-K3
+    name: kimi-k3
+  replicas: 1
+  template:
+    containers:
+      - name: main
+        # Must be the HYPHEN repo. The recipe's underscore `vllm-openai_rocm` is empty.
+        # This gfx950 image ships the MI355X (CDNA4) kernels; the generic ROCm image lacks them.
+        image: vllm/vllm-openai-rocm:kimi-k3
+        args:
+          - --tensor-parallel-size
+          - "8"
+          - --trust-remote-code                 # custom tiktoken tokenizer (encoding_k3.py)
+          - --max-model-len
+          - "131072"
+          - --load-format
+          - auto
+          - --gpu-memory-utilization
+          - "0.95"
+          - --mm-encoder-tp-mode
+          - data
+          - --max-num-seqs
+          - "128"
+          - --reasoning-parser
+          - kimi_k3                             # separates K3's <|open|>think<|sep|> channel
+          - --max-num-batched-tokens
+          - "4096"
+          # Prefix caching works on K3's hybrid KDA(mamba)+MLA attention via an EXPERIMENTAL
+          # Mamba "align" cache mode (vLLM auto-selects it). Benefits stable-prefix (RAG / API)
+          # traffic; the chat endpoint currently yields few hits. Drop this flag to disable.
+          - --enable-prefix-caching
+          - --enable-auto-tool-choice           # OpenAI clients send tool_choice: auto
+          - --tool-call-parser
+          - kimi_k3
+          # Do NOT add `--kv-cache-dtype fp8`: the aiter mla_gluon MLA kernel needs bf16 queries.
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-secret        # created by `make setup` (see repo root)
+                key: HF_TOKEN
+          - name: HF_HUB_DISABLE_XET
+            value: "1"
+          - name: VLLM_ROCM_USE_AITER
+            value: "1"                 # AITER MoE kernels — major throughput win on MI355X
+          - name: SAFETENSORS_FAST_GPU
+            value: "1"
+          - name: AITER_SITUV2_A8W4
+            value: "1"                 # a8w4 MoE path (set 0 for a16w4)
+          - name: AITER_BF16_FP8_MOE_BOUND
+            value: "0"
+          - name: VLLM_USE_BREAKABLE_CUDAGRAPH
+            value: "0"                 # REQUIRED on ROCm; the build auto-enables =1, which
+                                       # crashes K3's mla_gluon at CUDA-graph capture
+        resources:
+          limits: { amd.com/gpu: "8", cpu: "64", memory: 1Ti }
+          requests: { amd.com/gpu: "8", cpu: "16", memory: 128Gi }
+        # KServe v0.19's hardened securityContext sets runAsNonRoot; the vLLM ROCm image
+        # runs as root — relax it or the pod is CreateContainerConfigError.
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+          readOnlyRootFilesystem: false
+        # ~50-min budget (15 s x 200): the first start compiles the 235B-class MoE AITER
+        # kernels well past KServe's default 10-min probe. A restart recompiles but does
+        # not re-download (weights persist on the shared disk).
+        startupProbe:
+          httpGet: { path: /health, port: 8000 }
+          periodSeconds: 15
+          failureThreshold: 200
+          timeoutSeconds: 5
+    nodeSelector:
+      crusoe.ai/accelerator: amd-mi355x-288gb-roce
+    securityContext:
+      fsGroup: 1000
+    volumes:
+      - name: kserve-provision-location   # KServe's model-download volume; override to the RWX PVC
+        persistentVolumeClaim:
+          claimName: kimi-k3-weights
+  router:
+    gateway: {}
+    route: {}
+    scheduler: {}


### PR DESCRIPTION
Adds `recipes/kimi-k3-mi355x-tp8/` — a self-contained recipe to one-click deploy Moonshot AI **Kimi K3** (2.8T MoE, native MXFP4, 1M context) on a single **8-GPU MI355X (gfx950)** node with KServe + vLLM (ROCm), using the model's **native tiktoken tokenizer**, tensor-parallel across the 8 GPUs.

**Files**
- `kimi-k3.yaml` — `crusoe-fs` StorageClass + RWX weights PVC + `LLMInferenceService` (TP=8). The gfx950 day-0 requirements are documented inline: hyphen image `vllm/vllm-openai-rocm:kimi-k3`, bf16 KV (no fp8 KV), `VLLM_USE_BREAKABLE_CUDAGRAPH=0`, `kimi_k3` reasoning + tool parsers, AITER MoE env, root securityContext, and a ~50-min startupProbe for the AITER compile.
- `README.md` — prerequisites, deploy command, and what to expect (~15–20 min first start).

**Deploy**
```
kubectl apply -n kserve-test -f recipes/kimi-k3-mi355x-tp8/kimi-k3.yaml
```
Served OpenAI-compatibly as `kimi-k3`. Validated with `kubectl apply --dry-run=server`.

**Notes**
- Prefix caching is enabled via vLLM's experimental Mamba "align" mode (K3 is hybrid KDA+MLA); it helps stable-prefix traffic — remove the flag to disable.
- RWX weights disk enables zero-downtime rolling updates (new pod stages on another node). Multithread model loading is intentionally omitted — concurrent readers contend on network storage and load slower.
- Scope is single-node TP=8 only; EP, multi-node, and tokenizer variants are not included.