### PR TITLE
kimi-k3 sglang: disable CUDA graph capture (fix deep-context MoE corruption)

### DIFF
--- a/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/README.md
+++ b/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/README.md
@@ -75,6 +75,14 @@ load across replicas, drive through an L7 gateway/proxy, not the ClusterIP.
 
 ## Notes & gotchas
 
+- **⚠️ Silent deep-context corruption (CUDA graph capture is OFF for this reason).** On this day-0
+  stack the MXFP4 MoE path corrupts *under CUDA graph capture* — it silently produces repeated words,
+  control-token leakage (`<|close|>…<|sep|>`), and ASCII→CJK character substitution in **long,
+  warm-cache sessions** (300k+ tokens, hundreds of turns). It does **not** show up in cold one-shot
+  probes, so a smoke test looks clean — validate with a real long multi-turn session. This recipe
+  ships `--disable-cuda-graph` (eager) + omits `AITER_FLYDSL_FORCE` to avoid it (refs: ROCm/aiter#3632,
+  sglang#18002, sglang#27194). Cost: slower decode. Re-enable graph capture (`--cuda-graph-max-bs 256`)
+  only once an upstream-fixed image is available, and re-validate under a deep-context workload.
 - **fastsafetensors is mandatory** on network storage — `--load-format auto` uses a multi-thread
   loader that reads shards ~84 s each (~2 h total) and gets killed by the startup probe.
 - **nogds patch is required** — without it SGLang's fastsafetensors loader hangs at 0/12 shards on

--- a/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/kimi-k3-sglang.yaml
+++ b/crusoe-kserve-example/recipes/kimi-k3-mi355x-sglang/kimi-k3-sglang.yaml
@@ -88,8 +88,12 @@ spec:
             - bfloat16
             - --mem-fraction-static
             - "0.85"
-            - --cuda-graph-max-bs
-            - "256"
+            # CUDA graph capture DISABLED (eager). The MXFP4 MoE path corrupts under graph capture on
+            # this day-0 stack — SILENT output corruption (repeated words, control-token leakage like
+            # <|close|>...<|sep|>, ASCII->CJK char substitution) in long warm-cache sessions (300k+ ctx,
+            # many turns). Refs: ROCm/aiter#3632, sglang#18002, sglang#27194. Costs decode throughput;
+            # re-enable (`--cuda-graph-max-bs 256`) only with an upstream-fixed image. See README gotchas.
+            - --disable-cuda-graph
             - --attention-backend
             - triton                    # the only workable backend on ROCm (aiter MLA illegal at 96 heads)
             - --kv-cache-dtype
@@ -108,7 +112,8 @@ spec:
           env:
             - { name: SGLANG_USE_AITER,        value: "1" }
             - { name: SGLANG_AITER_K3_OPT,     value: "1" }
-            - { name: AITER_FLYDSL_FORCE,      value: "1" }
+            # AITER_FLYDSL_FORCE intentionally NOT set: the flydsl MoE reduce reads uninitialized
+            # memory (sglang#27194), a corruption source — leave the default MoE path.
             - { name: AITER_SITUV2_A8W4,       value: "1" }
             - { name: HF_HUB_OFFLINE,          value: "1" }   # weights already on /models
             - { name: HF_XET_HIGH_PERFORMANCE, value: "1" }


### PR DESCRIPTION
Fixes a **silent output-corruption** bug on the Kimi K3 SGLang recipe.

**Symptom:** in long warm-cache sessions (300k+ ctx, hundreds of turns) the model silently produces repeated words, control-token leakage (`<|close|>…<|sep|>`), and ASCII→CJK character substitution — well-formed text with wrong content. Confirmed on a production endpoint (~25%, Fisher p=3.3e-7). **Not** reproducible with cold one-shot probes, which is why it evaded earlier validation.

**Root cause:** the MXFP4 MoE path is unsafe under **CUDA graph capture** on this day-0 SGLang/ROCm stack — ROCm/aiter#3632 (MXFP4 MoE unsafe under capture), sglang#18002 (capture changes results, 0.10→0.97 with capture off), sglang#27194 (flydsl MoE reduce reads uninitialized memory). Non-deterministic across pod restarts.

**Fix:** ship `--disable-cuda-graph` (eager decode) and drop `AITER_FLYDSL_FORCE`. Keep fp8 KV (not implicated; bf16 would halve the KV pool / long-context depth). Documented in the manifest + README with a bold deep-context-corruption gotcha.

**Trade-off:** eager decode is slower than graph-replayed decode. Re-enable graph capture once an upstream-fixed image is available, and re-validate under a deep multi-turn workload (cold probes don't catch this).