### PR TITLE
Bugfix for Crusoe Managed Slurm Accounting

### DIFF
--- a/crusoe-managed-slurm-accounting/README.md
+++ b/crusoe-managed-slurm-accounting/README.md
@@ -4,24 +4,9 @@ This solution adds slurm accounting (slurmdbd + MariaDB) on top of a Crusoe **Ma
 
 ## Prerequisites
 
-### 1. Crusoe Managed Slurm cluster
-
-You need a Crusoe Managed Kubernetes cluster with the following:
-- Slurm CMK add-on
-- Mecessary Compute Node Pools
-- Access to the Kubernetes API
-- SlurmCluster CR already created, with SSH key configured for root 
-
-You can use `kubectl` to note the login LoadBalancer's external IP for later:
-
-```bash
-kubectl get svc -n slurm   # note the login LoadBalancer External IP
-```
-
-### 2. Tooling
-
 - `helm` v3+
 - `kubectl` matching (or close to) the cluster's Kubernetes version
+- Crusoe CLI
 - Cluster admin access — the chart creates a `StorageClass`, RBAC objects, and patches a cluster-scoped-adjacent `Controller` CR owned by the Crusoe operator.
 
 ## What the chart deploys
@@ -30,51 +15,81 @@ kubectl get svc -n slurm   # note the login LoadBalancer External IP
 |---|---|
 | `StorageClass` (`ssd.csi.crusoe.ai`) | StorageClass for MariaDB using Crusoe Persistent Disk. |
 | MariaDB `StatefulSet` + `Service` + `Secret` | The accounting database (`slurm_acct_db`). Credentials are auto-generated on first install and preserved across upgrades. |
