### PR TITLE
Add Kimi K3 SGLang recipe (MI355X) + benchmark harness

### DIFF
--- a/crusoe-kserve-example/load-test/kimi-bench-client.yaml
+++ b/crusoe-kserve-example/load-test/kimi-bench-client.yaml
@@ -1,0 +1,27 @@
+# Dedicated benchmark client for the Kimi-K3 Pareto sweeps. Runs vllm bench serve
+# against a variant's workload Service (server CPU untouched). No GPU; uses the K3
+# tokenizer via trust_remote_code (downloaded, ~3MB) so it needs no weights mount.
+# Driven by load-test/kimi_pareto_bench.sh (kubectl exec).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kimi-bench-client
+  namespace: kserve-test
+  labels: { app: kimi-bench-client }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: kimi-bench-client }
+  template:
+    metadata:
+      labels: { app: kimi-bench-client }
+    spec:
+      containers:
+        - name: client
+          image: vllm/vllm-openai-rocm:kimi-k3
+          command: ["sh", "-c", "pip install -q hf_transfer 2>/dev/null; sleep infinity"]
+          env:
+            - { name: HF_HUB_ENABLE_HF_TRANSFER, value: "1" }
+          resources:
+            requests: { cpu: "12", memory: 24Gi }
+            limits:   { cpu: "16", memory: 48Gi }

