### PR TITLE
kimi-k3 recipe: fastsafetensors load format (~3.75 min vs ~14 min)

### DIFF
--- a/crusoe-kserve-example/recipes/kimi-k3-mi355x-tp8/README.md
+++ b/crusoe-kserve-example/recipes/kimi-k3-mi355x-tp8/README.md
@@ -47,9 +47,13 @@ benchmark/monitoring docs). Tool calling and reasoning parsing are enabled.
 - **Prefix caching** is enabled and runs on K3's hybrid KDA(mamba)+MLA attention via an
   **experimental** Mamba "align" cache mode. It helps stable-prefix (RAG / API) traffic; remove the
   `--enable-prefix-caching` arg to disable.
+- **Fast weight loading:** `--load-format fastsafetensors` parallelizes the read across the 8 TP
+  ranks and overlaps it with the host→device copy. On the shared disk's large ~16 GB shards this
+  loads the 1.5 TB in **~3.75 min** (sustained ~6–7 GB/s) vs ~14 min for `auto`. Do **not** instead
+  reach for `--model-loader-extra-config` multithread loading — that default-loader knob issues
+  concurrent small reads that are *slower* on the latency-bound network filesystem.
 - **Weights on network storage:** the RWX disk lets a rolling `kubectl apply` (e.g. to change args)
   stage the new pod on a second node before the old one exits — zero downtime, weights are not
-  re-downloaded. Avoid `--model-loader-extra-config` multithread loading here: concurrent readers
-  contend on the shared filesystem and load *slower*, not faster.
+  re-downloaded.
 - Single-node TP=8 is the recommended layout for K3 on MI355X. To add capacity, run more replicas
   (independent full copies behind the router), rather than multi-node tensor/expert parallel.

--- a/crusoe-kserve-example/recipes/kimi-k3-mi355x-tp8/kimi-k3.yaml
+++ b/crusoe-kserve-example/recipes/kimi-k3-mi355x-tp8/kimi-k3.yaml
@@ -52,8 +52,14 @@ spec:
           - --trust-remote-code                 # custom tiktoken tokenizer (encoding_k3.py)
           - --max-model-len
           - "131072"
+          # fastsafetensors parallelizes the weight read across the 8 TP ranks (each pulls
+          # its own ~12 of the 96 shards) and overlaps host read with the pinned H2D copy.
+          # On the RWX shared disk's large ~16 GB contiguous shards this sustains ~6-7 GB/s
+          # and loads the 1.5 TB in ~3.75 min vs ~14 min for `auto`. Do NOT pair it with
+          # `--model-loader-extra-config` multithread loading: that's a default-loader knob
+          # and its concurrent small reads are SLOWER on the latency-bound network FS.
           - --load-format
-          - auto
+          - fastsafetensors
           - --gpu-memory-utilization
           - "0.95"
           - --mm-encoder-tp-mode


### PR DESCRIPTION
Switches the Kimi K3 MI355X recipe to `--load-format fastsafetensors`.

Measured on the shared RWX weights disk: **~3.75 min** to load the 1.5 TB MXFP4 weights (sustained ~6-7 GB/s) vs **~14 min** for `load-format auto`. fastsafetensors parallelizes the read across the 8 TP ranks (each pulls ~12 of the 96 shards) and overlaps it with the host->device copy; the model's large ~16 GB contiguous shards are the friendly access pattern for the latency-bound network filesystem.

The recipe/README also note why the default-loader `--model-loader-extra-config` multithread knob is the wrong lever here — its concurrent small reads are slower on the same disk.