-| `Accounting` CR (`slinky.slurm.net/v1beta1`, aka slurmdbd) | The slurmdbd daemon, pointed at the MariaDB instance and reusing the cluster's existing auth secrets. |
+| `Accounting` CR (`slinky.slurm.net/v1beta1`, aka slurmdbd) | The slurmdbd daemon, pointed at the MariaDB instance and reusing the cluster's existing auth secrets. Its pod carries `initContainers` that wait for MariaDB to be ready before slurmdbd starts (see [Known issues](#known-issues) #5). |
 | Pre-install/pre-upgrade Job + RBAC | Patches `spec.accountingRef` onto the existing `Controller` CR **before** the `Accounting` CR is created (ordering matters — see [Known issues](#known-issues) below). |
+| Post-install/post-upgrade Job + RBAC (`restartPods.enabled`, off by default) | Deletes existing controller/login (and optionally worker) pods so they re-fetch config with accounting enabled. See [Installing on an existing cluster](#installing-on-an-existing-cluster). |
 
-## Installation
+## Installations
+
+There will typically be two scenarios in which you will install this chart:
+
+### Installing on a new Crusoe Managed Slurm cluster
+
+Creating the `SlurmCluster` CR is what triggers node provisioning for the
+controller and login nodes — before that CR exists there are no nodes to
+schedule *anything* onto, including this chart's patch Job. Because of that,
+controller and login pods come up together as soon as the `SlurmCluster` CR
+is created, and there's no way to install this chart in between them.
+
+`sackd` (login) and `slurmd` (worker/compute nodes, in the configless/dynamic
+mode this cluster uses) each fetch `slurm.conf` from the controller **once,
+at process start**, and have no live-reconfigure signal — see
+[Known issues](#known-issues) #4. So a pod that's already running when
+`accountingRef` gets patched onto the `Controller` CR will keep reporting
+accounting as disabled until it's restarted, no matter how the chart install
+itself is sequenced.
+
+Given that, the sequencing that minimizes how much you need to restart is:
+
+1. Create the CMK cluster, then the `SlurmCluster` CR (provisions controller + login nodes).
+2. Install this chart **immediately** — before scaling up or adding any worker/compute node pools. Accept that the login pod will need a restart (unavoidable, see above); it's a cheap, single-replica Deployment. `clusterName` must match your `SlurmCluster` CR's `metadata.name` exactly
+(check with `kubectl get slurmclusters -n <namespace>`). `values.yaml` ships with it set to `test` as a placeholder; override it explicitly with `--set` (or edit `values.yaml`):
 
 ```bash
 cd chart/slurm-accounting
 
-# Review/edit values.yaml first -- at minimum confirm:
-#   clusterName, namespace, existingAuth.*, patchController.controllerName
-helm lint .
-helm install slurm-accounting . -n slurm --wait --timeout 5m
+# Also review namespace and the rest of values.yaml before installing.
+helm lint . --set clusterName=<your-slurmcluster-name>
+helm install slurm-accounting . -n slurm \
+  --set clusterName=<your-slurmcluster-name> \
+  --set restartPods.enabled=true \
+  --wait --timeout 30m
 ```
 
 `--wait` blocks until the MariaDB StatefulSet and the patch Job report ready/succeeded. On a clean cluster this should complete in under two minutes.
 
-The remaining steps below SSH into the login node as `root` (via the key in `rootSSHPubKeys`), since no `SlurmUser` exists yet.
+Setting `restartPods.enabled=true` will restart the controller and login pods (see [Known issue #4](#known-issues) for why).
 
-### Post-install: Make slurmctld pick up accounting
+3. Scale up / add worker node pools. Each worker's first `slurmd` fetch will already see accounting configured, so **no worker restarts are needed**.
 
-Setting `accountingRef` updates the `Controller` CR, which the Crusoe
-operator renders into the `slurm.conf` ConfigMap (`AccountingStorageType`,
-`AccountingStorageHost`, etc.) almost immediately. However, you may need to restart `slurmctld` in order for it to get picked up.
+### Installing on an existing cluster
 
-```bash
-# 1. Confirm the ConfigMap has the new setting
-kubectl get configmap -n slurm <cluster-name>-config -o yaml | grep AccountingStorageType
-
-# 2. Check whether the running slurmctld already picked it up
-ssh root@<login-ip> "scontrol show config | grep AccountingStorageType"
-# If this prints (null), slurmctld is still running on the old config.
-
-# 3. Restart the controller pod to force a clean re-read of slurm.conf
-kubectl delete pod -n slurm <cluster-name>-controller-0
-kubectl get pod -n slurm <cluster-name>-controller-0 -w   # wait for 3/3 Running
-```
-
-### Register the cluster name with accounting
-
-slurmdbd needs the cluster registered before it will store job records.
-Do this as `root`, before any `SlurmUser` exists:
+If you're installing this chart onto a cluster that **already** has controller, login, and worker pods up and running, then all of them predate `accountingRef` and are stuck on stale config — not just the controller. Doing the restarts by hand for every login and worker pod doesn't scale well once there are more than a handful, so the chart can do it for you:
 
 ```bash
-ssh root@<login-ip> "sacctmgr -i add cluster <cluster-name>"
+helm install slurm-accounting . -n slurm \
+  --set clusterName=<your-slurmcluster-name> \
+  --set restartPods.enabled=true \
+  --set restartPods.includeWorkers=true \
+  --wait --timeout 15m
 ```
+
+This adds a post-install/post-upgrade Job that runs after `accountingRef` is already set and:
+- Always deletes the controller and login pod(s) (cheap: a single StatefulSet replica and a Deployment).
+- Deletes worker (`slurmd`) pods too, **only if** `restartPods.includeWorkers=true`. Only set it if you're OK with that disruption (e.g. no active workload, or you're fine with those jobs failing/requeuing). If you'd rather restart workers in batches instead of all at once, leave `restartPods.includeWorkers=false` and drain/recreate them yourself in smaller groups.
+
+### Confirm the cluster is registered with accounting
+
+```bash
+ssh root@<login-ip> "sacctmgr show cluster"
+# Should list the cluster instead of erroring with "not running a supported
+# accounting_storage plugin".
+```
+
+If it's missing, that means slurmctld hasn't successfully talked to
+slurmdbd with accounting configured yet — re-check
+[Known issues](#known-issues) #4 and #5 rather than adding the cluster by
+hand.
 
 ## Set up accounts and users
 
@@ -90,8 +105,7 @@ first, then add users last:
    ssh root@<login-ip> "sacctmgr -i add account <account-name> Description='<description>' Organization='<org>'"
    ```
 
-   For a single-user/test cluster, the built-in `root` account is fine to
-   use directly and this step can be skipped.
+   For a single-user/test cluster, the built-in `root` account is fine to use directly and this step can be skipped.
 
 2. **Apply the `SlurmUser` CR** (see `user.yml` for an example) so the OS
    user exists and can SSH in:
@@ -107,10 +121,7 @@ first, then add users last:
    ssh root@<login-ip> "sacctmgr -i add user <username> Account=<account-name>"
    ```
 
-   Repeat steps 2–3 for each additional user. Until step 3 runs for a
-   user, their jobs still execute and still show up in `sacct` (accounting
-   isn't enforced by default — `AccountingStorageEnforce=none`), just with
-   an empty `Account` column and none of the account's limits applied.
+   Repeat steps 2–3 for each additional user. Until step 3 runs for a user, their jobs still execute and still show up in `sacct` (accounting isn't enforced by default — `AccountingStorageEnforce=none`), just with an empty `Account` column and none of the account's limits applied.
 
 Check the result:
 
@@ -173,6 +184,62 @@ Expected:
    this; watch `kubectl get pod -n slurm <cluster-name>-controller-0 -w`
    until it reaches `3/3 Running`.
 
+4. **`sacct`/`sacctmgr` say accounting is disabled even though
+   `scontrol show config` on the same node shows
+   `AccountingStorageType = accounting_storage/slurmdbd`.** This happens on
+   any login or worker pod that was already running before `accountingRef`
+   was patched onto the `Controller` CR. `scontrol` queries `slurmctld`
+   live over RPC, so it always reflects the current config — but `sacct`
+   and `sacctmgr` read the login/worker pod's own locally cached
+   `slurm.conf`, fetched once at process start by `sackd` (login) or
+   `slurmd` (worker, dynamic/configless mode) via `--conf-server`. Neither
+   daemon has a live-reconfigure signal, so that cached copy never updates
+   on its own. Fix: restart the affected pod(s) — see
+   [Installing on an existing cluster](#installing-on-an-existing-cluster) or set
+   `restartPods.enabled=true`/`restartPods.includeWorkers=true`. Prefer
+   [installing on a new cluster](#installing-on-a-new-crusoe-managed-slurm-cluster)
+   before worker node pools are scaled up, so workers never hit this in the
+   first place.
+
+5. **slurmdbd gets stuck not-Ready, and slurmctld crash-loops with
+   `error: Sending PersistInit msg: Operation not permitted` /
+   `fatal: Problem adding tres to the database`.** This is a first-boot
+   race between the `Accounting` (slurmdbd) resource and the MariaDB
+   `StatefulSet`, both created by the same `helm install`. slurmdbd's
+   `as_mysql` plugin only retries connecting to MariaDB a fixed number of
+   times at startup; if it starts while MariaDB is still doing its
+   one-time init (temp server → secure-installation → real restart — the
+   DNS name can also be briefly unresolvable during this window), it can
+   exhaust that retry budget and end up alive but never listening on 6819.
+   slurmctld then can't complete its persistent-connection handshake to
+   slurmdbd; Slurm's `auth/slurm` plugin surfaces that as
+   `Operation not permitted` (easy to mistake for a NetworkPolicy or RBAC
+   block — check `kubectl get networkpolicy` / `ciliumnetworkpolicy` to
+   rule that out first). It won't recover on its own.
+
+   **This chart prevents it automatically** when `mariadb.enabled: true`
+   (the default): the `Accounting` CR carries two `initContainers` (added
+   via its `spec.template.spec`, which the slurm-operator strategic-merges
+   into the slurmdbd pod — see `accounting.yaml`) that wait for the
+   MariaDB `StatefulSet` to exist and report an available replica before
+   slurmdbd's main container ever starts, so its first connection attempt
+   always lands on an already-usable database. Raise
+   `mariadb.waitForReadyTimeoutSeconds` (default `300`) if your storage
+   provisioner or MariaDB's first-boot init is slow enough to exceed it.
+
+   If you still hit this (e.g. `mariadb.enabled: false` with an external
+   database that wasn't ready), the manual fix is the same idea: once
+   `kubectl get pod -n slurm test-accounting-mariadb-0` (or
+   `<release>-mariadb-0`) has been `1/1 Running` for a few minutes, restart
+   the accounting pod, then the controller pod:
+
+   ```bash
+   kubectl delete pod -n slurm <release>-accounting-0
+   kubectl wait --for=condition=Ready pod -n slurm <release>-accounting-0 --timeout=60s
+   kubectl delete pod -n slurm <cluster-name>-controller-0
+   kubectl get pod -n slurm <cluster-name>-controller-0 -w   # wait for 3/3 Running
+   ```
+
 ## Uninstall
 
 ```bash
@@ -190,4 +257,4 @@ kubectl delete pod -n slurm <cluster-name>-controller-0
 
 ## Configuration reference
 
-See `chart/slurm-accounting/values.yaml` for the full set of options, including MariaDB image/resources/storage size, the slurmdbd image, and `patchController.enabled` (set to `false` if you'd rather patch `accountingRef` manually instead of via the chart's hook Job).
+See `chart/slurm-accounting/values.yaml` for the full set of options, including MariaDB image/resources/storage size, the slurmdbd image, `patchController.enabled` (set to `false` if you'd rather patch `accountingRef` manually instead of via the chart's hook Job), and `restartPods.enabled`/`restartPods.includeWorkers` (see [Installing on an existing cluster](#installing-on-an-existing-cluster)).

--- a/crusoe-managed-slurm-accounting/README.md
+++ b/crusoe-managed-slurm-accounting/README.md
@@ -107,11 +107,10 @@ first, then add users last:
 
    For a single-user/test cluster, the built-in `root` account is fine to use directly and this step can be skipped.
 
-2. **Apply the `SlurmUser` CR** (see `user.yml` for an example) so the OS
-   user exists and can SSH in:
+2. **Add Users via `SlurmUser` CR** as shown in [Crusoe Documentations](https://docs.crusoecloud.com/orchestration/slurm/kubernetes-setup#step-5-add-users-optional):
 
    ```bash
-   kubectl apply -f user.yml
+   kubectl apply -f user.yaml
    ```
 
 3. **Add the user to accounting under that account** (still as `root`,

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/NOTES.txt
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/NOTES.txt
@@ -5,7 +5,7 @@ Check status:
   kubectl get pods -n {{ .Values.namespace }} -l app.kubernetes.io/name=mariadb
 
 Verify slurmctld picked up accountingRef:
-  kubectl get controllers.slinky.slurm.net -n {{ .Values.namespace }} {{ .Values.patchController.controllerName }} -o jsonpath='{.spec.accountingRef}'
+  kubectl get controllers.slinky.slurm.net -n {{ .Values.namespace }} {{ include "slurm-accounting.controllerName" . }} -o jsonpath='{.spec.accountingRef}'
 
 From a login node, confirm sacctmgr can reach slurmdbd:
   sacctmgr show cluster

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/_helpers.tpl
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/_helpers.tpl
@@ -6,6 +6,10 @@
 {{ .Values.clusterName }}-accounting-mariadb
 {{- end -}}
 
+{{- define "slurm-accounting.controllerName" -}}
+slurm-{{ .Values.clusterName }}
+{{- end -}}
+
 {{- define "slurm-accounting.labels" -}}
 app.kubernetes.io/part-of: {{ .Values.clusterName }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/accounting-wait-rbac.yaml
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/accounting-wait-rbac.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.mariadb.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "slurm-accounting.fullname" . }}-wait-mariadb
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "slurm-accounting.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "slurm-accounting.fullname" . }}-wait-mariadb
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "slurm-accounting.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "slurm-accounting.fullname" . }}-wait-mariadb
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "slurm-accounting.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "slurm-accounting.fullname" . }}-wait-mariadb
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "slurm-accounting.fullname" . }}-wait-mariadb
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/accounting.yaml
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/accounting.yaml
@@ -7,12 +7,17 @@ metadata:
     {{- include "slurm-accounting.labels" . | nindent 4 }}
 spec:
   external: false
+  # The Crusoe operator names these secrets <clusterName>-auth-slurm and
+  # <clusterName>-auth-jwths256, with fixed key names slurm.key and
+  # jwt_hs256.key, for every SlurmCluster it provisions -- reusing them
+  # here keeps slurmctld <-> slurmdbd auth in sync without minting new
+  # keys.
   slurmKeyRef:
-    name: {{ .Values.existingAuth.slurmKeySecret }}
-    key: {{ .Values.existingAuth.slurmKeyKey }}
+    name: {{ .Values.clusterName }}-auth-slurm
+    key: slurm.key
   jwtHs256KeyRef:
-    name: {{ .Values.existingAuth.jwtHs256Secret }}
-    key: {{ .Values.existingAuth.jwtHs256Key }}
+    name: {{ .Values.clusterName }}-auth-jwths256
+    key: jwt_hs256.key
   storageConfig:
     host: {{ include "slurm-accounting.mariadb.fullname" . }}.{{ .Values.namespace }}.svc.cluster.local
     port: 3306
@@ -25,3 +30,49 @@ spec:
     image: {{ .Values.accounting.image }}
     resources:
       {{- toYaml .Values.accounting.resources | nindent 6 }}
+  {{- if .Values.mariadb.enabled }}
+  # slurmdbd's as_mysql plugin only retries connecting to MariaDB a fixed
+  # number of times at startup -- if MariaDB is still mid first-boot init
+  # (temp server -> secure-installation -> real restart) when slurmdbd
+  # starts, it can exhaust that budget and end up alive but never
+  # listening on 6819 (see README "Known issues"). These initContainers on
+  # the slurmdbd pod itself wait for the MariaDB StatefulSet to report an
+  # available replica first. spec.template.spec here is a schemaless
+  # corev1.PodSpec passthrough that the slurm-operator strategic-merges
+  # into the pod it generates from spec.slurmdbd above -- initContainers
+  # set here are appended to (not replacing) whatever the operator sets,
+  # which for Accounting is none.
+  template:
+    spec:
+      # The slurmdbd pod otherwise inherits the namespace's `default`
+      # ServiceAccount (confirmed against the equivalent slurmctld pod,
+      # which the operator builds through the same merge path), which
+      # can't get/list/watch statefulsets -- use a dedicated SA with just
+      # that permission for the wait initContainers below. The operator's
+      # base PodSpec also sets automountServiceAccountToken: false (sane
+      # default for a pod that only talks to MariaDB) -- override back to
+      # true or these initContainers have no token to auth kubectl with
+      # and kubectl falls back to trying http://localhost:8080, which
+      # fails immediately with "connection refused".
+      serviceAccountName: {{ include "slurm-accounting.fullname" . }}-wait-mariadb
+      automountServiceAccountToken: true
+      initContainers:
+        - name: wait-for-mariadb-statefulset
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - wait
+            - --for=create
+            - statefulset/{{ include "slurm-accounting.mariadb.fullname" . }}
+            - -n
+            - {{ .Values.namespace }}
+            - --timeout={{ .Values.mariadb.waitForReadyTimeoutSeconds }}s
+        - name: wait-for-mariadb-ready
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - wait
+            - --for=jsonpath={.status.availableReplicas}=1
+            - statefulset/{{ include "slurm-accounting.mariadb.fullname" . }}
+            - -n
+            - {{ .Values.namespace }}
+            - --timeout={{ .Values.mariadb.waitForReadyTimeoutSeconds }}s
+  {{- end }}

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/patch-controller-job.yaml
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/patch-controller-job.yaml
@@ -17,6 +17,14 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  # This Job commonly runs on a brand-new cluster where the SlurmCluster CR
+  # was just created: the Crusoe operator provisions nodes, then
+  # slurm-operator/topograph/cert-manager come up in the slinky namespace,
+  # and only after that does the Controller CR this Job patches actually
+  # get created. The wait-for-controller initContainer blocks for that CR
+  # to exist (instead of the main container failing fast on a 404), so
+  # backoffLimit only needs to cover transient API-server hiccups, not "the
+  # CR doesn't exist yet".
   backoffLimit: 5
   template:
     metadata:
@@ -25,15 +33,23 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "slurm-accounting.fullname" . }}-patch
+      initContainers:
+        - name: wait-for-controller
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - wait
+            - --for=create
+            - controllers.slinky.slurm.net/{{ include "slurm-accounting.controllerName" . }}
+            - -n
+            - {{ .Values.namespace }}
+            - --timeout={{ .Values.patchController.waitForControllerTimeoutSeconds }}s
       containers:
         - name: patch-controller
           image: docker.io/rancher/kubectl:v1.33.0
-          command:
-            - kubectl
           args:
             - patch
             - controllers.slinky.slurm.net
-            - {{ .Values.patchController.controllerName }}
+            - {{ include "slurm-accounting.controllerName" . }}
             - -n
             - {{ .Values.namespace }}
             - --type=merge

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/restart-pods-job.yaml
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/restart-pods-job.yaml
@@ -1,0 +1,130 @@
+{{- if .Values.restartPods.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "slurm-accounting.fullname" . }}-restart
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "slurm-accounting.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "slurm-accounting.fullname" . }}-restart
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "slurm-accounting.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "slurm-accounting.fullname" . }}-restart
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "slurm-accounting.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "slurm-accounting.fullname" . }}-restart
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "slurm-accounting.fullname" . }}-restart
+    namespace: {{ .Values.namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "slurm-accounting.fullname" . }}-restart-pods
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "slurm-accounting.labels" . | nindent 4 }}
+  annotations:
+    # Runs AFTER the Accounting CR + patch-controller Job (see
+    # patch-controller-job.yaml) as a post-install/post-upgrade hook, so
+    # accountingRef is already set by the time this fires.
+    #
+    # sackd (login) and slurmd (worker, configless/dynamic nodes) only read
+    # slurm.conf once at process start via --conf-server; neither exposes a
+    # live-reconfigure signal. Any of these pods that were already running
+    # before accountingRef was set are stuck with a pre-accounting config
+    # and sacct/sacctmgr will report accounting as disabled on them even
+    # though slurmctld and slurmdbd are healthy. Deleting them here forces
+    # a clean re-fetch. See README "Known issues" for why this can't be
+    # avoided by install ordering alone on a cluster that already has
+    # login/worker pods running.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        {{- include "slurm-accounting.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "slurm-accounting.fullname" . }}-restart
+      # docker.io/rancher/kubectl ships a single static kubectl binary with
+      # no shell, so each delete runs as its own container with plain args
+      # instead of a shell script.
+      initContainers:
+        - name: restart-controller
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - delete
+            - pod
+            - -n
+            - {{ .Values.namespace }}
+            - -l
+            - app.kubernetes.io/part-of={{ .Values.clusterName }},app.kubernetes.io/component=controller
+            - --ignore-not-found
+            - --wait=false
+        - name: restart-login
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - delete
+            - pod
+            - -n
+            - {{ .Values.namespace }}
+            - -l
+            - app.kubernetes.io/part-of={{ .Values.clusterName }},app.kubernetes.io/component=login
+            - --ignore-not-found
+            - --wait=false
+      containers:
+        - name: restart-workers
+          image: docker.io/rancher/kubectl:v1.33.0
+          {{- if .Values.restartPods.includeWorkers }}
+          args:
+            - delete
+            - pod
+            - -n
+            - {{ .Values.namespace }}
+            - -l
+            - slurm.crusoe.ai/cluster-name={{ .Values.clusterName }},app.kubernetes.io/component=worker
+            - --ignore-not-found
+            - --wait=false
+          {{- else }}
+          # restartPods.includeWorkers=false: leave worker pods untouched.
+          # If any worker pods were already running before this install,
+          # restart them manually -- see README Known issues.
+          args:
+            - version
+            - --client
+          {{- end }}
+{{- end }}

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/values.yaml
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/values.yaml
@@ -1,17 +1,20 @@
+# Must match metadata.name of your SlurmCluster CR exactly (e.g. `kubectl get
+# slurmclusters -n <namespace>`) -- not an arbitrary label. Everything below
+# that references the cluster by name (the Controller CR name, the auth
+# secret names, label selectors the chart uses to find/restart controller,
+# login, and worker pods) is derived from this value.
 clusterName: test
 namespace: slurm
 
-# Existing secrets created by the Crusoe-managed SlurmCluster/Controller.
-# The Accounting (slurmdbd) resource re-uses these so slurmctld <-> slurmdbd
-# auth stays in sync without minting new keys.
-existingAuth:
-  slurmKeySecret: test-auth-slurm
-  slurmKeyKey: slurm.key
-  jwtHs256Secret: test-auth-jwths256
-  jwtHs256Key: jwt_hs256.key
-
 mariadb:
   enabled: true
+  # slurmdbd's as_mysql plugin only retries connecting a fixed number of
+  # times at startup, so the Accounting CR's slurmdbd pod carries
+  # initContainers (see accounting.yaml) that wait for this StatefulSet to
+  # report an available replica before slurmdbd's main container starts --
+  # see "Known issues" in the README. Raise this if your storage
+  # provisioner or MariaDB's first-boot init is slow enough to exceed it.
+  waitForReadyTimeoutSeconds: 300
   image: mariadb:11.4
   # fs.csi.crusoe.ai is NFS-backed and enforces a 1Ti minimum volume size --
   # wrong fit for a MySQL/InnoDB data directory either way. Use the
@@ -44,9 +47,37 @@ accounting:
       memory: 512Mi
 
 # Whether this chart should patch the existing Crusoe-managed Controller CR
-# (slinky.slurm.net/v1beta1) to set spec.accountingRef. Disable if the
-# managed control plane reverts out-of-band edits and you'd rather patch
-# manually / re-run the patch job on a schedule.
+# (slinky.slurm.net/v1beta1) to set spec.accountingRef. The Controller CR
+# is always named slurm-<clusterName> by the Crusoe operator, so this chart
+# derives that name from clusterName above instead of taking it as a
+# separate value -- confirm with
+# `kubectl get controllers.slinky.slurm.net -n <namespace>` if you're
+# unsure. Disable if the managed control plane reverts out-of-band edits
+# and you'd rather patch manually / re-run the patch job on a schedule.
 patchController:
   enabled: true
-  controllerName: slurm-test
+  # On a fresh cluster, this Job's pre-install hook can run before the
+  # Crusoe operator has finished provisioning nodes and reconciling the
+  # SlurmCluster CR into a Controller CR -- an initContainer waits (via
+  # `kubectl wait --for=create`) for the Controller CR to exist before the
+  # patch runs, instead of failing fast and burning through the Job's
+  # backoffLimit. Raise this if node provisioning is slow enough to exceed
+  # it in your environment.
+  waitForControllerTimeoutSeconds: 900
+
+# sackd (login) and slurmd (worker, dynamic/configless nodes) only read
+# slurm.conf once at process start and have no live-reconfigure signal, so
+# any of these pods already running before accountingRef was patched onto
+# the Controller CR will keep reporting accounting as disabled even after
+# slurmctld and slurmdbd are healthy. On a brand-new cluster, install this
+# chart right after the SlurmCluster CR (before scaling up worker node
+# pools) and only the login pod will need this; on a cluster that already
+# has login/worker pods running, enable this to have the chart restart them
+# for you instead of doing it by hand.
+restartPods:
+  # Restarts the controller and login pod(s) after install/upgrade.
+  enabled: false
+  # Also restarts worker (slurmd) pods. Off by default because it deletes
+  # pods that may be running jobs -- only enable if you're OK with that
+  # disruption, e.g. on a cluster with no active workload.
+  includeWorkers: false


### PR DESCRIPTION
Fixed the following:
- End-to-end workflow for new cluster creation or implementing in existing clusters
- Implemented wait initContainers for pods to wait in sequence (for MariaDB, SlurmController CR, etc.)
- Updated README