### PR TITLE
slurm-accounting: fix restart Job ordering, document controller-restart pitfalls

### DIFF
--- a/crusoe-managed-slurm-accounting/README.md
+++ b/crusoe-managed-slurm-accounting/README.md
@@ -76,7 +76,9 @@ helm install slurm-accounting . -n slurm \
 
 This adds a post-install/post-upgrade Job that runs after `accountingRef` is already set and:
 - Always deletes the controller and login pod(s) (cheap: a single StatefulSet replica and a Deployment).
-- Deletes worker (`slurmd`) pods too, **only if** `restartPods.includeWorkers=true`. Only set it if you're OK with that disruption (e.g. no active workload, or you're fine with those jobs failing/requeuing). If you'd rather restart workers in batches instead of all at once, leave `restartPods.includeWorkers=false` and drain/recreate them yourself in smaller groups.
+- Deletes worker (`slurmd`) pods too, **only if** `restartPods.includeWorkers=true`. Only set it if you're OK with that disruption (e.g. no active workload, or you're fine with those jobs failing/requeuing). If you'd rather restart workers in batches instead of all at once, leave `restartPods.includeWorkers=false` and drain/recreate them yourself in smaller groups. With `includeWorkers`, the Job also sequences the restarts: it waits for the replacement controller pod to be Ready before deleting workers (see [Known issues](#known-issues) #7), then waits for the replacement workers and runs `scontrol reconfigure` so they rejoin the topology tree (see [Known issues](#known-issues) #8).
+
+> **Heads up:** restarting the controller on a cluster that has been running for a while can hit a statesave volume mount failure that is unrelated to this chart — see [Known issues](#known-issues) #6. Cheap insurance before installing with `restartPods.enabled=true`: run the one-line prevention command from that entry while the controller is still up.
 
 ### Confirm the cluster is registered with accounting
 
@@ -237,6 +239,113 @@ Expected:
    kubectl wait --for=condition=Ready pod -n slurm <release>-accounting-0 --timeout=60s
    kubectl delete pod -n slurm <cluster-name>-controller-0
    kubectl get pod -n slurm <cluster-name>-controller-0 -w   # wait for 3/3 Running
+   ```
+
+6. **Controller pod stuck `Init:0/2` after a restart —
+   `MountVolume.SetUp failed ... applyFSGroup failed ... open .../hash.0:
+   permission denied` on the statesave PVC.** A Managed Slurm platform
+   issue that any controller restart can hit, chart or no chart — but
+   `restartPods.enabled=true` restarts the controller, so it can surface
+   during this chart's install. The controller pod runs with `fsGroup`,
+   which makes kubelet recursively walk the NFS-backed statesave volume at
+   mount time; slurmctld creates `hash.N` state directories with mode
+   `0700`, and the NFS export squashes root, so kubelet can't read them and
+   the mount fails forever. The first-ever mount only works because the
+   volume is empty. (`fsGroupChangePolicy: OnRootMismatch` does **not**
+   help: the volume root's group never matches the pod's `fsGroup` — the
+   server silently ignores kubelet's chown — so the full walk always runs.)
+
+   **Prevention** (controller still running — e.g. right before installing
+   this chart with `restartPods.enabled=true`): make the state directories
+   group/other-traversable from inside the controller pod itself:
+
+   ```bash
+   kubectl exec -n slurm <cluster-name>-controller-0 -c slurmctld -- \
+     sh -c 'find /var/spool/slurmctld -type d ! -perm -005 -exec chmod o+rx {} +'
+   ```
+
+   **Recovery** (controller already stuck `Init:0/2`, so `exec` is not an
+   option): same chmod, but via a helper pod that mounts the statesave PVC
+   running as the Slurm UID (401) **without** `fsGroup` (so no ownership
+   walk is triggered), then let kubelet's next mount retry (~2 min)
+   succeed:
+
+   ```yaml
+   # statesave-fix.yaml -- set nodeName to the node the controller pod is
+   # scheduled on (kubectl get pod -n slurm <cluster-name>-controller-0 -o wide)
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: statesave-fix
+     namespace: slurm
+   spec:
+     nodeName: <controller-node>
+     restartPolicy: Never
+     securityContext:
+       runAsUser: 401
+       runAsGroup: 401
+       runAsNonRoot: true
+     containers:
+       - name: shell
+         image: busybox:1.36
+         command: ["sh", "-c", "sleep 3600"]
+         volumeMounts:
+           - name: statesave
+             mountPath: /statesave
+     volumes:
+       - name: statesave
+         persistentVolumeClaim:
+           claimName: statesave-<controller-name>-0
+   ```
+
+   ```bash
+   kubectl apply -f statesave-fix.yaml
+   # The helper pod can sit in ContainerCreating for ~10 minutes, queued
+   # behind the failing controller mount's retry backoff -- be patient.
+   kubectl wait --for=condition=Ready pod/statesave-fix -n slurm --timeout=15m
+   kubectl exec -n slurm statesave-fix -- \
+     find /statesave -type d ! -perm -005 -exec chmod o+rx {} +
+   kubectl delete pod -n slurm statesave-fix
+   kubectl get pod -n slurm <cluster-name>-controller-0 -w   # wait for 3/3 Running
+   ```
+
+   This can recur: slurmctld may create new `0700` `hash.N` directories
+   later, breaking the *next* controller restart until the chmod is
+   repeated (or the platform fixes the fsGroup/root-squash interaction).
+
+7. **Worker (`slurmd`) pods deleted while the controller is down are not
+   recreated for a long time.** The slurm-operator's nodeset controller
+   needs a live slurmctld to sync its Slurm node cache; while the
+   controller is restarting it errors with `failed to wait on type V0044Node
+   cache sync: ... Unable to contact slurm controller` and goes into
+   exponential backoff — deleted worker pods stay gone and `sinfo` shows
+   the node as `idle*` (non-responding). The chart's restart Job avoids
+   this by waiting for the replacement controller pod to be Ready before
+   deleting workers (`restartPods.waitForControllerReadyTimeoutSeconds`).
+   If you hit it anyway (e.g. workers deleted by hand), force a reconcile
+   once the controller is back:
+
+   ```bash
+   kubectl annotate nodesets.slinky.slurm.net -n slurm <nodeset-name> \
+     reconcile-nudge=1 --overwrite
+   ```
+
+8. **After a controller restart, jobs fail with `srun: error: Unable to
+   allocate resources: Requested topology configuration is not available`
+   even though `sinfo` shows the node as `idle`.** Worker nodes are
+   dynamic (configless): they register with slurmctld at `slurmd` start.
+   A slurmctld that boots while workers are down parses `topology.conf`
+   with node names it doesn't know yet — those entries are dropped, the
+   nodes end up outside the topology tree (`scontrol show topology` shows
+   the leaf switch with `Nodes=` empty), and nothing re-parses topology
+   when the workers register later (if the topology ConfigMap content is
+   unchanged, the reconfigure sidecar sees no change and stays quiet).
+   The chart's restart Job handles this when `restartPods.includeWorkers=true`
+   by waiting for the replacement workers and running `scontrol
+   reconfigure`. If you hit it after restarting pods by hand:
+
+   ```bash
+   kubectl exec -n slurm <controller-pod> -c slurmctld -- scontrol reconfigure
    ```
 
 ## Uninstall

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/Chart.yaml
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: slurm-accounting
 description: Slurm accounting (slurmdbd + MariaDB) for Crusoe Managed Slurm clusters
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "25.11.2"

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/restart-pods-job.yaml
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/templates/restart-pods-job.yaml
@@ -25,7 +25,15 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list", "delete"]
+    # watch is needed by the `kubectl wait` initContainers below.
+    verbs: ["get", "list", "watch", "delete"]
+{{- if .Values.restartPods.includeWorkers }}
+  # The reconfigure-slurm container runs `scontrol reconfigure` inside the
+  # controller pod after workers are back (see the Job below for why).
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -84,6 +92,9 @@ spec:
       # no shell, so each delete runs as its own container with plain args
       # instead of a shell script.
       initContainers:
+        # No --wait=false here: block until the old controller pod is fully
+        # gone, so the wait-for-controller-* initContainers below can't latch
+        # onto the terminating pod instead of its replacement.
         - name: restart-controller
           image: docker.io/rancher/kubectl:v1.33.0
           args:
@@ -94,7 +105,6 @@ spec:
             - -l
             - app.kubernetes.io/part-of={{ .Values.clusterName }},app.kubernetes.io/component=controller
             - --ignore-not-found
-            - --wait=false
         - name: restart-login
           image: docker.io/rancher/kubectl:v1.33.0
           args:
@@ -106,10 +116,37 @@ spec:
             - app.kubernetes.io/part-of={{ .Values.clusterName }},app.kubernetes.io/component=login
             - --ignore-not-found
             - --wait=false
-      containers:
+        {{- if .Values.restartPods.includeWorkers }}
+        # Deleting worker pods while slurmctld is still down strands them: the
+        # slurm-operator's nodeset controller needs a live controller to sync
+        # its Slurm node cache, errors into exponential backoff, and doesn't
+        # recreate the deleted slurmd pods for a long time (see README "Known
+        # issues"). Wait for the replacement controller pod to exist and be
+        # Ready before the main container touches workers.
+        - name: wait-for-controller-created
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - wait
+            - --for=create
+            - pod
+            - -n
+            - {{ .Values.namespace }}
+            - -l
+            - app.kubernetes.io/part-of={{ .Values.clusterName }},app.kubernetes.io/component=controller
+            - --timeout={{ .Values.restartPods.waitForControllerReadyTimeoutSeconds }}s
+        - name: wait-for-controller-ready
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - wait
+            - --for=condition=Ready
+            - pod
+            - -n
+            - {{ .Values.namespace }}
+            - -l
+            - app.kubernetes.io/part-of={{ .Values.clusterName }},app.kubernetes.io/component=controller
+            - --timeout={{ .Values.restartPods.waitForControllerReadyTimeoutSeconds }}s
         - name: restart-workers
           image: docker.io/rancher/kubectl:v1.33.0
-          {{- if .Values.restartPods.includeWorkers }}
           args:
             - delete
             - pod
@@ -119,12 +156,59 @@ spec:
             - slurm.crusoe.ai/cluster-name={{ .Values.clusterName }},app.kubernetes.io/component=worker
             - --ignore-not-found
             - --wait=false
-          {{- else }}
-          # restartPods.includeWorkers=false: leave worker pods untouched.
-          # If any worker pods were already running before this install,
-          # restart them manually -- see README Known issues.
+        # Dynamic (configless) slurmd nodes register with slurmctld at
+        # process start, but the slurmctld that just booted parsed
+        # topology.conf while the workers were down -- unknown node names
+        # are dropped, the nodes end up outside the topology tree, and jobs
+        # fail with "Requested topology configuration is not available"
+        # until a reconfigure forces a re-parse (see README Known issues).
+        # Wait for the replacement workers to register (pod Ready), then
+        # `scontrol reconfigure` in the main container below.
+        - name: wait-for-workers-created
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - wait
+            - --for=create
+            - pod
+            - -n
+            - {{ .Values.namespace }}
+            - -l
+            - slurm.crusoe.ai/cluster-name={{ .Values.clusterName }},app.kubernetes.io/component=worker
+            - --timeout={{ .Values.restartPods.waitForWorkersReadyTimeoutSeconds }}s
+        - name: wait-for-workers-ready
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - wait
+            - --for=condition=Ready
+            - pod
+            - -n
+            - {{ .Values.namespace }}
+            - -l
+            - slurm.crusoe.ai/cluster-name={{ .Values.clusterName }},app.kubernetes.io/component=worker
+            - --timeout={{ .Values.restartPods.waitForWorkersReadyTimeoutSeconds }}s
+        {{- end }}
+      containers:
+        {{- if .Values.restartPods.includeWorkers }}
+        - name: reconfigure-slurm
+          image: docker.io/rancher/kubectl:v1.33.0
+          args:
+            - exec
+            - -n
+            - {{ .Values.namespace }}
+            - {{ include "slurm-accounting.controllerName" . }}-controller-0
+            - -c
+            - slurmctld
+            - --
+            - scontrol
+            - reconfigure
+        {{- else }}
+        # restartPods.includeWorkers=false: leave worker pods untouched.
+        # If any worker pods were already running before this install,
+        # restart them manually -- see README Known issues.
+        - name: restart-workers
+          image: docker.io/rancher/kubectl:v1.33.0
           args:
             - version
             - --client
-          {{- end }}
+        {{- end }}
 {{- end }}

--- a/crusoe-managed-slurm-accounting/chart/slurm-accounting/values.yaml
+++ b/crusoe-managed-slurm-accounting/chart/slurm-accounting/values.yaml
@@ -81,3 +81,19 @@ restartPods:
   # pods that may be running jobs -- only enable if you're OK with that
   # disruption, e.g. on a cluster with no active workload.
   includeWorkers: false
+  # With includeWorkers, the restart Job waits for the replacement controller
+  # pod to be Ready before deleting worker pods -- deleting workers while
+  # slurmctld is down strands them in the nodeset controller's error backoff
+  # (see README "Known issues"). Raise this if your controller takes longer
+  # than this to come back (e.g. slow statesave volume mounts).
+  waitForControllerReadyTimeoutSeconds: 600
+  # With includeWorkers, after deleting the worker pods the Job also waits
+  # for their replacements to be Ready and then runs `scontrol reconfigure`
+  # in the controller pod: slurmctld parsed topology.conf while the (dynamic)
+  # workers were down, so without a reconfigure they sit outside the topology
+  # tree and jobs fail with "Requested topology configuration is not
+  # available" (see README "Known issues"). Raise this on large clusters
+  # where worker pods take longer to come back. Note: only set includeWorkers
+  # on a cluster that actually has worker pods -- with zero workers the wait
+  # times out and the hook fails.
+  waitForWorkersReadyTimeoutSeconds: 900


### PR DESCRIPTION
## Changes

- **Restart Job sequencing** (`restartPods.includeWorkers=true`): the Job previously deleted controller and worker pods simultaneously. Deleting workers while slurmctld is down strands them — the nodeset controller errors into backoff and doesn't recreate them — and the freshly booted slurmctld parses topology.conf without the dynamic nodes, so jobs fail with "Requested topology configuration is not available". The Job now: waits for the replacement controller pod to be Ready → deletes workers → waits for replacement workers → runs `scontrol reconfigure`. New `restartPods.waitForControllerReadyTimeoutSeconds` / `waitForWorkersReadyTimeoutSeconds` values; restart Role gains `watch` on pods and `create` on pods/exec.
- **README known issues** for three failure modes hit in practice:
  - #6: controller restart wedges on the statesave PVC mount (`applyFSGroup ... hash.0: permission denied`) — fsGroup walk vs 0700 state dirs on a root-squashed NFS export; prevention one-liner and helper-pod recovery. Platform-level; any controller restart on a cluster with accumulated state is exposed.
  - #7: workers deleted while the controller is down aren't recreated (nodeset backoff) + escape-hatch annotation nudge.
  - #8: stale topology after controller restart with dynamic nodes + manual `scontrol reconfigure` fix.
- Chart version 0.1.1.

## Testing

Verified end to end on a live Managed Slurm cluster (1 controller, 2 logins, 1 worker): `helm upgrade` with the new Job completes with hooks sequencing exactly as intended (worker deleted only after controller Ready; reconfigure after workers Ready), the worker was recreated within seconds instead of stranding, and `srun` succeeds immediately after `helm upgrade` returns with no manual steps. `helm lint` and template rendering verified for both `includeWorkers` modes.