--- a/crusoe-kserve-example/load-test/kimi_pareto_bench.py
+++ b/crusoe-kserve-example/load-test/kimi_pareto_bench.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Kimi-K3 Pareto sweep harness (output throughput vs TTFT-p95 across concurrency x shape).
+
+Drives `vllm bench serve` from the dedicated kimi-bench-client pod against ONE variant's
+workload Service. Fixed shapes (not random), ignore-EOS, fixed seed, warmup discarded,
+>=300 requests per run. Errors are their own column and are NEVER dropped from throughput
+math. Per shape, concurrency escalates until the SLO/stop rule trips; saturation is recorded.
+
+Usage:
+  VARIANT=kimi-ep SVC=kimi-ep-llm-kserve-workload-svc python3 kimi_pareto_bench.py
+Env: VARIANT (served-model-name, required) · SVC (workload svc, default <VARIANT>-llm-kserve-workload-svc)
+     NS=kserve-test · CTX=mi-poc-amd-355 · CLIENT=deploy/kimi-bench-client · OUT=<csv>
+     SHAPES="512:128,4096:512,32768:1024,131072:2048,1024:8192" · CONC="1,4,16,64,128,256,512"
+Stop rules (per shape): TTFT-p95 > 10s, OR output-tok/s plateaus twice (<5% gain), OR any 100% error run.
+SLO reference (flagged in output, not a stop): TTFT-p95 < 1s, TPOT < 50ms.
+"""
+import os, re, subprocess, sys, csv, time
+
+VARIANT = os.environ["VARIANT"]
+SVC     = os.environ.get("SVC", f"{VARIANT}-llm-kserve-workload-svc")
+NS      = os.environ.get("NS", "kserve-test")
+CTX     = os.environ.get("CTX", "mi-poc-amd-355")
+CLIENT  = os.environ.get("CLIENT", "deploy/kimi-bench-client")
+OUT     = os.environ.get("OUT", f"/tmp/kimi_pareto_{VARIANT}.csv")
+# Long shape input is 124000 (not 128k): vllm's random dataset inflates tokens ~1.4% on
+# decode->re-encode, so 128000 -> ~129.8k, and +2048 output exceeds max_model_len 131072.
+# 124000 -> ~125.7k + 2048 = ~127.7k, comfortably under 131072.
+SHAPES  = os.environ.get("SHAPES", "512:128,4096:512,32768:1024,124000:2048,1024:8192")
+CONC    = [int(c) for c in os.environ.get("CONC", "1,4,16,64,128,256,512").split(",")]
+BASE    = f"http://{SVC}.{NS}.svc.cluster.local:8000"
+WARMUPS = int(os.environ.get("WARMUPS", "8"))
+TTFT_STOP_MS = 10_000
+SLO_TTFT_MS, SLO_TPOT_MS = 1_000, 50
+
+COLS = ["config_id","variant","in_tok","out_tok","concurrency","num_prompts",
+        "successful","errors","err_pct","duration_s","req_s","output_tps","total_tps",
+        "ttft_p95_ms","ttft_p99_ms","tpot_p95_ms","tpot_p50_ms","slo_ok","note"]
+
+def run_bench(in_tok, out_tok, conc):
+    # Adaptive request count: target ~120s per run (per the "300 requests OR 120s" rule) instead of
+    # a flat 300 — otherwise slow long-output shapes at low concurrency need 300 x ~25s >> timeout.
+    est_req_s = max(3.0, out_tok * 0.045 + in_tok * 0.0006)   # rough: TPOT-dominated + prefill
+    n_cap = max(3, int(conc * 1500.0 / est_req_s))            # keep each run <= ~25min (< task lifetime)
+    n = max(3, min(300, round(conc * 120.0 / est_req_s), n_cap))
+    vllm = ["vllm","bench","serve",
+        "--model","moonshotai/Kimi-K3","--tokenizer","moonshotai/Kimi-K3","--trust-remote-code",
+        "--served-model-name",VARIANT,
+        "--base-url",BASE,"--backend","openai-chat","--endpoint","/v1/chat/completions",
+        "--dataset-name","random","--random-input-len",str(in_tok),
+        "--random-output-len",str(out_tok),"--random-range-ratio","0","--ignore-eos",
+        "--seed","0","--num-warmups",str(WARMUPS),
+        "--num-prompts",str(n),"--request-rate","inf","--max-concurrency",str(conc),
+        "--percentile-metrics","ttft,tpot,itl,e2el","--metric-percentiles","95,99",
+        "--disable-tqdm"]
+    # IN_POD=1: run vllm bench directly (inside the client pod, survives the local task lifetime).
+    # else: drive it via kubectl exec from the workstation.
+    cmd = vllm if os.environ.get("IN_POD") else ["kubectl","--context",CTX,"-n",NS,"exec",CLIENT,"--"] + vllm
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=3600).stdout
+    except subprocess.TimeoutExpired:
+        return {"num_prompts": n, "successful": 0, "errors": n, "err_pct": 100.0, "note": "timeout"}
+    g = lambda pat: (float(m.group(1)) if (m := re.search(pat, out)) else None)
+    succ = g(r"Successful requests:\s+([0-9.]+)")
+    succ = int(succ) if succ is not None else 0
+    return {
+        "num_prompts": n, "successful": succ, "errors": n - succ,
+        "err_pct": round(100.0 * (n - succ) / n, 1),
+        "duration_s": g(r"Benchmark duration \(s\):\s+([0-9.]+)"),
+        "req_s": g(r"Request throughput \(req/s\):\s+([0-9.]+)"),
+        "output_tps": g(r"Output token throughput \(tok/s\):\s+([0-9.]+)"),
+        "total_tps": g(r"Total [Tt]oken throughput \(tok/s\):\s+([0-9.]+)"),
+        "ttft_p95": g(r"P95 TTFT \(ms\):\s+([0-9.]+)"),
+        "ttft_p99": g(r"P99 TTFT \(ms\):\s+([0-9.]+)"),
+        "tpot_p95": g(r"P95 TPOT \(ms\):\s+([0-9.]+)"),
+        "tpot_p50": g(r"Median TPOT \(ms\):\s+([0-9.]+)"),
+        "note": "",
+    }
+
+def main():
+    # RESUMABLE: skip runs already in the CSV and whole shapes already marked done, so a
+    # relaunch (e.g. after a killed background task) continues instead of restarting.
+    progress = OUT + ".doneshapes"
+    done_shapes = set(l.strip() for l in open(progress)) if os.path.exists(progress) else set()
+    done_cfg, prev_by_shape = set(), {}
+    if os.path.exists(OUT):
+        for row in csv.reader(open(OUT)):
+            if row and row[0] != "config_id":
+                done_cfg.add(row[0])
+                try: prev_by_shape[(row[2], row[3])] = float(row[11])   # last out_tps per shape
+                except Exception: pass
+    rows = []
+    new = not os.path.exists(OUT)
+    with open(OUT, "a", newline="") as f:
+        w = csv.writer(f)
+        if new: w.writerow(COLS); f.flush()
+        for shape in SHAPES.split(","):
+            in_tok, out_tok = (int(x) for x in shape.split(":"))
+            skey = "%dx%d" % (in_tok, out_tok)
+            if skey in done_shapes:
+                print("[skip] shape %s already complete" % skey, flush=True); continue
+            prev_tps = prev_by_shape.get((str(in_tok), str(out_tok)))
+            plateau = 0
+            for conc in CONC:
+                cid = f"{VARIANT}-{in_tok}x{out_tok}-c{conc}"
+                if cid in done_cfg:
+                    print("[skip] %s already done" % cid, flush=True); continue
+                print(f"[run] {cid} ...", flush=True)
+                r = run_bench(in_tok, out_tok, conc)
+                otps = r.get("output_tps") or 0.0
+                ttft95 = r.get("ttft_p95")
+                tpot95 = r.get("tpot_p95")
+                slo_ok = (ttft95 is not None and ttft95 < SLO_TTFT_MS and
+                          tpot95 is not None and tpot95 < SLO_TPOT_MS and r["errors"] == 0)
+                note = r.get("note","")
+                # plateau: <5% output-tps gain vs previous concurrency
+                if prev_tps and prev_tps > 0 and (otps - prev_tps) / prev_tps < 0.05:
+                    plateau += 1
+                else:
+                    plateau = 0
+                prev_tps = otps
+                row = [cid, VARIANT, in_tok, out_tok, conc, r["num_prompts"], r["successful"],
+                       r["errors"], r["err_pct"], r.get("duration_s"), r.get("req_s"), otps,
+                       r.get("total_tps"), ttft95, r.get("ttft_p99"), tpot95, r.get("tpot_p50"),
+                       "yes" if slo_ok else "no", note]
+                w.writerow(row); f.flush(); rows.append(row)
+                print(f"      out_tps={otps} ttft_p95={ttft95}ms tpot_p95={tpot95}ms "
+                      f"err={r['errors']}/{r['num_prompts']} slo={'ok' if slo_ok else 'no'}", flush=True)
+                # stop rules for this shape
+                if r["errors"] == r["num_prompts"]:
+                    print(f"      SATURATED: 100% errors at c={conc}", flush=True); break
+                if ttft95 is not None and ttft95 > TTFT_STOP_MS:
+                    print(f"      SATURATED: TTFT-p95 {ttft95}ms > {TTFT_STOP_MS}ms at c={conc}", flush=True); break
+                if plateau >= 2:
+                    print(f"      SATURATED: output-tps plateaued twice at c={conc}", flush=True); break
+            with open(progress, "a") as pf:      # shape ladder finished -> mark complete for resume
+                pf.write(skey + "\n")
+    print(f"\nDONE -> {OUT} ({len(rows)} runs)")
+
+if __name__ == "__main__":
+    main()

--- a/crusoe-kserve-example/load-test/kimi_pareto_bench.py
+++ b/crusoe-kserve-example/load-test/kimi_pareto_bench.py
@@ -9,7 +9,7 @@ math. Per shape, concurrency escalates until the SLO/stop rule trips; saturation
 Usage:
   VARIANT=kimi-ep SVC=kimi-ep-llm-kserve-workload-svc python3 kimi_pareto_bench.py
 Env: VARIANT (served-model-name, required) · SVC (workload svc, default <VARIANT>-llm-kserve-workload-svc)
-     NS=kserve-test · CTX=mi-poc-amd-355 · CLIENT=deploy/kimi-bench-client · OUT=<csv>
+     NS=kserve-test · CTX=<kube-context> (optional, default: current-context) · CLIENT=deploy/kimi-bench-client · OUT=<csv>
      SHAPES="512:128,4096:512,32768:1024,131072:2048,1024:8192" · CONC="1,4,16,64,128,256,512"
 Stop rules (per shape): TTFT-p95 > 10s, OR output-tok/s plateaus twice (<5% gain), OR any 100% error run.
 SLO reference (flagged in output, not a stop): TTFT-p95 < 1s, TPOT < 50ms.
@@ -19,7 +19,7 @@ import os, re, subprocess, sys, csv, time
 VARIANT = os.environ["VARIANT"]
 SVC     = os.environ.get("SVC", f"{VARIANT}-llm-kserve-workload-svc")
 NS      = os.environ.get("NS", "kserve-test")
-CTX     = os.environ.get("CTX", "mi-poc-amd-355")
+CTX     = os.environ.get("CTX", "")   # kube context; empty => kubeconfig current-context
 CLIENT  = os.environ.get("CLIENT", "deploy/kimi-bench-client")
 OUT     = os.environ.get("OUT", f"/tmp/kimi_pareto_{VARIANT}.csv")
 # Long shape input is 124000 (not 128k): vllm's random dataset inflates tokens ~1.4% on
@@ -54,7 +54,7 @@ def run_bench(in_tok, out_tok, conc):
         "--disable-tqdm"]
     # IN_POD=1: run vllm bench directly (inside the client pod, survives the local task lifetime).
     # else: drive it via kubectl exec from the workstation.
-    cmd = vllm if os.environ.get("IN_POD") else ["kubectl","--context",CTX,"-n",NS,"exec",CLIENT,"--"] + vllm
+    cmd = vllm if os.environ.get("IN_POD") else ["kubectl"] + (["--context",CTX] if CTX else []) + ["-n",NS,"exec",CLIENT,"--"] + vllm
     try:
         out = subprocess.run(cmd, capture_output=True, text=True, timeout=3600).stdout
     except subprocess.TimeoutExpired:

--- a/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/Dockerfile
+++ b/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/Dockerfile
@@ -1,0 +1,24 @@
+# Derived SGLang image for Kimi K3 on AMD MI355X (gfx950) with fast weight loading.
+#
+# The stock image serves Kimi K3 correctly, but its default weight loader is unusable on
+# network-backed storage, so this image adds two things:
+#   1. fastsafetensors  — parallel weight loading (~5 min vs ~2 h for the default
+#      "multi-thread" loader, which reads shards ~84 s each over a network filesystem).
+#   2. a one-line nogds patch — SGLang's fastsafetensors path calls SafeTensorsFileLoader
+#      WITHOUT nogds=True, so on ROCm (no libcufile.so / GPU Direct Storage) it deadlocks
+#      trying to open GDS. vLLM forces nogds for TP>1; SGLang does not. (Upstream candidate.)
+#
+# Base image is pinned per the MI355X optimization work — the 20260802 tag is broken for K3.
+FROM lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727
+
+RUN pip install --no-cache-dir fastsafetensors
+
+RUN sed -i \
+      's/loader = SafeTensorsFileLoader(pg, device)/loader = SafeTensorsFileLoader(pg, device, nogds=True)/' \
+      /sgl-workspace/sglang/python/sglang/srt/model_loader/weight_utils.py && \
+    grep -q 'nogds=True' /sgl-workspace/sglang/python/sglang/srt/model_loader/weight_utils.py
+
+# Build + push to a registry your cluster can pull from, e.g.:
+#   docker build -t <registry>/kimi-k3-sglang-fss:20260727 .
+#   docker push  <registry>/kimi-k3-sglang-fss:20260727
+# then set that image in kimi-k3-sglang.yaml (and create an imagePullSecret if the registry is private).

--- a/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/README.md
+++ b/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/README.md
@@ -1,0 +1,90 @@
+# Kimi K3 on MI355X — SGLang recipe (TP=8)
+
+Serve **Moonshot AI Kimi K3** (2.8T-param MoE, native MXFP4, 1M context) on a single **8-GPU AMD
+MI355X (gfx950)** node with **SGLang** (ROCm), OpenAI-compatible, TP=8.
+
+**Why SGLang here:** under long-context *agentic* load (large system prompt + tools, many turns),
+the day-0 vLLM ROCm image can corrupt into repeated-token garbage. SGLang serves K3 cleanly —
+verified on the same request that broke vLLM — with a proper `reasoning_content` / `content`
+split and working tool calls. That makes it the right backend for coding agents (opencode, etc.).
+
+Config is the quality-gated **`fp8kv`** cell (GPQA Diamond 94.71% PASS): `--attention-backend triton`,
+`--kv-cache-dtype fp8_e4m3`, `--mamba-ssm-dtype bfloat16`, `kimi_k3` reasoning + tool parsers.
+
+## Prerequisites
+
+- A Crusoe Managed Kubernetes cluster with an **MI355X node pool**, and a `hf-secret`
+  (key `HF_TOKEN`) with HuggingFace access to `moonshotai/Kimi-K3`. The repo root's
+  `make setup-amd` provisions the cluster + secret.
+- A container registry your cluster can pull from (to host the derived image below).
+
+## 1. Build the derived image
+
+The stock SGLang image needs two fixes for network-backed storage (both in the `Dockerfile`):
+**fastsafetensors** (parallel load: **~5 min** vs **~2 h** for the default multi-thread loader),
+and a one-line **nogds** patch (SGLang's fastsafetensors path deadlocks on ROCm without it —
+no GPU Direct Storage). Build and push:
+
+```bash
+docker build -t <registry>/kimi-k3-sglang-fss:20260727 recipes/kimi-k3-mi355x-sglang/
+docker push  <registry>/kimi-k3-sglang-fss:20260727
+```
+
+## 2. Deploy
+
+Set your image in `kimi-k3-sglang.yaml` (the two `REPLACE_WITH_YOUR_REGISTRY` lines; add an
+`imagePullSecret` if the registry is private), then:
+
+```bash
+kubectl apply -n kserve-test -f recipes/kimi-k3-mi355x-sglang/kimi-k3-sglang.yaml
+kubectl -n kserve-test rollout status deploy/kimi-k3-sglang --timeout=90m
+```
+
+First boot: the init container downloads the ~1.5 TB weights to the RWX disk **once**, then
+fastsafetensors loads them (~5 min) and SGLang captures CUDA graphs. Restarts skip the download.
+
+## 3. Use
+
+Served OpenAI-compatibly as `kimi-k3`:
+
+```bash
+kubectl -n kserve-test exec deploy/kimi-k3-sglang -- \
+  curl -s http://localhost:30000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"kimi-k3","messages":[{"role":"user","content":"Reverse a string in Python"}]}'
+```
+
+The service `kimi-k3-sglang-workload-svc:8000` fronts it in-cluster. Reasoning is returned in
+`reasoning_content`; the final answer is in `content`. Tool calls come back as OpenAI `tool_calls`.
+
+## Benchmark
+
+Load-test this (or any) served variant with the harness in `load-test/`:
+
+```bash
+kubectl apply -n kserve-test -f load-test/kimi-bench-client.yaml   # CPU-only client: vllm bench serve + K3 tokenizer
+VARIANT=kimi-k3-sglang-fss SVC=kimi-k3-sglang-fss-workload-svc \
+  python3 load-test/kimi_pareto_bench.py
+```
+
+It sweeps concurrency × input/output shapes (`vllm bench serve`, closed-loop), recording
+output-throughput / TTFT / TPOT with errors as their own column and stopping each shape at
+saturation. On this fp8-KV config, single-node peak is ~9.5k tok/s (512/128, c256) and
+per-token latency (TPOT) beats the vLLM ROCm arm by ~2× at high concurrency. Note: the plain
+ClusterIP workload Service is L4 and keep-alive pins connections to one pod — for aggregate
+load across replicas, drive through an L7 gateway/proxy, not the ClusterIP.
+
+## Notes & gotchas
+
+- **fastsafetensors is mandatory** on network storage — `--load-format auto` uses a multi-thread
+  loader that reads shards ~84 s each (~2 h total) and gets killed by the startup probe.
+- **nogds patch is required** — without it SGLang's fastsafetensors loader hangs at 0/12 shards on
+  ROCm. Baked into the derived image.
+- **Probe timeouts matter** — `/health` runs a 1-token generation (~1 s); the default 1 s readiness
+  timeout makes the pod never go Ready. The manifest sets readiness `timeoutSeconds: 8`.
+- **Two known SGLang engine bugs** (present on all configs, not fatal): tool-call IDs can collide
+  across concurrent requests, and `/tokenize` returns HTTP 500 (`/detokenize` is fine).
+- **Speculative decoding (DSPARK) is omitted** here — it needs a draft model staged and is a
+  throughput lever, not a correctness one. Add `--speculative-algorithm DSPARK` + the draft path
+  once you've staged `Kimi-K3-DSpark-sgl` (see the MI355X optimization notes).
+- Single-node TP=8 is the layout; to add capacity, run more replicas behind a router rather than
+  multi-node tensor/expert parallel.

--- a/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/kimi-k3-sglang.yaml
+++ b/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/kimi-k3-sglang.yaml
@@ -1,0 +1,153 @@
+# Kimi K3 on AMD MI355X (gfx950) via SGLang — single-node TP=8, OpenAI-compatible.
+#
+# Why SGLang (vs the day-0 vLLM ROCm image): SGLang serves K3 coherently under long-context
+# agentic load (clean reasoning/content split + tool calls), where the day-0 vLLM image can
+# corrupt into repeated-token garbage. Config is the quality-gated `nospecfp8kv` cell
+# (GPQA 94.71% PASS) from the MI355X optimization work.
+#
+# BEFORE APPLYING:
+#   1. Build + push the derived image (see Dockerfile) and set `image:` below to it (2 places).
+#   2. If your registry is private, create an imagePullSecret and add it under imagePullSecrets.
+#   3. Ensure a `hf-secret` with key HF_TOKEN exists in this namespace (HuggingFace access to
+#      moonshotai/Kimi-K3). The repo root's `make setup-amd` creates it.
+#   4. Apply:  kubectl apply -n kserve-test -f kimi-k3-sglang.yaml
+#
+# First boot downloads the ~1.5 TB MXFP4 weights to the RWX disk (init container, one time),
+# then fastsafetensors loads them in ~5 min. Later restarts skip the download.
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: crusoe-fs
+provisioner: fs.csi.crusoe.ai
+volumeBindingMode: Immediate
+reclaimPolicy: Delete
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kimi-k3-weights
+spec:
+  accessModes: [ReadWriteMany]      # RWX so a rolling update can stage the new pod on another node
+  storageClassName: crusoe-fs
+  resources:
+    requests:
+      storage: 2Ti                  # min 1 TiB for fs.csi.crusoe.ai; 2Ti fits the 1.5 TB weights
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kimi-k3-sglang
+  labels: { app: kimi-k3-sglang }
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector:
+    matchLabels: { app: kimi-k3-sglang }
+  template:
+    metadata:
+      labels: { app: kimi-k3-sglang }
+    spec:
+      nodeSelector:
+        crusoe.ai/accelerator: amd-mi355x-288gb-roce
+      securityContext:
+        fsGroup: 1000
+      # imagePullSecrets:            # uncomment + name your secret if the registry is private
+      #   - name: <your-pull-secret>
+      initContainers:
+        # One-time weight download to the RWX disk (skipped if already present). Not gated by
+        # the serving probes, so it can take as long as the 1.5 TB pull needs.
+        - name: fetch-weights
+          image: REPLACE_WITH_YOUR_REGISTRY/kimi-k3-sglang-fss:20260727   # same image (has huggingface_hub)
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              if [ -f /models/config.json ]; then echo "weights present, skipping download"; exit 0; fi
+              python3 -c "from huggingface_hub import snapshot_download; snapshot_download('moonshotai/Kimi-K3', local_dir='/models', local_dir_use_symlinks=False)"
+          env:
+            - name: HF_TOKEN
+              valueFrom: { secretKeyRef: { name: hf-secret, key: HF_TOKEN } }
+            - { name: HF_XET_HIGH_PERFORMANCE, value: "1" }
+          volumeMounts:
+            - { name: models, mountPath: /models }
+      containers:
+        - name: sglang
+          image: REPLACE_WITH_YOUR_REGISTRY/kimi-k3-sglang-fss:20260727     # derived image (fastsafetensors + nogds)
+          command: ["python3", "-m", "sglang.launch_server"]
+          args:
+            - --model-path
+            - /models
+            - --served-model-name
+            - kimi-k3
+            - --trust-remote-code
+            - --load-format
+            - fastsafetensors          # MANDATORY on network storage; default 'auto' = ~2 h multi-thread load
+            - --tp-size
+            - "8"
+            - --dtype
+            - bfloat16
+            - --mem-fraction-static
+            - "0.85"
+            - --cuda-graph-max-bs
+            - "256"
+            - --attention-backend
+            - triton                    # the only workable backend on ROCm (aiter MLA illegal at 96 heads)
+            - --kv-cache-dtype
+            - fp8_e4m3                   # 2x KV pool; GPQA-validated PASS (94.71%)
+            - --mamba-ssm-dtype
+            - bfloat16
+            - --reasoning-parser
+            - kimi_k3                    # splits thinking into reasoning_content; keeps content = final answer
+            - --tool-call-parser
+            - kimi_k3
+            - --enable-metrics
+            - --host
+            - 0.0.0.0
+            - --port
+            - "30000"
+          env:
+            - { name: SGLANG_USE_AITER,        value: "1" }
+            - { name: SGLANG_AITER_K3_OPT,     value: "1" }
+            - { name: AITER_FLYDSL_FORCE,      value: "1" }
+            - { name: AITER_SITUV2_A8W4,       value: "1" }
+            - { name: HF_HUB_OFFLINE,          value: "1" }   # weights already on /models
+            - { name: HF_XET_HIGH_PERFORMANCE, value: "1" }
+          ports:
+            - { containerPort: 30000, name: http }
+          resources:
+            limits:   { amd.com/gpu: "8", cpu: "64", memory: 1Ti }
+            requests: { amd.com/gpu: "8", cpu: "16", memory: 128Gi }
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          startupProbe:
+            httpGet: { path: /health, port: 30000 }
+            periodSeconds: 15
+            failureThreshold: 200        # ~50 min for load + graph capture
+            timeoutSeconds: 10           # /health runs a 1-token generation (~1s); give margin
+          readinessProbe:
+            httpGet: { path: /health, port: 30000 }
+            periodSeconds: 30
+            timeoutSeconds: 8            # default 1s times out on /health's ~1s response -> never Ready
+            failureThreshold: 3
+          volumeMounts:
+            - { name: models, mountPath: /models, readOnly: true }
+            - { name: dshm,   mountPath: /dev/shm }
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: kimi-k3-weights
+        - name: dshm
+          emptyDir: { medium: Memory, sizeLimit: 128Gi }   # TP8 intra-node comms need large /dev/shm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kimi-k3-sglang-workload-svc
+  labels: { app: kimi-k3-sglang }
+spec:
+  selector: { app: kimi-k3-sglang }
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 30000


### PR DESCRIPTION
Adds a **SGLang** serving recipe for Kimi K3 on AMD MI355X, plus the benchmark harness.

**Why:** the day-0 vLLM ROCm image corrupts into repeated-token garbage under long-context agentic load. SGLang serves K3 cleanly (verified on the same request) with a proper `reasoning_content`/`content` split and working tool calls.

**`recipes/kimi-k3-mi355x-sglang/`**
- `Dockerfile` — derived image: `fastsafetensors` + a one-line `nogds` patch (SGLang's fastsafetensors path deadlocks on ROCm without it — no libcufile/GDS).
- `kimi-k3-sglang.yaml` — single-node TP8, validated **fp8-KV** config, init-container weight download to a RWX disk, and fixed probe timeouts.
- `README.md` — build → deploy → use → benchmark, with the ROCm/day-0 gotchas.

**`load-test/`** — env-driven Pareto sweep harness (`kimi_pareto_bench.py` + `kimi-bench-client.yaml`) driving `vllm bench serve` across concurrency × input/output shape for any variant.

**Results:** single-node SGLang beats the vLLM ROCm arm ~2× on TPOT and ~25–31% on throughput at high concurrency (fp8 KV doubles the KV pool, removing the admission collapse).